### PR TITLE
[INF-138] Remove workaround for data not existing in response

### DIFF
--- a/src/breeding-insight/service/ProgramLocationService.ts
+++ b/src/breeding-insight/service/ProgramLocationService.ts
@@ -90,13 +90,11 @@ export class ProgramLocationService {
           biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
 
           let programLocations: ProgramLocation[] = [];
-      
-          // TODO: workaround for no program locations for now
-          if (biResponse.result.data) {
-            programLocations = biResponse.result.data.map((programLocation: any) => {
-              return new ProgramLocation(programLocation.id, programLocation.programId, programLocation.name);
-            });
-          }
+
+          programLocations = biResponse.result.data.map((programLocation: any) => {
+            return new ProgramLocation(programLocation.id, programLocation.programId, programLocation.name);
+          });
+
           //TODO: Remove when backend pagination is implemented
           let newPagination;
           [programLocations, newPagination] = PaginationController.mockPagination(programLocations, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);

--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -88,14 +88,12 @@ export class ProgramService {
         biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
 
         let programs: Program[] = [];
-    
-        // TODO: workaround for no programs for now
-        if (biResponse.result.data) {
-          // Parse our programs into the vue programs param
-          programs = biResponse.result.data.map((program: any) => {
-            return new Program(program.id, program.name, program.species.id);
-          });
-        }
+
+        // Parse our programs into the vue programs param
+        programs = biResponse.result.data.map((program: any) => {
+          return new Program(program.id, program.name, program.species.id);
+        });
+
         //TODO: Remove when backend pagination is implemented
         let newPagination;
         [programs, newPagination] = PaginationController.mockPagination(programs, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);

--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -104,14 +104,12 @@ export class ProgramUserService {
           //TODO: Remove when backend sorts the data by default
           biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
           let programUsers: ProgramUser[] = [];
-      
-          // TODO: workaround for no program users for now
-          if (biResponse.result.data) {
-            programUsers = biResponse.result.data.map((programUser: any) => {
-              const newProgram = new Program(programUser.program.id, programUser.program.name);
-              return new ProgramUser(programUser.user.id, programUser.user.name, programUser.user.email, programUser.roles[0].id, newProgram, programUser.active);
-            });
-          }
+
+          programUsers = biResponse.result.data.map((programUser: any) => {
+            const newProgram = new Program(programUser.program.id, programUser.program.name);
+            return new ProgramUser(programUser.user.id, programUser.user.name, programUser.user.email, programUser.roles[0].id, newProgram, programUser.active);
+          });
+
           //TODO: Remove when backend pagination is implemented
           let newPagination;
           [programUsers, newPagination] = PaginationController.mockPagination(programUsers, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);


### PR DESCRIPTION
Removes workarounds for the `data` object not being included in the response if no results were in the data response. Goes with bi-api INF-138. 