### PR TITLE
Feature/inf 81

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -135,7 +135,8 @@ nav.pagination {
     display: flex;
     flex-grow: 1;
     flex-shrink: 0;
-    justify-content: space-evenly;
+    justify-content: flex-start;
+    margin-left: 2em;
 
     & div.page-size-select {
       order: 1;

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -101,7 +101,7 @@ main {
   pre,
   table {
     &:not(last-child) {
-    margin-bottom: 1em;
+      margin-bottom: 1em;
     }
   }
 }
@@ -110,9 +110,44 @@ main ul {
   list-style: disc outside;
   margin-left: 2em;
   ul {
-      list-style-type: circle;
-      margin-top: .5em;
+    list-style-type: circle;
+    margin-top: .5em;
+  }
+}
+
+
+
+nav.pagination {
+  align-items: normal;
+  justify-content: flex-start;
+  & ul.pagination-list {
+    list-style-type: none;
+    margin-left: 0;
+    flex-grow: 0;
+    flex-shrink: 0;
+    & li a.is-current {
+      background-color: $info;
+      border: none;
+    }
+  }
+  & div.pagination-extras {
+    order: 4;
+    display: flex;
+    flex-grow: 1;
+    flex-shrink: 0;
+    justify-content: space-evenly;
+
+    & div.page-size-select {
+      order: 1;
+      border: none;
+      & span {
+        margin-left: 4px;
       }
+    }
+    & a.show-all-button {
+      order: 2;
+    }
+  }
 }
 
 main ol {

--- a/src/breeding-insight/dao/ProgramDAO.ts
+++ b/src/breeding-insight/dao/ProgramDAO.ts
@@ -18,8 +18,19 @@
 import {Program} from "@/breeding-insight/model/Program";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramDAO {
+
+  static mockMetadata: any = {
+    pagination: {
+      totalCount: 1000,
+      pageSize: 50,
+      totalPages: 20,
+      currentPage: 1
+    },
+    status: []
+  }
 
   static create(program: Program): Promise<BiResponse> {
 
@@ -57,12 +68,28 @@ export class ProgramDAO {
     return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/archive/${id}`, method: 'delete'});
   }
 
-  static getAll(): Promise<BiResponse> {
+  static getAll(paginationQuery: PaginationQuery): Promise<BiResponse> {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get' })
+      let params: any = {};
+      if (paginationQuery.pageSize){
+        params.pageSize = paginationQuery.pageSize;
+        //TODO: Remove when backend has pagination
+        if (params.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
+      }
+      if (paginationQuery.page) {
+        params.page = paginationQuery.page;
+        //TODO: Remove when backend has pagination
+        if (params.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
+      }
+      if (paginationQuery.showAll) {
+        params.showAll = paginationQuery.showAll;
+      }
+
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get', params})
         .then((response: any) => {
+          response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);
         }).catch((error) => {

--- a/src/breeding-insight/dao/ProgramDAO.ts
+++ b/src/breeding-insight/dao/ProgramDAO.ts
@@ -72,23 +72,20 @@ export class ProgramDAO {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      let params: any = {};
+      //TODO: Remove when backend has pagination
       if (paginationQuery.pageSize){
-        params.pageSize = paginationQuery.pageSize;
-        //TODO: Remove when backend has pagination
-        if (params.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
+        if (paginationQuery.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
       }
       if (paginationQuery.page) {
-        params.page = paginationQuery.page;
-        //TODO: Remove when backend has pagination
-        if (params.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
+        if (paginationQuery.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
       }
       if (paginationQuery.showAll) {
-        params.showAll = paginationQuery.showAll;
+        console.log('showing all');
       }
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get', params})
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get', paginationQuery})
         .then((response: any) => {
+          //TODO: Change back when no longer mocked
           response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/ProgramDAO.ts
+++ b/src/breeding-insight/dao/ProgramDAO.ts
@@ -22,16 +22,6 @@ import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramDAO {
 
-  static mockMetadata: any = {
-    pagination: {
-      totalCount: 1000,
-      pageSize: 50,
-      totalPages: 20,
-      currentPage: 1
-    },
-    status: []
-  }
-
   static create(program: Program): Promise<BiResponse> {
 
     return new Promise<BiResponse>((resolve, reject) => {
@@ -72,21 +62,8 @@ export class ProgramDAO {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      //TODO: Remove when backend has pagination
-      if (paginationQuery.pageSize){
-        if (paginationQuery.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
-      }
-      if (paginationQuery.page) {
-        if (paginationQuery.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
-      }
-      if (paginationQuery.showAll) {
-        console.log('showing all');
-      }
-
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get', paginationQuery})
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get', params: paginationQuery})
         .then((response: any) => {
-          //TODO: Change back when no longer mocked
-          response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);
         }).catch((error) => {

--- a/src/breeding-insight/dao/ProgramLocationDAO.ts
+++ b/src/breeding-insight/dao/ProgramLocationDAO.ts
@@ -22,16 +22,6 @@ import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramLocationDAO {
 
-  static mockMetadata: any = {
-    pagination: {
-      totalCount: 1000,
-      pageSize: 50,
-      totalPages: 20,
-      currentPage: 1
-    },
-    status: []
-  }
-
   static create(programLocation: ProgramLocation): Promise<BiResponse> {
 
     return new Promise<BiResponse>((resolve, reject) => {
@@ -70,23 +60,10 @@ export class ProgramLocationDAO {
 
   static getAll(programId: string, paginationQuery: PaginationQuery): Promise<BiResponse> {
 
-    //TODO: Remove when backend has pagination
-    if (paginationQuery.pageSize){
-      if (paginationQuery.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
-    }
-    if (paginationQuery.page) {
-      if (paginationQuery.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
-    }
-    if (paginationQuery.showAll) {
-      console.log('showing all');
-    }
-
     return new Promise<BiResponse>(((resolve, reject) => {
 
       api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations`, method: 'get', params: paginationQuery })
         .then((response: any) => {
-          //TODO: Change back when no longer mocked
-          response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);
         }).catch((error) => {

--- a/src/breeding-insight/dao/ProgramLocationDAO.ts
+++ b/src/breeding-insight/dao/ProgramLocationDAO.ts
@@ -18,8 +18,19 @@
 import {ProgramLocation} from "@/breeding-insight/model/ProgramLocation";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramLocationDAO {
+
+  static mockMetadata: any = {
+    pagination: {
+      totalCount: 1000,
+      pageSize: 50,
+      totalPages: 20,
+      currentPage: 1
+    },
+    status: []
+  }
 
   static create(programLocation: ProgramLocation): Promise<BiResponse> {
 
@@ -57,12 +68,25 @@ export class ProgramLocationDAO {
     return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations/${locationId}`, method: 'delete'});
   }
 
-  static getAll(programId: string): Promise<BiResponse> {
+  static getAll(programId: string, paginationQuery: PaginationQuery): Promise<BiResponse> {
+
+    //TODO: Remove when backend has pagination
+    if (paginationQuery.pageSize){
+      if (paginationQuery.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
+    }
+    if (paginationQuery.page) {
+      if (paginationQuery.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
+    }
+    if (paginationQuery.showAll) {
+      console.log('showing all');
+    }
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations`, method: 'get' })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations`, method: 'get', params: paginationQuery })
         .then((response: any) => {
+          //TODO: Change back when no longer mocked
+          response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);
         }).catch((error) => {

--- a/src/breeding-insight/dao/ProgramUserDAO.ts
+++ b/src/breeding-insight/dao/ProgramUserDAO.ts
@@ -22,16 +22,6 @@ import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramUserDAO {
 
-  static mockMetadata: any = {
-    pagination: {
-      totalCount: 1000,
-      pageSize: 50,
-      totalPages: 20,
-      currentPage: 1
-    },
-    status: []
-  }
-
   static create(programUser: ProgramUser): Promise<BiResponse> {
 
     return new Promise<BiResponse>((resolve, reject) => {
@@ -82,23 +72,10 @@ export class ProgramUserDAO {
 
   static getAll(programId: string, paginationQuery: PaginationQuery): Promise<BiResponse> {
 
-    //TODO: Remove when backend has pagination
-    if (paginationQuery.pageSize){
-      if (paginationQuery.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
-    }
-    if (paginationQuery.page) {
-      if (paginationQuery.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
-    }
-    if (paginationQuery.showAll) {
-      console.log('showing all');
-    }
-
     return new Promise<BiResponse>(((resolve, reject) => {
 
       api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users`, method: 'get', params: paginationQuery })
         .then((response: any) => {
-          //TODO: Change back when no longer mocked
-          response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);
         }).catch((error) => {

--- a/src/breeding-insight/dao/ProgramUserDAO.ts
+++ b/src/breeding-insight/dao/ProgramUserDAO.ts
@@ -18,8 +18,19 @@
 import {ProgramUser} from "@/breeding-insight/model/ProgramUser";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramUserDAO {
+
+  static mockMetadata: any = {
+    pagination: {
+      totalCount: 1000,
+      pageSize: 50,
+      totalPages: 20,
+      currentPage: 1
+    },
+    status: []
+  }
 
   static create(programUser: ProgramUser): Promise<BiResponse> {
 
@@ -69,12 +80,25 @@ export class ProgramUserDAO {
     return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users/${userId}`, method: 'delete'});
   }
 
-  static getAll(programId: string): Promise<BiResponse> {
+  static getAll(programId: string, paginationQuery: PaginationQuery): Promise<BiResponse> {
+
+    //TODO: Remove when backend has pagination
+    if (paginationQuery.pageSize){
+      if (paginationQuery.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
+    }
+    if (paginationQuery.page) {
+      if (paginationQuery.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
+    }
+    if (paginationQuery.showAll) {
+      console.log('showing all');
+    }
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users`, method: 'get' })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users`, method: 'get', params: paginationQuery })
         .then((response: any) => {
+          //TODO: Change back when no longer mocked
+          response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);
         }).catch((error) => {

--- a/src/breeding-insight/dao/RoleDAO.ts
+++ b/src/breeding-insight/dao/RoleDAO.ts
@@ -17,14 +17,15 @@
 
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class RoleDAO {
 
-  static getAll(): Promise<BiResponse> {
+  static getAll(paginationQuery: PaginationQuery): Promise<BiResponse> {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/roles`, method: 'get' })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/roles`, method: 'get', params: paginationQuery })
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/SpeciesDAO.ts
+++ b/src/breeding-insight/dao/SpeciesDAO.ts
@@ -18,14 +18,15 @@
 import {Species} from "@/breeding-insight/model/Species";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class SpeciesDAO {
 
-  static getAll(): Promise<BiResponse> {
+  static getAll(paginationQuery: PaginationQuery): Promise<BiResponse> {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/species`, method: 'get' })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/species`, method: 'get', params: paginationQuery })
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/SystemRoleDao.ts
+++ b/src/breeding-insight/dao/SystemRoleDao.ts
@@ -17,14 +17,15 @@
 
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class SystemRoleDao {
 
-  static getAll(): Promise<BiResponse> {
+  static getAll(paginationQuery: PaginationQuery): Promise<BiResponse> {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/roles`, method: 'get' })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/roles`, method: 'get', params: paginationQuery })
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/UserDAO.ts
+++ b/src/breeding-insight/dao/UserDAO.ts
@@ -23,16 +23,6 @@ import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class UserDAO {
 
-  static mockMetadata: any = {
-    pagination: {
-      totalCount: 1000,
-      pageSize: 50,
-      totalPages: 20,
-      currentPage: 1
-    },
-    status: []
-  }
-
   static getUserInfo(): Promise<BiResponse> {
 
     return new Promise<BiResponse>((resolve, reject) => {
@@ -85,23 +75,10 @@ export class UserDAO {
 
   static getAll(paginationQuery: PaginationQuery): Promise<BiResponse> {
 
-    //TODO: Remove when backend has pagination
-    if (paginationQuery.pageSize){
-      if (paginationQuery.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
-    }
-    if (paginationQuery.page) {
-      if (paginationQuery.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
-    }
-    if (paginationQuery.showAll) {
-      console.log('showing all');
-    }
-
     return new Promise<BiResponse>(((resolve, reject) => {
 
       api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users`, method: 'get', params: paginationQuery })
         .then((response: any) => {
-          //TODO: Change back when no longer mocked
-          response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);
         }).catch((error) => {

--- a/src/breeding-insight/dao/UserDAO.ts
+++ b/src/breeding-insight/dao/UserDAO.ts
@@ -19,8 +19,19 @@ import {User} from "@/breeding-insight/model/User";
 import * as api from "@/util/api";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import {Role} from "@/breeding-insight/model/Role";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class UserDAO {
+
+  static mockMetadata: any = {
+    pagination: {
+      totalCount: 1000,
+      pageSize: 50,
+      totalPages: 20,
+      currentPage: 1
+    },
+    status: []
+  }
 
   static getUserInfo(): Promise<BiResponse> {
 
@@ -72,12 +83,25 @@ export class UserDAO {
     return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users/${id}`, method: 'delete'});
   }
 
-  static getAll(): Promise<BiResponse> {
+  static getAll(paginationQuery: PaginationQuery): Promise<BiResponse> {
+
+    //TODO: Remove when backend has pagination
+    if (paginationQuery.pageSize){
+      if (paginationQuery.pageSize != 0) this.mockMetadata.pagination.pageSize = paginationQuery.pageSize;
+    }
+    if (paginationQuery.page) {
+      if (paginationQuery.page != 0) this.mockMetadata.pagination.currentPage = paginationQuery.page;
+    }
+    if (paginationQuery.showAll) {
+      console.log('showing all');
+    }
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users`, method: 'get' })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users`, method: 'get', params: paginationQuery })
         .then((response: any) => {
+          //TODO: Change back when no longer mocked
+          response.data.metadata = this.mockMetadata;
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);
         }).catch((error) => {

--- a/src/breeding-insight/model/BiResponse.ts
+++ b/src/breeding-insight/model/BiResponse.ts
@@ -25,7 +25,7 @@ export class BiResponse {
   }
 }
 
-class Metadata {
+export class Metadata {
   pagination: Pagination;
   statusArray: Array<Status>;
 
@@ -35,17 +35,25 @@ class Metadata {
   }
 }
 
-class Pagination {
+export class Pagination {
   totalPages: Number;
   currentPage: Number;
   totalCount: Number;
   pageSize: Number;
 
-  constructor(paginationResult: any) {
-    this.totalPages = paginationResult.totalPages;
-    this.currentPage = paginationResult.currentPage;
-    this.totalCount = paginationResult.totalCount;
-    this.pageSize = paginationResult.pageSize;
+  constructor(paginationResult?: any) {
+    if (paginationResult){
+      this.totalPages = paginationResult.totalPages;
+      this.currentPage = paginationResult.currentPage;
+      this.totalCount = paginationResult.totalCount;
+      this.pageSize = paginationResult.pageSize;
+    } else {
+      this.totalPages = 1;
+      this.currentPage = 1;
+      this.totalCount = 0;
+      this.pageSize = 0;
+    }
+
   }
 }
 

--- a/src/breeding-insight/model/PaginationQuery.ts
+++ b/src/breeding-insight/model/PaginationQuery.ts
@@ -1,9 +1,9 @@
 export class PaginationQuery {
-  page: Number;
-  pageSize: Number;
+  page: number;
+  pageSize: number;
   showAll: boolean;
 
-  constructor(page: Number, pageSize: Number, showAll: boolean) {
+  constructor(page: number, pageSize: number, showAll: boolean) {
     this.page = page;
     this.pageSize = pageSize;
     this.showAll = showAll;

--- a/src/breeding-insight/model/PaginationQuery.ts
+++ b/src/breeding-insight/model/PaginationQuery.ts
@@ -1,0 +1,11 @@
+export class PaginationQuery {
+  page: Number;
+  pageSize: Number;
+  showAll: boolean;
+
+  constructor(page: Number, pageSize: Number, showAll: boolean) {
+    this.page = page;
+    this.pageSize = pageSize;
+    this.showAll = showAll;
+  }
+}

--- a/src/breeding-insight/model/view_models/PaginationController.ts
+++ b/src/breeding-insight/model/view_models/PaginationController.ts
@@ -2,12 +2,12 @@ import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {Pagination} from "@/breeding-insight/model/BiResponse";
 
 export class PaginationController {
-  public currentPage: Number = 1;
-  public pageSize: Number = 50;
+  public currentPage: number = 1;
+  public pageSize: number = 50;
   public showAll: boolean = false;
   public currentCall?: PaginationQuery;
 
-  constructor(currentPage?: Number, pageSize?: Number, currentCall?: PaginationQuery) {
+  constructor(currentPage?: number, pageSize?: number, currentCall?: PaginationQuery) {
     if (currentPage) this.currentPage = currentPage;
     if (pageSize) this.pageSize = pageSize;
     if (currentCall) this.currentCall = currentCall;
@@ -17,12 +17,12 @@ export class PaginationController {
     this.showAll = !this.showAll;
   }
 
-  updatePageSize(pageSize: Number) {
+  updatePageSize(pageSize: number) {
     this.pageSize = pageSize;
     this.showAll = false;
   }
 
-  updatePage(page: Number) {
+  updatePage(page: number) {
     this.currentPage = page;
     this.showAll = false;
   }
@@ -53,7 +53,9 @@ export class PaginationController {
     }
   }
 
+  //TODO: Remove when backend pagination is implemented
   static mockPagination(records: any[], page: number, pageSize: number, showAll: boolean): [any[], Pagination] {
+
     if (showAll){
       const newPagination: Pagination = new Pagination({
         totalCount: records.length,
@@ -62,6 +64,14 @@ export class PaginationController {
         currentPage: 1
       });
       return [records, newPagination];
+    } else if (records.length === 0){
+      const newPagination: Pagination = new Pagination({
+        totalCount: 0,
+        pageSize: pageSize,
+        totalPages: 1,
+        currentPage: page
+      });
+      return [[], newPagination];
     } else {
       const newPagination: Pagination = new Pagination({
         totalCount: records.length,

--- a/src/breeding-insight/model/view_models/PaginationController.ts
+++ b/src/breeding-insight/model/view_models/PaginationController.ts
@@ -7,7 +7,7 @@ export class PaginationController {
   public showAll: boolean = false;
   public currentCall?: PaginationQuery;
 
-  constructor(currentPage?: Number, pageSize?: Number, lockPaginate?: boolean, currentCall?: PaginationQuery) {
+  constructor(currentPage?: Number, pageSize?: Number, currentCall?: PaginationQuery) {
     if (currentPage) this.currentPage = currentPage;
     if (pageSize) this.pageSize = pageSize;
     if (currentCall) this.currentCall = currentCall;

--- a/src/breeding-insight/model/view_models/PaginationController.ts
+++ b/src/breeding-insight/model/view_models/PaginationController.ts
@@ -34,18 +34,42 @@ export class PaginationController {
   matchesCurrentRequest(pagination: Pagination): boolean {
 
     if (this.currentCall) {
-      return this.currentCall.page === pagination.currentPage &&
-        this.currentCall.pageSize === pagination.pageSize;
+      if (this.showAll){
+        return pagination.currentPage == 1 && pagination.totalPages == 1;
+      } else {
+        return this.currentCall.page === pagination.currentPage &&
+          this.currentCall.pageSize === pagination.pageSize;
+      }
     }
     return false;
   }
 
-  static getPaginationSelections(currentPage: Number, pageSize: Number, showAll: boolean): PaginationQuery {
+  static getPaginationSelections(currentPage: number, pageSize: number, showAll: boolean): PaginationQuery {
     if (showAll) {
       return new PaginationQuery(0, 0, true);
     } else {
       return new PaginationQuery(
         currentPage, pageSize, false);
+    }
+  }
+
+  static mockPagination(records: any[], page: number, pageSize: number, showAll: boolean): [any[], Pagination] {
+    if (showAll){
+      const newPagination: Pagination = new Pagination({
+        totalCount: records.length,
+        pageSize: records.length,
+        totalPages: 1,
+        currentPage: 1
+      });
+      return [records, newPagination];
+    } else {
+      const newPagination: Pagination = new Pagination({
+        totalCount: records.length,
+        pageSize: pageSize,
+        totalPages: records.length / pageSize,
+        currentPage: page
+      });
+      return [records.slice((page * pageSize - pageSize), (page * pageSize > records.length ? records.length : page * pageSize)), newPagination];
     }
   }
 

--- a/src/breeding-insight/model/view_models/PaginationController.ts
+++ b/src/breeding-insight/model/view_models/PaginationController.ts
@@ -1,4 +1,5 @@
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {Pagination} from "@/breeding-insight/model/BiResponse";
 
 export class PaginationController {
   public currentPage: Number = 1;
@@ -28,6 +29,24 @@ export class PaginationController {
 
   setCurrentCall(paginationQuery: PaginationQuery){
     this.currentCall = paginationQuery;
+  }
+
+  matchesCurrentRequest(pagination: Pagination): boolean {
+
+    if (this.currentCall) {
+      return this.currentCall.page === pagination.currentPage &&
+        this.currentCall.pageSize === pagination.pageSize;
+    }
+    return false;
+  }
+
+  static getPaginationSelections(currentPage: Number, pageSize: Number, showAll: boolean): PaginationQuery {
+    if (showAll) {
+      return new PaginationQuery(0, 0, true);
+    } else {
+      return new PaginationQuery(
+        currentPage, pageSize, false);
+    }
   }
 
 }

--- a/src/breeding-insight/model/view_models/PaginationController.ts
+++ b/src/breeding-insight/model/view_models/PaginationController.ts
@@ -83,4 +83,15 @@ export class PaginationController {
     }
   }
 
+  //TODO: Remove when backend pagination is implemented
+  static mockSortRecords(records: any[]){
+    // Imitates sql sorting by created date
+    if (records && records.length > 0){
+      if (records[0].createdAt){
+        records = records.sort((record1, record2) => record1.createdAt > record2.createdAt ? -1: 1);
+      }
+    }
+    return records;
+  }
+
 }

--- a/src/breeding-insight/model/view_models/PaginationController.ts
+++ b/src/breeding-insight/model/view_models/PaginationController.ts
@@ -1,0 +1,33 @@
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+
+export class PaginationController {
+  public currentPage: Number = 1;
+  public pageSize: Number = 50;
+  public showAll: boolean = false;
+  public currentCall?: PaginationQuery;
+
+  constructor(currentPage?: Number, pageSize?: Number, lockPaginate?: boolean, currentCall?: PaginationQuery) {
+    if (currentPage) this.currentPage = currentPage;
+    if (pageSize) this.pageSize = pageSize;
+    if (currentCall) this.currentCall = currentCall;
+  }
+
+  toggleShowAll(){
+    this.showAll = !this.showAll;
+  }
+
+  updatePageSize(pageSize: Number) {
+    this.pageSize = pageSize;
+    this.showAll = false;
+  }
+
+  updatePage(page: Number) {
+    this.currentPage = page;
+    this.showAll = false;
+  }
+
+  setCurrentCall(paginationQuery: PaginationQuery){
+    this.currentCall = paginationQuery;
+  }
+
+}

--- a/src/breeding-insight/service/ProgramLocationService.ts
+++ b/src/breeding-insight/service/ProgramLocationService.ts
@@ -19,6 +19,7 @@ import {ProgramLocationDAO} from "@/breeding-insight/dao/ProgramLocationDAO";
 import {ProgramLocation} from "@/breeding-insight/model/ProgramLocation";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 
 export class ProgramLocationService {
 
@@ -92,6 +93,10 @@ export class ProgramLocationService {
             programLocations = biResponse.result.data.map((programLocation: any) => {
               return new ProgramLocation(programLocation.id, programLocation.programId, programLocation.name);
             });
+            //TODO: Remove when backend pagination is implemented
+            let newPagination;
+            [programLocations, newPagination] = PaginationController.mockPagination(programLocations, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
+            biResponse.metadata.pagination = newPagination;
           }
       
           resolve([programLocations, biResponse.metadata]);

--- a/src/breeding-insight/service/ProgramLocationService.ts
+++ b/src/breeding-insight/service/ProgramLocationService.ts
@@ -93,11 +93,11 @@ export class ProgramLocationService {
             programLocations = biResponse.result.data.map((programLocation: any) => {
               return new ProgramLocation(programLocation.id, programLocation.programId, programLocation.name);
             });
-            //TODO: Remove when backend pagination is implemented
-            let newPagination;
-            [programLocations, newPagination] = PaginationController.mockPagination(programLocations, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
-            biResponse.metadata.pagination = newPagination;
           }
+          //TODO: Remove when backend pagination is implemented
+          let newPagination;
+          [programLocations, newPagination] = PaginationController.mockPagination(programLocations, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
+          biResponse.metadata.pagination = newPagination;
       
           resolve([programLocations, biResponse.metadata]);
       

--- a/src/breeding-insight/service/ProgramLocationService.ts
+++ b/src/breeding-insight/service/ProgramLocationService.ts
@@ -86,6 +86,9 @@ export class ProgramLocationService {
       if (programId) {
         ProgramLocationDAO.getAll(programId, paginationQuery).then((biResponse) => {
 
+          //TODO: Remove when backend sorts the data by default
+          biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
+
           let programLocations: ProgramLocation[] = [];
       
           // TODO: workaround for no program locations for now

--- a/src/breeding-insight/service/ProgramLocationService.ts
+++ b/src/breeding-insight/service/ProgramLocationService.ts
@@ -17,6 +17,8 @@
 
 import {ProgramLocationDAO} from "@/breeding-insight/dao/ProgramLocationDAO";
 import {ProgramLocation} from "@/breeding-insight/model/ProgramLocation";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramLocationService {
 
@@ -73,11 +75,15 @@ export class ProgramLocationService {
     }));
   }
 
-  static getAll(programId: string): Promise<ProgramLocation[]> {
-    return new Promise<ProgramLocation[]>(((resolve, reject) => {
+  static getAll(programId: string, paginationQuery?: PaginationQuery): Promise<[ProgramLocation[], Metadata]> {
+    return new Promise<[ProgramLocation[], Metadata]>(((resolve, reject) => {
+
+      if (paginationQuery === undefined){
+        paginationQuery = new PaginationQuery(0, 0, true);
+      }
 
       if (programId) {
-        ProgramLocationDAO.getAll(programId).then((biResponse) => {
+        ProgramLocationDAO.getAll(programId, paginationQuery).then((biResponse) => {
 
           let programLocations: ProgramLocation[] = [];
       
@@ -88,7 +94,7 @@ export class ProgramLocationService {
             });
           }
       
-          resolve(programLocations);
+          resolve([programLocations, biResponse.metadata]);
       
         }).catch((error) => reject(error));
       

--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -17,6 +17,8 @@
 
 import {ProgramDAO} from "@/breeding-insight/dao/ProgramDAO";
 import {Program} from "@/breeding-insight/model/Program";
+import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramService {
 
@@ -73,10 +75,13 @@ export class ProgramService {
     }));
   }
 
-  static getAll(): Promise<Program[]> {
-    return new Promise<Program[]>(((resolve, reject) => {
+  static getAll(paginationQuery?: PaginationQuery): Promise<[Program[], Metadata]> {
+    return new Promise<[Program[], Metadata]>(((resolve, reject) => {
 
-      ProgramDAO.getAll().then((biResponse) => {
+      if (paginationQuery === undefined){
+        paginationQuery = new PaginationQuery(0, 0, true);
+      }
+      ProgramDAO.getAll(paginationQuery).then((biResponse) => {
 
         let programs: Program[] = [];
     
@@ -87,8 +92,8 @@ export class ProgramService {
             return new Program(program.id, program.name, program.species.id);
           });
         }
-    
-        resolve(programs);
+
+        resolve([programs, biResponse.metadata]);
     
       }).catch((error) => reject(error));
     

--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -92,11 +92,11 @@ export class ProgramService {
           programs = biResponse.result.data.map((program: any) => {
             return new Program(program.id, program.name, program.species.id);
           });
-          //TODO: Remove when backend pagination is implemented
-          let newPagination;
-          [programs, newPagination] = PaginationController.mockPagination(programs, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
-          biResponse.metadata.pagination = newPagination;
         }
+        //TODO: Remove when backend pagination is implemented
+        let newPagination;
+        [programs, newPagination] = PaginationController.mockPagination(programs, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
+        biResponse.metadata.pagination = newPagination;
 
         resolve([programs, biResponse.metadata]);
     

--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -19,6 +19,7 @@ import {ProgramDAO} from "@/breeding-insight/dao/ProgramDAO";
 import {Program} from "@/breeding-insight/model/Program";
 import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 
 export class ProgramService {
 
@@ -91,6 +92,10 @@ export class ProgramService {
           programs = biResponse.result.data.map((program: any) => {
             return new Program(program.id, program.name, program.species.id);
           });
+          //TODO: Remove when backend pagination is implemented
+          let newPagination;
+          [programs, newPagination] = PaginationController.mockPagination(programs, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
+          biResponse.metadata.pagination = newPagination;
         }
 
         resolve([programs, biResponse.metadata]);

--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -84,6 +84,9 @@ export class ProgramService {
       }
       ProgramDAO.getAll(paginationQuery).then((biResponse) => {
 
+        //TODO: Remove when backend sorts the data by default
+        biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
+
         let programs: Program[] = [];
     
         // TODO: workaround for no programs for now

--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -18,6 +18,8 @@
 import {ProgramUserDAO} from "@/breeding-insight/dao/ProgramUserDAO";
 import {ProgramUser} from "@/breeding-insight/model/ProgramUser";
 import {Program} from "@/breeding-insight/model/Program";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class ProgramUserService {
 
@@ -88,11 +90,15 @@ export class ProgramUserService {
     }));
   }
 
-  static getAll(programId: string): Promise<ProgramUser[]> {
-    return new Promise<ProgramUser[]>(((resolve, reject) => {
+  static getAll(programId: string, paginationQuery?: PaginationQuery): Promise<[ProgramUser[], Metadata]> {
+    return new Promise<[ProgramUser[], Metadata]>(((resolve, reject) => {
+
+      if (paginationQuery === undefined){
+        paginationQuery = new PaginationQuery(0, 0, true);
+      }
 
       if (programId) {
-        ProgramUserDAO.getAll(programId).then((biResponse) => {
+        ProgramUserDAO.getAll(programId, paginationQuery).then((biResponse) => {
 
           let programUsers: ProgramUser[] = [];
       
@@ -104,7 +110,7 @@ export class ProgramUserService {
             });
           }
       
-          resolve(programUsers);
+          resolve([programUsers, biResponse.metadata]);
       
         }).catch((error) => reject(error));
       

--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -109,12 +109,12 @@ export class ProgramUserService {
               const newProgram = new Program(programUser.program.id, programUser.program.name);
               return new ProgramUser(programUser.user.id, programUser.user.name, programUser.user.email, programUser.roles[0].id, newProgram, programUser.active);
             });
-            //TODO: Remove when backend pagination is implemented
-            let newPagination;
-            [programUsers, newPagination] = PaginationController.mockPagination(programUsers, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
-            biResponse.metadata.pagination = newPagination;
           }
-      
+          //TODO: Remove when backend pagination is implemented
+          let newPagination;
+          [programUsers, newPagination] = PaginationController.mockPagination(programUsers, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
+          biResponse.metadata.pagination = newPagination;
+
           resolve([programUsers, biResponse.metadata]);
       
         }).catch((error) => reject(error));

--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -101,6 +101,8 @@ export class ProgramUserService {
       if (programId) {
         ProgramUserDAO.getAll(programId, paginationQuery).then((biResponse) => {
 
+          //TODO: Remove when backend sorts the data by default
+          biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
           let programUsers: ProgramUser[] = [];
       
           // TODO: workaround for no program users for now

--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -20,6 +20,7 @@ import {ProgramUser} from "@/breeding-insight/model/ProgramUser";
 import {Program} from "@/breeding-insight/model/Program";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 
 export class ProgramUserService {
 
@@ -108,6 +109,10 @@ export class ProgramUserService {
               const newProgram = new Program(programUser.program.id, programUser.program.name);
               return new ProgramUser(programUser.user.id, programUser.user.name, programUser.user.email, programUser.roles[0].id, newProgram, programUser.active);
             });
+            //TODO: Remove when backend pagination is implemented
+            let newPagination;
+            [programUsers, newPagination] = PaginationController.mockPagination(programUsers, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
+            biResponse.metadata.pagination = newPagination;
           }
       
           resolve([programUsers, biResponse.metadata]);

--- a/src/breeding-insight/service/RoleService.ts
+++ b/src/breeding-insight/service/RoleService.ts
@@ -18,14 +18,19 @@
 import {RoleDAO} from "@/breeding-insight/dao/RoleDAO";
 import {Role} from "@/breeding-insight/model/Role";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class RoleService {
 
   static errorGetRoles: string = 'Error while loading roles.'
-  static getAll(): Promise<[Role[], Metadata]> {
+  static getAll(paginationQuery?: PaginationQuery): Promise<[Role[], Metadata]> {
     return new Promise<[Role[], Metadata]>(((resolve, reject) => {
 
-      RoleDAO.getAll().then((biResponse) => {
+      if (paginationQuery === undefined){
+        paginationQuery = new PaginationQuery(0, 0, true);
+      }
+
+      RoleDAO.getAll(paginationQuery).then((biResponse) => {
 
         const roles = biResponse.result.data.map((roles: any) => {
           return new Role(roles.id, roles.domain);

--- a/src/breeding-insight/service/RoleService.ts
+++ b/src/breeding-insight/service/RoleService.ts
@@ -17,12 +17,13 @@
 
 import {RoleDAO} from "@/breeding-insight/dao/RoleDAO";
 import {Role} from "@/breeding-insight/model/Role";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
 
 export class RoleService {
 
   static errorGetRoles: string = 'Error while loading roles.'
-  static getAll(): Promise<Role[]> {
-    return new Promise<Role[]>(((resolve, reject) => {
+  static getAll(): Promise<[Role[], Metadata]> {
+    return new Promise<[Role[], Metadata]>(((resolve, reject) => {
 
       RoleDAO.getAll().then((biResponse) => {
 
@@ -30,7 +31,7 @@ export class RoleService {
           return new Role(roles.id, roles.domain);
         });
 
-        resolve(roles);
+        resolve([roles, biResponse.metadata]);
 
       }).catch((error) => {
         error['errorMessage'] = this.errorGetRoles;

--- a/src/breeding-insight/service/SpeciesService.ts
+++ b/src/breeding-insight/service/SpeciesService.ts
@@ -18,13 +18,18 @@
 import {SpeciesDAO} from "@/breeding-insight/dao/SpeciesDAO";
 import {Species} from "@/breeding-insight/model/Species";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class SpeciesService{
 
-  static getAll(): Promise<[Species[], Metadata]> {
+  static getAll(paginationQuery?: PaginationQuery): Promise<[Species[], Metadata]> {
     return new Promise<[Species[], Metadata]>(((resolve, reject) => {
 
-      SpeciesDAO.getAll().then((biResponse) => {
+      if (paginationQuery === undefined){
+        paginationQuery = new PaginationQuery(0, 0, true);
+      }
+
+      SpeciesDAO.getAll(paginationQuery).then((biResponse) => {
 
         // Parse our users into the vue users param
         const species = biResponse.result.data.map((species: any) => {

--- a/src/breeding-insight/service/SpeciesService.ts
+++ b/src/breeding-insight/service/SpeciesService.ts
@@ -17,11 +17,12 @@
 
 import {SpeciesDAO} from "@/breeding-insight/dao/SpeciesDAO";
 import {Species} from "@/breeding-insight/model/Species";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
 
 export class SpeciesService{
 
-  static getAll(): Promise<Species[]> {
-    return new Promise<Species[]>(((resolve, reject) => {
+  static getAll(): Promise<[Species[], Metadata]> {
+    return new Promise<[Species[], Metadata]>(((resolve, reject) => {
 
       SpeciesDAO.getAll().then((biResponse) => {
 
@@ -30,7 +31,7 @@ export class SpeciesService{
           return new Species(species.id, species.commonName);
         });
 
-        resolve(species);
+        resolve([species, biResponse.metadata]);
 
       }).catch((error) => reject(error));
 

--- a/src/breeding-insight/service/SystemRoleService.ts
+++ b/src/breeding-insight/service/SystemRoleService.ts
@@ -17,13 +17,14 @@
 
 import {Role} from "@/breeding-insight/model/Role";
 import {SystemRoleDao} from "@/breeding-insight/dao/SystemRoleDao";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
 
 export class SystemRoleService {
 
   static errorGetRoles = "Unable to load system roles";
 
-  static getAll(): Promise<Role[]> {
-    return new Promise<Role[]>(((resolve, reject) => {
+  static getAll(): Promise<[Role[], Metadata]> {
+    return new Promise<[Role[], Metadata]>(((resolve, reject) => {
 
       SystemRoleDao.getAll().then((biResponse) => {
 
@@ -31,7 +32,7 @@ export class SystemRoleService {
           return new Role(roles.id, roles.domain);
         });
 
-        resolve(roles);
+        resolve([roles, biResponse.metadata]);
 
       }).catch((error) => {
         error['errorMessage'] = this.errorGetRoles;

--- a/src/breeding-insight/service/SystemRoleService.ts
+++ b/src/breeding-insight/service/SystemRoleService.ts
@@ -18,15 +18,20 @@
 import {Role} from "@/breeding-insight/model/Role";
 import {SystemRoleDao} from "@/breeding-insight/dao/SystemRoleDao";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class SystemRoleService {
 
   static errorGetRoles = "Unable to load system roles";
 
-  static getAll(): Promise<[Role[], Metadata]> {
+  static getAll(paginationQuery?: PaginationQuery): Promise<[Role[], Metadata]> {
     return new Promise<[Role[], Metadata]>(((resolve, reject) => {
 
-      SystemRoleDao.getAll().then((biResponse) => {
+      if (paginationQuery === undefined){
+        paginationQuery = new PaginationQuery(0, 0, true);
+      }
+
+      SystemRoleDao.getAll(paginationQuery).then((biResponse) => {
 
         const roles = biResponse.result.data.map((roles: any) => {
           return new Role(roles.id, roles.domain);

--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -137,6 +137,7 @@ export class UserService {
 
       UserDAO.getAll(paginationQuery).then((biResponse) => {
 
+        biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
         // Parse our users into the vue users param
         let users = biResponse.result.data.map((user: any) => {
           const role: Role | undefined = this.parseSystemRoles(user.systemRoles);

--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -23,6 +23,7 @@ import {BiResponse, Metadata} from "@/breeding-insight/model/BiResponse";
 import {Program} from "@/breeding-insight/model/Program";
 import {ProgramUser} from "@/breeding-insight/model/ProgramUser";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 
 export class UserService {
 
@@ -137,11 +138,15 @@ export class UserService {
       UserDAO.getAll(paginationQuery).then((biResponse) => {
 
         // Parse our users into the vue users param
-        const users = biResponse.result.data.map((user: any) => {
+        let users = biResponse.result.data.map((user: any) => {
           const role: Role | undefined = this.parseSystemRoles(user.systemRoles);
           const programRoles: ProgramUser[] | undefined = this.parseProgramRoles(user.programRoles);
           return new User(user.id, user.name, user.orcid, user.email, role, programRoles);
         });
+        //TODO: Remove when backend pagination is implemented
+        let newPagination;
+        [users, newPagination] = PaginationController.mockPagination(users, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
+        biResponse.metadata.pagination = newPagination;
 
         resolve([users, biResponse.metadata]);
 

--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -19,9 +19,10 @@ import {User} from "@/breeding-insight/model/User";
 import {UserDAO} from "@/breeding-insight/dao/UserDAO";
 import {Role} from "@/breeding-insight/model/Role";
 import {Vue} from "vue-property-decorator";
-import {BiResponse} from "@/breeding-insight/model/BiResponse";
+import {BiResponse, Metadata} from "@/breeding-insight/model/BiResponse";
 import {Program} from "@/breeding-insight/model/Program";
 import {ProgramUser} from "@/breeding-insight/model/ProgramUser";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 
 export class UserService {
 
@@ -126,10 +127,14 @@ export class UserService {
     }))
   }
 
-  static getAll(): Promise<User[]> {
-    return new Promise<User[]>(((resolve, reject) => {
+  static getAll(paginationQuery?: PaginationQuery): Promise<[User[], Metadata]> {
+    return new Promise<[User[], Metadata]>(((resolve, reject) => {
 
-      UserDAO.getAll().then((biResponse) => {
+      if (paginationQuery === undefined){
+        paginationQuery = new PaginationQuery(0, 0, true);
+      }
+
+      UserDAO.getAll(paginationQuery).then((biResponse) => {
 
         // Parse our users into the vue users param
         const users = biResponse.result.data.map((user: any) => {
@@ -138,7 +143,7 @@ export class UserService {
           return new User(user.id, user.name, user.orcid, user.email, role, programRoles);
         });
 
-        resolve(users);
+        resolve([users, biResponse.metadata]);
 
       }).catch((error) => {
         error['errorMessage'] = this.errorGetUsers;

--- a/src/components/admin/AdminProgramsTable.vue
+++ b/src/components/admin/AdminProgramsTable.vue
@@ -96,9 +96,13 @@
       v-bind:records.sync="programs"
       v-bind:row-validations="programValidations"
       v-bind:editable="true"
+      v-bind:pagination="programsPagination"
       v-on:submit="updateProgram($event)"
       v-on:remove="displayWarning($event)"
       v-on:show-error-notification="$emit('show-error-notification', $event)"
+      v-on:paginate="paginationController.updatePage($event)"
+      v-on:paginate-toggle-all="paginationController.toggleShowAll()"
+      v-on:paginate-page-size="paginationController.updatePageSize($event)"
     >
       <template v-slot:columns="data">
         <TableRowColumn name="name">
@@ -155,7 +159,7 @@
 </template>
 
 <script lang="ts">
-import {Component, Prop, Vue} from 'vue-property-decorator'
+  import {Component, Prop, Vue, Watch} from 'vue-property-decorator'
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate'
 import {required} from 'vuelidate/lib/validators'
@@ -173,6 +177,9 @@ import {SpeciesService} from "@/breeding-insight/service/SpeciesService";
 import NewDataForm from "@/components/forms/NewDataForm.vue";
 import EmtpyTableMessage from "@/components/tables/EmtpyTableMessage.vue";
 import {EventBus} from "@/util/event-bus";
+import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+  import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 
 @Component({
   mixins: [validationMixin],
@@ -185,6 +192,7 @@ import {EventBus} from "@/util/event-bus";
 export default class AdminProgramsTable extends Vue {
 
   private programs: Array<Program> = [];
+  private programsPagination?: Pagination = new Pagination();
   programTableHeaders: string[] = ['Name', 'Species', '# Users'];
 
   private deactivateActive: boolean = false;
@@ -195,6 +203,8 @@ export default class AdminProgramsTable extends Vue {
 
   private speciesMap: Map<string, Species> = new Map();
   private deleteProgram: Program | undefined;
+
+  private paginationController: PaginationController = new PaginationController();
 
   private programName: string = "Program Name";
 
@@ -208,10 +218,23 @@ export default class AdminProgramsTable extends Vue {
     this.getSpecies();
   }
 
+  @Watch('paginationController', { deep: true})
   getPrograms() {
 
-    ProgramService.getAll().then((programs: Program[]) => {
-      this.programs = programs;
+    let paginationQuery: PaginationQuery = this.getPaginationSelections();
+    this.paginationController.setCurrentCall(paginationQuery);
+
+    ProgramService.getAll(paginationQuery).then(([programs, metadata]) => {
+
+      // Check that our most recent query is this one
+      const currentPaginationQuery = this.paginationController.currentCall;
+      if (currentPaginationQuery &&
+          currentPaginationQuery.page === metadata.pagination.currentPage &&
+          currentPaginationQuery.pageSize === metadata.pagination.pageSize)
+      {
+        this.programs = programs;
+        this.programsPagination = metadata.pagination;
+      }
     }).catch((error) => {
       // Display error that users cannot be loaded
       this.$emit('show-error-notification', 'Error while trying to load programs');
@@ -312,6 +335,18 @@ export default class AdminProgramsTable extends Vue {
 
   emitProgramChange() {
     EventBus.bus.$emit(EventBus.programChange);
+  }
+
+  getPaginationSelections(): PaginationQuery {
+    let paginationQuery: PaginationQuery;
+    if (this.paginationController.showAll) {
+      paginationQuery = new PaginationQuery(0, 0, true);
+    } else {
+      paginationQuery = new PaginationQuery(
+        this.paginationController.currentPage, this.paginationController.pageSize, false);
+    }
+
+    return paginationQuery;
   }
 
 }

--- a/src/components/admin/AdminProgramsTable.vue
+++ b/src/components/admin/AdminProgramsTable.vue
@@ -272,6 +272,7 @@ export default class AdminProgramsTable extends Vue {
   saveProgram() {
 
     ProgramService.create(this.newProgram).then((program: Program) => {
+      this.paginationController.updatePage(1);
       this.getPrograms();
       this.$emit('show-success-notification', 'Success! ' + this.newProgram.name + ' added.');
       this.newProgramActive = false;

--- a/src/components/admin/AdminProgramsTable.vue
+++ b/src/components/admin/AdminProgramsTable.vue
@@ -221,17 +221,14 @@ export default class AdminProgramsTable extends Vue {
   @Watch('paginationController', { deep: true})
   getPrograms() {
 
-    let paginationQuery: PaginationQuery = this.getPaginationSelections();
+    let paginationQuery: PaginationQuery = PaginationController.getPaginationSelections(
+        this.paginationController.currentPage, this.paginationController.pageSize, this.paginationController.showAll);
     this.paginationController.setCurrentCall(paginationQuery);
 
     ProgramService.getAll(paginationQuery).then(([programs, metadata]) => {
 
       // Check that our most recent query is this one
-      const currentPaginationQuery = this.paginationController.currentCall;
-      if (currentPaginationQuery &&
-          currentPaginationQuery.page === metadata.pagination.currentPage &&
-          currentPaginationQuery.pageSize === metadata.pagination.pageSize)
-      {
+      if (this.paginationController.matchesCurrentRequest(metadata.pagination)) {
         this.programs = programs;
         this.programsPagination = metadata.pagination;
       }
@@ -245,7 +242,7 @@ export default class AdminProgramsTable extends Vue {
 
   getSpecies() {
 
-    SpeciesService.getAll().then((species: Species[]) => {
+    SpeciesService.getAll().then(([species, metadata]) => {
       this.species = species;
       for (const individual of this.species){
         // reassign so vue picks up changes
@@ -337,17 +334,7 @@ export default class AdminProgramsTable extends Vue {
     EventBus.bus.$emit(EventBus.programChange);
   }
 
-  getPaginationSelections(): PaginationQuery {
-    let paginationQuery: PaginationQuery;
-    if (this.paginationController.showAll) {
-      paginationQuery = new PaginationQuery(0, 0, true);
-    } else {
-      paginationQuery = new PaginationQuery(
-        this.paginationController.currentPage, this.paginationController.pageSize, false);
-    }
 
-    return paginationQuery;
-  }
 
 }
 

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -346,6 +346,7 @@ export default class AdminUsersTable extends Vue {
   addUser() {
 
     UserService.create(this.newUser).then((user: User) => {
+      this.paginationController.updatePage(1);
       this.getUsers();
       this.newUser = new User();
       this.newUserActive = false;

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -218,7 +218,7 @@
     }
 
     getPrograms() {
-      ProgramService.getAll().then((programs: Program[]) => {
+      ProgramService.getAll().then(([programs, metadata]) => {
         this.programs = programs;
         // Clear the active program if its not in the list of programs anymore
         if (this.activeProgram){

--- a/src/components/program/ProgramLocationsTable.vue
+++ b/src/components/program/ProgramLocationsTable.vue
@@ -218,6 +218,7 @@ export default class ProgramLocationsTable extends Vue {
     this.newLocation.programId = this.activeProgram!.id;
 
     ProgramLocationService.create(this.newLocation).then((location: ProgramLocation) => {
+      this.paginationController.updatePage(1);
       this.getLocations();
       this.$emit('show-success-notification', 'Success! ' + this.newLocation.name + ' added.');
       this.newLocation = new ProgramLocation();

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -107,9 +107,13 @@
       v-bind:records.sync="users"
       v-bind:row-validations="userValidations"
       v-bind:editable="true"
+      v-bind:pagination="usersPagination"
       v-on:submit="updateUser($event)"
       v-on:remove="displayWarning($event)"
       v-on:show-error-notification="$emit('show-error-notification', $event)"
+      v-on:paginate="paginationController.updatePage($event)"
+      v-on:paginate-toggle-all="paginationController.toggleShowAll()"
+      v-on:paginate-page-size="paginationController.updatePageSize($event)"
     >
       <template v-slot:columns="data">
         <TableRowColumn name="name">
@@ -158,7 +162,7 @@
 </template>
 
 <script lang="ts">
-import {Component, Prop, Vue} from 'vue-property-decorator'
+  import {Component, Prop, Vue, Watch} from 'vue-property-decorator'
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate'
 import {required, email} from 'vuelidate/lib/validators'
@@ -176,6 +180,9 @@ import {RoleService} from "@/breeding-insight/service/RoleService";
 import { mapGetters } from 'vuex'
 import {Program} from "@/breeding-insight/model/Program";
 import EmptyTableMessage from "@/components/tables/EmtpyTableMessage.vue";
+  import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
+  import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+  import {Pagination} from "@/breeding-insight/model/BiResponse";
 
 @Component({
   mixins: [validationMixin],
@@ -192,6 +199,7 @@ export default class ProgramUsersTable extends Vue {
 
   private activeProgram?: Program;
   public users: ProgramUser[] = [];
+  private usersPagination?: Pagination = new Pagination();
   userTableHeaders: string[] = ['Name', 'Email', 'Role'];
 
   private deactivateActive: boolean = false;
@@ -204,6 +212,8 @@ export default class ProgramUsersTable extends Vue {
   private rolesMap: Map<string, Role> = new Map();
   private programName: string = "Program Name";
 
+  private paginationController: PaginationController = new PaginationController();
+
   userValidations = {
     name: {required},
     email: {required, email},
@@ -215,10 +225,19 @@ export default class ProgramUsersTable extends Vue {
     this.getUsers();
   }
 
+  @Watch('paginationController', { deep: true})
   getUsers() {
 
-    ProgramUserService.getAll(this.activeProgram!.id!).then((programUsers: ProgramUser[]) => {
-      this.users = programUsers;
+    let paginationQuery: PaginationQuery = PaginationController.getPaginationSelections(
+      this.paginationController.currentPage, this.paginationController.pageSize, this.paginationController.showAll);
+    this.paginationController.setCurrentCall(paginationQuery);
+
+    ProgramUserService.getAll(this.activeProgram!.id!, paginationQuery).then(([programUsers, metadata]) => {
+      if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
+        this.users = programUsers;
+        this.usersPagination = metadata.pagination;
+      }
+
     }).catch((error) => {
       // Display error that users cannot be loaded
       this.$emit('show-error-notification', 'Error while trying to load program users');
@@ -228,7 +247,7 @@ export default class ProgramUsersTable extends Vue {
 
   getRoles() {
 
-    RoleService.getAll().then((roles: Role[]) => {
+    RoleService.getAll().then(([roles, metadata]) => {
       this.roles = roles;
       for (const role of this.roles){
         // reassign so vue picks up changes

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -277,6 +277,7 @@ export default class ProgramUsersTable extends Vue {
     this.newUser.program = this.activeProgram;
 
     ProgramUserService.create(this.newUser).then((user: ProgramUser) => {
+      this.paginationController.updatePage(1);
       this.getUsers();
       this.$emit('show-success-notification', 'Success! ' + this.newUser.name + ' added.');
       this.newUser = new ProgramUser();

--- a/src/components/tables/BaseTable.vue
+++ b/src/components/tables/BaseTable.vue
@@ -17,233 +17,140 @@
 
 <template>
   <div>
-    <table
+    <template
       v-if="tableRows.length > 0"
-      class="table is-striped is-narrow is-hoverable is-fullwidth"
     >
-      <thead>
-        <tr>
-          <template v-for="(header, index) in headers">
-            <th
-              v-bind:key="'header' + index"
-              v-bind:class="{'is-hidden-mobile': hideMobileHeaders !== undefined && hideMobileHeaders.indexOf(header) !== -1 }"
+      <table
+
+        class="table is-striped is-narrow is-hoverable is-fullwidth"
+      >
+        <thead>
+          <tr>
+            <template v-for="(header, index) in headers">
+              <th
+                v-bind:key="'header' + index"
+                v-bind:class="{'is-hidden-mobile': hideMobileHeaders !== undefined && hideMobileHeaders.indexOf(header) !== -1 }"
+              >
+                {{ header }}
+              </th>
+            </template>
+            <template v-if="editable">
+              <th />
+            </template>
+          </tr>
+        </thead>
+        <tbody>
+          <template v-for="(row, index) in tableRows">
+            <BaseTableRow
+              v-bind:key="'row' + index"
+              v-bind:row-data="row"
+              v-on:edit="row.toggleEdit()"
+              v-on:remove="$emit('remove', row.data)"
             >
-              {{ header }}
-            </th>
+              <slot
+                v-bind="row.data"
+                name="columns"
+              />
+            </BaseTableRow>
+            <template v-if="row.edit">
+              <tr
+                v-bind:key="'edit' + index"
+                v-bind:class="{'is-selected': row.edit, 'is-new': row.new}"
+              >
+                <td v-bind:colspan="columnSpan">
+                  <EditDataRowForm
+                    @submit="validateAndSubmit(index)"
+                    @cancel="cancelEdit(row, index)"
+                  >
+                    <slot
+                      v-bind:editData="row.editData"
+                      v-bind:validations="getValidations(index)"
+                      name="edit"
+                    />
+                  </EditDataRowForm>
+                </td>
+              </tr>
+            </template>
           </template>
-          <template v-if="editable">
-            <th />
-          </template>
-        </tr>
-      </thead>
-      <tbody>
-        <template v-for="(row, index) in tableRows">
-          <BaseTableRow
-            v-bind:key="'row' + index"
-            v-bind:row-data="row"
-            v-on:edit="row.toggleEdit()"
-            v-on:remove="$emit('remove', row.data)"
+        </tbody>
+      </table>
+
+      <b-pagination
+          v-if="pagination"
+          :total="pagination.totalCount"
+          :current="pagination.currentPage"
+          range-before="1"
+          range-after="1"
+          order="is-centered"
+          size="is-small"
+          :simple="false"
+          :rounded="false"
+          :per-page="pagination.pageSize"
+          aria-next-label="Next page"
+          aria-previous-label="Previous page"
+          aria-page-label="Page"
+          aria-current-label="Current page"
+          v-on:change="$emit('paginate', $event)"
+      >
+        <b-pagination-button
+            slot="previous"
+            slot-scope="props"
+            :page="props.page"
+            tag="a"
+        >
+          Previous
+        </b-pagination-button>
+
+        <template
+            slot="next"
+            slot-scope="props"
+        >
+          <b-pagination-button
+              :page="props.page"
+              tag="a"
           >
-            <slot
-              v-bind="row.data"
-              name="columns"
-            />
-          </BaseTableRow>
-          <template v-if="row.edit">
-            <tr
-              v-bind:key="'edit' + index"
-              v-bind:class="{'is-selected': row.edit, 'is-new': row.new}"
-            >
-              <td v-bind:colspan="columnSpan">
-                <EditDataRowForm
-                  @submit="validateAndSubmit(index)"
-                  @cancel="cancelEdit(row, index)"
+            Next
+          </b-pagination-button>
+
+          <div class="pagination-extras">
+            <div class="page-size-select pagination-link">
+              <div class="select is-small">
+                <select
+                    v-model="pagination.pageSize"
+                    v-on:change="$emit('paginate-page-size', $event.target.value)"
                 >
-                  <slot
-                    v-bind:editData="row.editData"
-                    v-bind:validations="getValidations(index)"
-                    name="edit"
-                  />
-                </EditDataRowForm>
-              </td>
-            </tr>
-          </template>
+                  <option value="50">
+                    50
+                  </option>
+                  <option value="100">
+                    100
+                  </option>
+                  <option value="200">
+                    200
+                  </option>
+                </select>
+              </div>
+              <span>per page</span>
+            </div>
+
+            <a
+                role="button"
+                class="pagination-link show-all-button"
+                v-bind:class="{ 'has-background-info': pagination.totalPages === 1}"
+                v-on:click="$emit('paginate-toggle-all')"
+            >
+              Show All
+            </a>
+          </div>
         </template>
-      </tbody>
-    </table>
+      </b-pagination>
+
+    </template>
     <div v-else>
       <slot name="emptyMessage" />
     </div>
 
-    <!--<nav class="pagination" v-if="pagination">
-      <ul class="pagination-list">
-        <li>
-          <a
-              class="pagination-link"
-              v-bind:disabled="pagination.totalPages <= 1"
-              v-on:click="$emit('paginate', pagination.currentPage - 1)"
-              v-bind:aria-label="'Page ' + pagination.currentPage - 1"
-          >
-            Previous
-          </a>
-        </li>
-        <template v-if="pagination.totalPages > 5">
-          <li v-if="pagination.currentPage > 2" class="pagination-link">
-            <a
-              role="button"
-              aria-label="Page 1"
-              class="pagination-link"
-              v-on:click="$emit('paginate', 1)"
-            >
-              1
-            </a>
-          </li>
-          <li v-if="pagination.currentPage > 2 && pagination.currentPage != 3">
-            <span></span>
-          </li>
 
-          <li v-if="pagination.currentPage != 1">
-            <a
-              role="button"
-              v-bind:aria-label="`Page ${pagination.currentPage - 1}`"
-              class="pagination-link"
-              v-on:click="$emit('paginate', pagination.currentPage - 1)"
-            >
-              {{ pagination.currentPage - 1 }}
-            </a>
-          </li>
-          <li>
-            <a
-              role="button"
-              class="has-background-info pagination-link"
-            >
-              {{ pagination.currentPage }}
-            </a>
-          </li>
-          <li v-if="pagination.currentPage != pagination.totalPages">
-            <a
-                class="pagination-link"
-                v-bind:aria-label="`Page ${pagination.currentPage + 1}`"
-                v-on:click="$emit('paginate', pagination.currentPage + 1)"
-            >
-              {{ pagination.currentPage + 1 }}
-            </a>
-          </li>
-
-          <li v-if="pagination.currentPage < pagination.totalPages - 1 && pagination.currentPage != pagination.totalPages - 2">
-            <span></span>
-          </li>
-
-          <li v-if="pagination.currentPage < pagination.totalPages - 1">
-            <a
-              role="button"
-              v-bind:aria-label="`Page ${pagination.totalPages}`"
-              class="pagination-link"
-              v-on:click="$emit('paginate', pagination.totalPages)"
-            >
-              {{ pagination.totalPages }}
-            </a>
-          </li>
-
-        </template>
-        <template
-          v-for="pageNumber in pagination.totalPages"
-          v-else
-        >
-          <li v-bind:key="pageNumber">
-            <a
-              role="button"
-              v-bind:aria-label="`Page ${pageNumber}`"
-              class="pagination-link"
-              v-on:click="$emit('paginate', pageNumber)"
-            >
-              {{ pageNumber }}
-            </a>
-          </li>
-
-        </template>
-        <li>
-          <a
-              class="pagination-link"
-              v-bind:disabled="pagination.totalPages <= 1"
-              v-on:click="$emit('paginate', pagination.currentPage + 1)"
-              v-bind:aria-label="'Page ' + pagination.currentPage + 1"
-          >
-            Next
-          </a>
-        </li>
-      </ul>
-    </nav>-->
-
-    <b-pagination
-      v-if="pagination"
-      :total="pagination.totalCount"
-      :current="pagination.currentPage"
-      range-before="1"
-      range-after="1"
-      order="is-centered"
-      size="is-small"
-      :simple="false"
-      :rounded="false"
-      :per-page="pagination.pageSize"
-      aria-next-label="Next page"
-      aria-previous-label="Previous page"
-      aria-page-label="Page"
-      aria-current-label="Current page"
-      v-on:change="$emit('paginate', $event)"
-    >
-      <b-pagination-button
-        slot="previous"
-        slot-scope="props"
-        :page="props.page"
-        tag="a"
-      >
-        Previous
-      </b-pagination-button>
-
-      <template
-        slot="next"
-        slot-scope="props"
-      >
-        <b-pagination-button
-          :page="props.page"
-          tag="a"
-        >
-          Next
-        </b-pagination-button>
-
-        <div class="pagination-extras">
-          <div class="page-size-select pagination-link">
-            <div class="select is-small">
-              <select
-                v-model="pagination.pageSize"
-                v-on:change="$emit('paginate-page-size', $event.target.value)"
-              >
-                <option value="50">
-                  50
-                </option>
-                <option value="100">
-                  100
-                </option>
-                <option value="200">
-                  200
-                </option>
-              </select>
-            </div>
-            <span>per page</span>
-          </div>
-
-          <a
-            role="button"
-            class="pagination-link show-all-button"
-            v-bind:class="{ 'has-background-info': pagination.totalPages === 1}"
-            v-on:click="$emit('paginate-toggle-all')"
-          >
-            Show All
-          </a>
-        </div>
-      </template>
-    </b-pagination>
   </div>
 </template>
 

--- a/src/components/tables/BaseTable.vue
+++ b/src/components/tables/BaseTable.vue
@@ -186,10 +186,7 @@
     initialUpdate: boolean = false;
 
     private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
-
-    mounted() {
-      console.log(this.pagination);
-    }
+    
     updated() {
       this.initialUpdate = true;
     }

--- a/src/components/tables/BaseTable.vue
+++ b/src/components/tables/BaseTable.vue
@@ -119,6 +119,12 @@
                     v-model="pagination.pageSize"
                     v-on:change="$emit('paginate-page-size', $event.target.value)"
                 >
+                  <option value="10">
+                    10
+                  </option>
+                  <option value="20">
+                    20
+                  </option>
                   <option value="50">
                     50
                   </option>
@@ -186,7 +192,7 @@
     initialUpdate: boolean = false;
 
     private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
-    
+
     updated() {
       this.initialUpdate = true;
     }

--- a/src/components/tables/BaseTable.vue
+++ b/src/components/tables/BaseTable.vue
@@ -16,63 +16,235 @@
   -->
 
 <template>
-  <table
-    class="table is-striped is-narrow is-hoverable is-fullwidth"
-    v-if="tableRows.length > 0"
-  >
-    <thead>
-      <tr>
-        <template v-for="(header, index) in headers">
-          <th
-            v-bind:key="'header' + index"
-            v-bind:class="{'is-hidden-mobile': hideMobileHeaders !== undefined && hideMobileHeaders.indexOf(header) !== -1 }"
-          >
-            {{header}}
-          </th>
-        </template>
-        <template v-if="editable">
-          <th></th>
-        </template>
-      </tr>
-    </thead>
-    <tbody>
+  <div>
+    <table
+      v-if="tableRows.length > 0"
+      class="table is-striped is-narrow is-hoverable is-fullwidth"
+    >
+      <thead>
+        <tr>
+          <template v-for="(header, index) in headers">
+            <th
+              v-bind:key="'header' + index"
+              v-bind:class="{'is-hidden-mobile': hideMobileHeaders !== undefined && hideMobileHeaders.indexOf(header) !== -1 }"
+            >
+              {{ header }}
+            </th>
+          </template>
+          <template v-if="editable">
+            <th />
+          </template>
+        </tr>
+      </thead>
+      <tbody>
         <template v-for="(row, index) in tableRows">
           <BaseTableRow
-              v-bind:key="'row' + index"
-              v-bind:row-data="row"
-              v-on:edit="row.toggleEdit()"
-              v-on:remove="$emit('remove', row.data)"
+            v-bind:key="'row' + index"
+            v-bind:row-data="row"
+            v-on:edit="row.toggleEdit()"
+            v-on:remove="$emit('remove', row.data)"
           >
             <slot
-                v-bind="row.data"
-                name="columns"
+              v-bind="row.data"
+              name="columns"
             />
           </BaseTableRow>
           <template v-if="row.edit">
             <tr
-                v-bind:key="'edit' + index"
-                v-bind:class="{'is-selected': row.edit, 'is-new': row.new}"
+              v-bind:key="'edit' + index"
+              v-bind:class="{'is-selected': row.edit, 'is-new': row.new}"
             >
               <td v-bind:colspan="columnSpan">
                 <EditDataRowForm
-                    @submit="validateAndSubmit(index)"
-                    @cancel="cancelEdit(row, index)"
+                  @submit="validateAndSubmit(index)"
+                  @cancel="cancelEdit(row, index)"
                 >
                   <slot
-                      v-bind:editData="row.editData"
-                      v-bind:validations="getValidations(index)"
-                      name="edit" />
+                    v-bind:editData="row.editData"
+                    v-bind:validations="getValidations(index)"
+                    name="edit"
+                  />
                 </EditDataRowForm>
               </td>
             </tr>
           </template>
         </template>
-    </tbody>
-  </table>
-  <div v-else>
-    <slot name="emptyMessage" />
-  </div>
+      </tbody>
+    </table>
+    <div v-else>
+      <slot name="emptyMessage" />
+    </div>
 
+    <!--<nav class="pagination" v-if="pagination">
+      <ul class="pagination-list">
+        <li>
+          <a
+              class="pagination-link"
+              v-bind:disabled="pagination.totalPages <= 1"
+              v-on:click="$emit('paginate', pagination.currentPage - 1)"
+              v-bind:aria-label="'Page ' + pagination.currentPage - 1"
+          >
+            Previous
+          </a>
+        </li>
+        <template v-if="pagination.totalPages > 5">
+          <li v-if="pagination.currentPage > 2" class="pagination-link">
+            <a
+              role="button"
+              aria-label="Page 1"
+              class="pagination-link"
+              v-on:click="$emit('paginate', 1)"
+            >
+              1
+            </a>
+          </li>
+          <li v-if="pagination.currentPage > 2 && pagination.currentPage != 3">
+            <span></span>
+          </li>
+
+          <li v-if="pagination.currentPage != 1">
+            <a
+              role="button"
+              v-bind:aria-label="`Page ${pagination.currentPage - 1}`"
+              class="pagination-link"
+              v-on:click="$emit('paginate', pagination.currentPage - 1)"
+            >
+              {{ pagination.currentPage - 1 }}
+            </a>
+          </li>
+          <li>
+            <a
+              role="button"
+              class="has-background-info pagination-link"
+            >
+              {{ pagination.currentPage }}
+            </a>
+          </li>
+          <li v-if="pagination.currentPage != pagination.totalPages">
+            <a
+                class="pagination-link"
+                v-bind:aria-label="`Page ${pagination.currentPage + 1}`"
+                v-on:click="$emit('paginate', pagination.currentPage + 1)"
+            >
+              {{ pagination.currentPage + 1 }}
+            </a>
+          </li>
+
+          <li v-if="pagination.currentPage < pagination.totalPages - 1 && pagination.currentPage != pagination.totalPages - 2">
+            <span></span>
+          </li>
+
+          <li v-if="pagination.currentPage < pagination.totalPages - 1">
+            <a
+              role="button"
+              v-bind:aria-label="`Page ${pagination.totalPages}`"
+              class="pagination-link"
+              v-on:click="$emit('paginate', pagination.totalPages)"
+            >
+              {{ pagination.totalPages }}
+            </a>
+          </li>
+
+        </template>
+        <template
+          v-for="pageNumber in pagination.totalPages"
+          v-else
+        >
+          <li v-bind:key="pageNumber">
+            <a
+              role="button"
+              v-bind:aria-label="`Page ${pageNumber}`"
+              class="pagination-link"
+              v-on:click="$emit('paginate', pageNumber)"
+            >
+              {{ pageNumber }}
+            </a>
+          </li>
+
+        </template>
+        <li>
+          <a
+              class="pagination-link"
+              v-bind:disabled="pagination.totalPages <= 1"
+              v-on:click="$emit('paginate', pagination.currentPage + 1)"
+              v-bind:aria-label="'Page ' + pagination.currentPage + 1"
+          >
+            Next
+          </a>
+        </li>
+      </ul>
+    </nav>-->
+
+    <b-pagination
+      v-if="pagination"
+      :total="pagination.totalCount"
+      :current="pagination.currentPage"
+      range-before="1"
+      range-after="1"
+      order="is-centered"
+      size="is-small"
+      :simple="false"
+      :rounded="false"
+      :per-page="pagination.pageSize"
+      aria-next-label="Next page"
+      aria-previous-label="Previous page"
+      aria-page-label="Page"
+      aria-current-label="Current page"
+      v-on:change="$emit('paginate', $event)"
+    >
+      <b-pagination-button
+        slot="previous"
+        slot-scope="props"
+        :page="props.page"
+        tag="a"
+      >
+        Previous
+      </b-pagination-button>
+
+      <template
+        slot="next"
+        slot-scope="props"
+      >
+        <b-pagination-button
+          :page="props.page"
+          tag="a"
+        >
+          Next
+        </b-pagination-button>
+
+        <div class="pagination-extras">
+          <div class="page-size-select pagination-link">
+            <div class="select is-small">
+              <select
+                v-model="pagination.pageSize"
+                v-on:change="$emit('paginate-page-size', $event.target.value)"
+              >
+                <option value="50">
+                  50
+                </option>
+                <option value="100">
+                  100
+                </option>
+                <option value="200">
+                  200
+                </option>
+              </select>
+            </div>
+            <span>per page</span>
+          </div>
+
+          <a
+            role="button"
+            class="pagination-link show-all-button"
+            v-bind:class="{ 'has-background-info': pagination.totalPages === 1}"
+            v-on:click="$emit('paginate-toggle-all')"
+          >
+            Show All
+          </a>
+        </div>
+      </template>
+    </b-pagination>
+  </div>
 </template>
 
 
@@ -83,6 +255,7 @@
   import {TableRow} from "@/breeding-insight/model/view_models/TableRow"
   import EditDataRowForm from '@/components/forms/EditDataRowForm.vue'
   import {Validations} from "vuelidate-property-decorators";
+  import {Pagination} from "@/breeding-insight/model/BiResponse";
 
   @Component({
     components: { BaseTableRow, EditDataRowForm }
@@ -100,11 +273,16 @@
     rowValidations!: Object;
     @Prop()
     editable!: boolean;
+    @Prop()
+    pagination!: Pagination;
 
     initialUpdate: boolean = false;
 
     private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
 
+    mounted() {
+      console.log(this.pagination);
+    }
     updated() {
       this.initialUpdate = true;
     }

--- a/src/views/ProgramSelection.vue
+++ b/src/views/ProgramSelection.vue
@@ -57,6 +57,7 @@
   import { ProgramService } from '../breeding-insight/service/ProgramService';
   import {mapGetters} from "vuex";
   import {User} from "@/breeding-insight/model/User";
+  import {BiResponse} from "@/breeding-insight/model/BiResponse";
 
   @Component({
     components: {},
@@ -76,7 +77,7 @@
     }
 
     getPrograms() {
-      ProgramService.getAll().then((programs: Program[]) => {
+      ProgramService.getAll().then(([programs, metadata]) => {
         this.programs = programs;
         if (programs.length == 1){
           const program: Program = programs[0];


### PR DESCRIPTION
Implementation of pagination on bi-web. This is based onto PRO-53 so will include changes from that too. This should run on PRO-53 of bi-api. 

This implementation is currently mocked out, so the mocks will need to remove and functionality double checked when we have the real deal implemented. I created a card for this:

https://trello.com/c/RSYJJSKT/178-remove-mocked-pagination-from-front-end

## Implementation Details

The pagination UI exists within the `BaseTable` component, and take a `Pagination` object as a property. The `BaseTable` emits three different events, one for a page change, one for a page size change, and one for a show all toggle. It is the job of the component handling the `BaseTable` to handle these events. A `PaginationController` in the main component handles most of the data and logic for pagination to limit the amount of duplicate code in each component. When a `getAll()` request is called on a service, the response is only assigned to the data table if the returned response matches the most recent request. I did it this way so that in the case that a request takes longer than it does for the user to click 'Next', we are not lagging behind the users actions. 

Only the `getAll()` requests implement pagination, the other requests will have no need for them.

You will see a large chunk of css in the main.css. I went with the buefy pagination implementation, so needed to override some css in order to get it looking the right way. 

For the mocks, the calls are still made as normal, but the data is parsed on the front end to get the pagination effect. if you don't want to enter a ton of records to see the pagination in action, you can use this query to generate a bunch of locations. If you want more than 100 records, change the max number in the series generator

```
insert into program(name, species_id, created_by, updated_by)
select 'Test Program Locations', species.id, bi_user.id, bi_user.id from
species 
join bi_user on bi_user."name" = 'system'
limit 1;

insert into place(name, program_id, coordinates, created_by, updated_by)
select concat('test_location', i::text), program.id, 'null', program.created_by, program.updated_by from generate_series(1, 100) s(i)
join program on name = 'Test Program Locations'
```

## A note and question:

Our current pagination implements a 0 indexed `currentPage` property. We initially did this to match brapi. Staying with this on our backend means more logic on the front end. I wonder if we want to change our backend implementation to be 1 starting index to make it more translatable to the UI. I don't see much advantage in doing 0 index for a pagination result parameter. Anyone have thoughts on this? 

## Testing

- Play around with the pagination controls and make sure it works as you expect. 
- Open your dev tools and look at the `network` tab. Interact with the pagination controls and check that the request that is sent reflects the action you made in the pagination controls. This is necessary because our backend doesn't do pagination yet, so all results are returned regardless of the request we send. 
- Pagination controls match the design specification
- Pagination controls are not shown when there is no data in the table