### PR TITLE
Feature/inf 76

### DIFF
--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -2,7 +2,7 @@
   <BaseSideBarLayout
     :title="'Program Name'" 
     :username="username"
-    v-on:logout="logout"
+    v-on:logout="$emit('logout')"
   >
   <template v-slot:menu>
     <ul class="menu-list">
@@ -13,17 +13,14 @@
       <li><a>Labels</a></li>
       <li><a>Reports</a></li>
       <li>
-        <a
-            v-bind:class="{ 'is-active': programManagementActive }"
-            @click="programManagementActive = !programManagementActive"
-        >
+        <router-link to="/program-management/locations" v-bind:class="{ 'is-active': programManagementActive }">
           Program Management
           <MoreVerticalIcon v-if="!programManagementActive" class="is-pulled-right"></MoreVerticalIcon>
           <MoreHorizontalIcon v-if="programManagementActive" class="is-pulled-right"></MoreHorizontalIcon>
-        </a>
+        </router-link>
         <ul v-show="programManagementActive">
-          <li><router-link to="/program-management">Locations</router-link></li>
-          <li><a>Users</a></li>
+          <li><router-link to="/program-management/locations">Locations</router-link></li>
+          <li><router-link to="/program-management/program-users">Users</router-link></li>
         </ul>
       </li>
     </ul>
@@ -36,7 +33,7 @@
 </template>
 
 <script lang="ts">
-  import {Component, Prop, Vue} from 'vue-property-decorator'
+  import {Component, Prop, Vue, Watch} from 'vue-property-decorator'
   import BaseSideBarLayout from '@/components/layouts/BaseSideBarLayout.vue';
   import { MoreVerticalIcon, MoreHorizontalIcon } from 'vue-feather-icons'
 
@@ -49,8 +46,16 @@
     @Prop()
     username!: string;
 
-    logout() {
-      this.$emit('logout');
+    mounted() {
+      this.setActiveLinkSubmenus();
+    }
+    updated() {
+      this.setActiveLinkSubmenus();
+    }
+
+    setActiveLinkSubmenus() {
+      var path: string = this.$route.path;
+      this.programManagementActive = path.startsWith('/program-management');
     }
   
   }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -10,6 +10,8 @@ import store from '@/store/index.ts';
 import { LOGIN, LOGOUT, REQUESTED_PATH, ERROR_STATE } from '@/store/mutation-types';
 import * as api from '@/util/api';
 import { BiResponse } from '@/breeding-insight/model/BiResponse';
+import ProgramLocationsManagement from "@/views/ProgramLocationsManagement.vue";
+import ProgramUserManagement from "@/views/ProgramUsersManagement.vue";
 
 Vue.use(VueRouter);
 
@@ -88,12 +90,33 @@ const routes = [
   },
   {
     path: '/program-management',
+    redirect: {name: 'program-locations'},
     name: 'program-management',
     meta: {
       title: 'Program Management',
       layout: layouts.userSideBar
     }, 
-    component: ProgramManagement
+    component: ProgramManagement,
+    children: [
+      {
+        path: 'locations',
+        name: 'program-locations',
+        meta: {
+          title: 'Program Location Management',
+          layout: layouts.userSideBar
+        },
+        component: ProgramLocationsManagement
+      },
+      {
+        path: 'program-users',
+        name: 'program-users',
+        meta: {
+          title: 'Program User Management',
+          layout: layouts.userSideBar
+        },
+        component: ProgramUserManagement
+      }
+    ]
   }
 ]
 

