### PR TITLE
[INF-75] add ability to add existing user to program

### DIFF
--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -31,7 +31,7 @@ export class ProgramUserService {
 
     return new Promise<ProgramUser>((resolve, reject) => {
 
-      if (programUser.id === undefined && programUser.program) {
+      if (programUser.program) {
 
           ProgramUserDAO.create(programUser).then((biResponse) => {
             const result: any = biResponse.result;


### PR DESCRIPTION
Modifies the front end to be able to send add an existing user to the program. 

### Design

I modified the front end instead of the backend so that we could keep our desired behavior for the endpoints in the front end. When an acting user adds a user to a program, the front end checks if a system user with that email exists, and gets the id from that user if so. The front end then uses its existing methods to POST the user. When the response returns, we check if the id of the returned user matches the id of one of the existing users, and shows a notification indicating an existing user was added to the program. 

### How to test

- Look in the system users table and copy one of the ids there. 
- Create a few programs
- Go into each of the programs and add a user with the copied email above
- When you save, make sure the notification clearly indicates that an existing user was added to the program
- After adding the user to all of the programs, go back to the system users page and confirm that all of the user's programs are listed in that table. 