### PR TITLE
[PRO-78] manual entry of orcids

### DIFF
--- a/src/breeding-insight/model/ProgramUser.ts
+++ b/src/breeding-insight/model/ProgramUser.ts
@@ -25,6 +25,8 @@ export class ProgramUser {
   roleId?: string;
   program?: Program;
   active?: boolean;
+  //TODO: Remove when full registration flow is complete
+  orcid?: string;
 
   constructor(id?: string, name?:string, email?: string, roleId?: string, program?: Program, active?: boolean) {
     this.id = id;

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -211,7 +211,7 @@ export default class ProgramUsersTable extends Vue {
   public users: ProgramUser[] = [];
   public systemUsers: User[] = [];
   private usersPagination?: Pagination = new Pagination();
-  userTableHeaders: string[] = ['Name', 'Email', 'Orcid', 'Role'];
+  userTableHeaders: string[] = ['Name', 'Email', 'Role'];
 
   private deactivateActive: boolean = false;
   private newUserActive: boolean = false;

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -93,7 +93,8 @@
           <!--TODO: Remove when registration flow is complete -->
           <div class="column is-one-fourth">
             <BasicInputField
-                v-model="newUserOrcid"
+                v-model="newUser.orcid"
+                v-bind:validations="validations.orcid"
                 v-bind:field-name="'Orcid'"
                 v-bind:field-help="'Orcid Id to link account to.'"
             />
@@ -229,7 +230,8 @@ export default class ProgramUsersTable extends Vue {
   userValidations = {
     name: {required},
     email: {required, email},
-    roleId: {required}
+    roleId: {required},
+    orcid: {required}
   }
 
   mounted() {
@@ -287,6 +289,7 @@ export default class ProgramUsersTable extends Vue {
 
   saveUser() {
 
+    this.newUserOrcid = this.newUser.orcid!;
     this.newUser.program = this.activeProgram;
     this.newUser = this.checkExistingUserByEmailOrOrcid(this.newUser, this.newUserOrcid, this.systemUsers);
 


### PR DESCRIPTION
Adds a manual entry of the orcid to the admin users and program users endpoints. 

## Design
- Most extra orcid logic is added to the services and daos for easy removal. There is some stuff in the view pages that will have to be removed as well. 

## Behavior
- In Program Users, if the orcid (or email) matches an existing (and active) user, that existing user will be added to the program. 

## Known Limitations
- In Admin Users, if you add a valid user with a duplicate user id, there will be an error message that the user was created, by the orcid was a duplicate. The user will be created, but the id will not be assigned. You can assign this later. 
- Same goes for updating a user in admin users. 
- In Program Users, if an orcid overlaps the orcid of an inactive user, it will not add the inactive user to the program, it will show a duplicate error. A new user will be created without an orcid in this case. 