--- a/src/views/ProgramLocationsManagement.vue
+++ b/src/views/ProgramLocationsManagement.vue
@@ -1,0 +1,23 @@
+<template>
+  <div id="program-location-management">
+    <ProgramLocationsTable
+      v-on:show-success-notification="$emit('show-success-notification', $event)"
+      v-on:show-error-notification="$emit('show-error-notification', $event)"
+    >
+    </ProgramLocationsTable>
+  </div>
+</template>
+
+<script lang="ts">
+  import { Component, Prop, Vue } from 'vue-property-decorator'
+  import ProgramLocationsTable from "@/components/program/ProgramLocationsTable.vue"
+
+  @Component({
+    components: {
+      ProgramLocationsTable
+    }
+  })
+  export default class ProgramLocationManagement extends Vue {
+
+  }
+</script>

--- a/src/views/ProgramManagement.vue
+++ b/src/views/ProgramManagement.vue
@@ -6,22 +6,28 @@
     <p class="is-size-5 has-text-weight-bold">
       {{programName}}
     </p>
+
     <section>
-      <b-tabs type="is-boxed">
-        <b-tab-item label="Locations">
-          <ProgramLocationsTable v-on:show-success-notification="showSuccessNotification"
-                                 v-on:show-error-notification="showErrorNotification"
-          >
-          </ProgramLocationsTable>
-        </b-tab-item>
-        <b-tab-item label="Users">
-          <ProgramUsersTable v-on:show-success-notification="showSuccessNotification"
-                             v-on:show-error-notification="showErrorNotification"
-          >
-          </ProgramUsersTable>
-        </b-tab-item>
-      </b-tabs>
+      <nav class="tabs is-boxed">
+        <ul>
+          <router-link to="/program-management/locations" tag="li" active-class="is-active">
+            <a>Locations</a>
+          </router-link>
+          <router-link to="/program-management/program-users" tag="li" active-class="is-active">
+            <a>Users</a>
+          </router-link>
+        </ul>
+      </nav>
     </section>
+
+    <div class="tab-content">
+      <router-view
+        @show-success-notification="$emit('show-success-notification', $event)"
+        @show-info-notification="$emit('show-info-notification', $event)"
+        @show-error-notification="$emit('show-error-notification', $event)"
+      ></router-view>
+    </div>
+
   </div>
 </template>
 
@@ -39,20 +45,6 @@
 
     // get this when endpoint is implmented
     private programName: string = "Program Name";
-
-    mounted() {
-
-    }
-
-    showSuccessNotification(msg: string) {
-      console.log('showSuccess');
-      this.$emit('show-success-notification', msg);
-    }
-
-    showErrorNotification(msg: string) {
-      console.log('showError');
-      this.$emit('show-error-notification', msg);
-    }
 
   }
 </script>

--- a/src/views/ProgramUsersManagement.vue
+++ b/src/views/ProgramUsersManagement.vue
@@ -1,0 +1,21 @@
+<template>
+  <ProgramUsersTable
+    v-on:show-success-notification="$emit('show-success-notification', $event)"
+    v-on:show-error-notification="$emit('show-error-notification', $event)"
+  >
+  </ProgramUsersTable>
+</template>
+
+<script lang="ts">
+  import { Component, Prop, Vue } from 'vue-property-decorator'
+  import ProgramUsersTable from "../components/program/ProgramUsersTable.vue";
+
+  @Component({
+    components: {
+      ProgramUsersTable
+    }
+  })
+  export default class ProgramUserManagement extends Vue {
+
+  }
+</script>


### PR DESCRIPTION
This pull request fixes a bug in the project where the side menu links would not navigate to their corresponding tags. 

## Design choice explanation

Fix removes the buefy tabs and replaces them with bulma tabs. The fix treats tab options as links and uses vue router functionality to show tab content so that we can take advantage of the vue router machinery. 

## Testing

No tests need to be written since we use the vue router machinery to determine states. 

## Review considerations

Look at the acceptance criteria on the trello card, 

https://trello.com/c/mSsuTFIR/170-inf-76-show-navigation-link-active-when-corresponding-tab-is-active. 

In general, run the project and check that the program locations and program users links and tabs work as expected. Look at the code and make sure you approve of the code structure and do not see any limitations in future uses. 

