### PR TITLE
Feature/ont 42

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -362,3 +362,7 @@ nav.tabs li.is-active {
 .is-full-length {
   height:100vh;
 }
+
+a.is-underlined {
+  text-decoration: underline;
+}

--- a/src/breeding-insight/dao/UserDAO.ts
+++ b/src/breeding-insight/dao/UserDAO.ts
@@ -105,4 +105,20 @@ export class UserDAO {
     });
   }
 
+  //TODO: Remove when registration flow is complete
+  static updateOrcid(id: string, orcid: string){
+
+    return new Promise<BiResponse>((resolve, reject) => {
+      const body = {'orcid': orcid}
+
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users/${id}/orcid`, method: 'put', data: body})
+        .then((response: any) => {
+          const biResponse = new BiResponse(response.data);
+          resolve(biResponse);
+        }).catch((error) => reject(error));
+
+    });
+
+  }
+
 }

--- a/src/breeding-insight/model/errors/FieldError.ts
+++ b/src/breeding-insight/model/errors/FieldError.ts
@@ -1,0 +1,30 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class FieldError {
+  field: string;
+  errorMessage: string;
+  httpStatus: string;
+  httpStatusCode: number;
+
+  constructor(field: string, errorMessage: string, httpStatus: string, httpStatusCode: number){
+    this.field = field;
+    this.errorMessage = errorMessage;
+    this.httpStatus = httpStatus;
+    this.httpStatusCode = httpStatusCode;
+  }
+}

--- a/src/breeding-insight/model/errors/RowError.ts
+++ b/src/breeding-insight/model/errors/RowError.ts
@@ -1,0 +1,28 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FieldError} from "@/breeding-insight/model/errors/FieldError";
+
+export class RowError {
+  rowIndex: number;
+  errors: FieldError[];
+
+  constructor(rowIndex: number, errors: FieldError[]){
+    this.rowIndex = rowIndex;
+    this.errors = errors;
+  }
+}

--- a/src/breeding-insight/model/errors/ValidationError.ts
+++ b/src/breeding-insight/model/errors/ValidationError.ts
@@ -1,0 +1,26 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {RowError} from "@/breeding-insight/model/errors/RowError";
+
+export class ValidationError {
+  rows: RowError[];
+
+  constructor(rows: RowError[]){
+    this.rows = rows;
+  }
+}

--- a/src/breeding-insight/service/TraitUploadService.ts
+++ b/src/breeding-insight/service/TraitUploadService.ts
@@ -21,8 +21,12 @@ import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {Trait} from "@/breeding-insight/model/Trait";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
+import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 
 export class TraitUploadService {
+
+  static errorContactingServer: string = "Unknown error when contacting server. Please try again.";
+  static errorUnknown: string = "Unable to determine reason for failure upload. Please check file and try again."
 
   static uploadFile(programId: string, file: File): Promise<ProgramUpload> {
 
@@ -41,7 +45,14 @@ export class TraitUploadService {
           const upload = new ProgramUpload(result.id, traits);
           resolve(upload);
 
-        }).catch((error) => reject(error));
+        }).catch((error) => {
+          if (error.response){
+            reject(this.parseError(error));
+          } else {
+            reject(this.errorContactingServer);
+          }
+
+        });
       }
       else {
         reject();
@@ -81,6 +92,26 @@ export class TraitUploadService {
         reject();
       }
     }));
+  }
+
+  static parseError(error: any): ValidationError | string {
+
+    const jsonError = error.response;
+    if (jsonError.data){
+      const rowErrors = jsonError.data.rowErrors;
+      if (rowErrors) {
+        let validationError: ValidationError = new ValidationError(rowErrors);
+        return validationError;
+      } else {
+        return jsonError;
+      }
+    } else {
+      if (jsonError.statusText){
+        return jsonError.statusText;
+      } else {
+        return this.errorUnknown;
+      }
+    }
   }
 
 }

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -122,6 +122,7 @@
               v-bind:field-name="'Email'"
             />
           </div>
+          <!--TODO: Remove when registration flow is complete -->
           <div class="column is-one-fourth">
             <BasicInputField
                 v-model="newUser.orcid"

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -107,7 +107,7 @@
     >
       <template v-slot="validations">
         <div class="columns">
-          <div class="column is-one-third">
+          <div class="column is-one-fourth">
             <BasicInputField
               v-model="newUser.name"
               v-bind:validations="validations.name"
@@ -115,14 +115,21 @@
               v-bind:field-help="'Name of user. All Unicode special characters accepted.'"
             />
           </div>
-          <div class="column is-one-third">
+          <div class="column is-one-fourth">
             <BasicInputField
               v-model="newUser.email"
               v-bind:validations="validations.email"
               v-bind:field-name="'Email'"
             />
           </div>
-          <div class="column is-one-third">
+          <div class="column is-one-fourth">
+            <BasicInputField
+                v-model="newUser.orcid"
+                v-bind:validations="validations.orcid"
+                v-bind:field-name="'Orcid'"
+            />
+          </div>
+          <div class="column is-one-fourth">
             <BasicSelectField
               v-model="newUser.roleId"
               v-bind:options="roles"
@@ -151,8 +158,12 @@
         <TableRowColumn name="name">
           {{ data.name }}
         </TableRowColumn>
-        <TableRowColumn name="species" class="is-hidden-mobile">
+        <TableRowColumn name="email" class="is-hidden-mobile">
           {{ data.email }}
+        </TableRowColumn>
+        <!--TODO: Remove when registration flow is complete -->
+        <TableRowColumn name="orcid" class="is-hidden-mobile">
+          {{ data.orcid }}
         </TableRowColumn>
         <TableRowColumn name="roles">
           <template v-if="rolesMap.size > 0">
@@ -202,6 +213,15 @@
               v-model="editData.email"
               v-bind:validations="validations.email"
               v-bind:field-name="'Email'"
+            />
+          </div>
+          <!--TODO: Remove when registration flow is complete -->
+          <div class="column is-one-half">
+            <BasicInputField
+                v-model="editData.orcid"
+                v-bind:validations="validations.orcid"
+                v-bind:field-name="'Orcid'"
+                v-bind:field-help="'Orcid to link account to.'"
             />
           </div>
           <div class="column is-one-third">
@@ -259,14 +279,15 @@ export default class AdminUsersTable extends Vue {
   userValidations = {
     name: {required},
     email: {required, email},
+    orcid: {required}
   }
 
   private paginationController: PaginationController = new PaginationController();
 
   public users: User[] = [];
   private usersPagination?: Pagination = new Pagination();
-  private userTableHeaders = ['Name', 'Email', 'Role', 'Programs'];
-  private hideMobileHeaders = ['Email'];
+  private userTableHeaders = ['Name', 'Email', 'Orcid', 'Role', 'Programs'];
+  private hideMobileHeaders = ['Email', 'Orcid'];
 
   mounted() {
     this.getRoles();
@@ -346,13 +367,14 @@ export default class AdminUsersTable extends Vue {
   addUser() {
 
     UserService.create(this.newUser).then((user: User) => {
-      this.paginationController.updatePage(1);
       this.getUsers();
+      this.paginationController.updatePage(1);
       this.newUser = new User();
       this.newUserActive = false;
       this.$emit('show-success-notification', 'User successfully created');
     }).catch((error) => {
       this.$emit('show-error-notification', error.errorMessage);
+      this.getUsers();
     });
 
   }

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -19,10 +19,52 @@
   <div class="file-select">
     <div class="box">
       <article>
+
+        <!-- Error messages -->
+        <div v-if="allErrors.length > 0" class="has-text-danger mb-6">
+
+          <!-- Multiple errors list -->
+          <template v-if="isValidationError">
+            <AlertTriangleIcon size="1x" aria-hidden="true" class="has-vertical-align-middle pb-0"></AlertTriangleIcon>
+            <span class="has-text-weight-bold ml-1 has-vertical-align-middle">File contains data errors</span>
+            <ul>
+              <template v-if="displayAllErrors">
+                <li v-for="(errorMessage, rowIndex) of allErrors" v-bind:key="rowIndex">{{errorMessage}}</li>
+              </template>
+              <template v-else>
+                <li v-for="(errorMessage, rowIndex) of allErrors.slice(0, numDisplayedErrors)" v-bind:key="rowIndex">{{errorMessage}}</li>
+              </template>
+            </ul>
+            <div v-if="allErrors.length > this.numDisplayedErrors">
+              <template v-if="displayAllErrors">
+                <a href="#" v-on:click="displayAllErrors = false" class="is-underlined">
+                  &lt; Show Less Errors
+                </a>
+              </template>
+              <template v-else>
+                <span>... and {{allErrors.length - numDisplayedErrors}} more.</span>
+                <a href="#" v-on:click="displayAllErrors = true" class="is-underlined">
+                  View All Errors &gt;
+                </a>
+              </template>
+            </div>
+          </template>
+
+          <!-- Single Error -->
+          <template v-else>
+            <AlertTriangleIcon size="1x" aria-hidden="true" class="has-vertical-align-middle pb-0"></AlertTriangleIcon>
+            <span class="has-text-weight-bold ml-1 has-vertical-align-middle">{{allErrors[0]}}</span>
+          </template>
+
+        </div>
+
+        <!-- Select file -->
         <nav class="level">
           <div class="level-left">
             <div v-if="file" class="level-item">
-              <div class="has-text-dark">
+              <div
+                v-bind:class="{'has-text-dark': allErrors.length <= 0, 'has-text-danger': allErrors.length > 0}"
+            >
                 {{file.name}}                  
               </div>
             </div>
@@ -50,16 +92,29 @@
 <script lang="ts">
   import { Component, Prop, Watch, Vue } from 'vue-property-decorator'
   import FileSelector from "@/components/file-import/FileSelector.vue";
+  import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+  import { AlertTriangleIcon } from 'vue-feather-icons';
 
   @Component({
     components: {
-      FileSelector
+      FileSelector,
+      AlertTriangleIcon
     }
   })
   export default class FileSelectMessageBox extends Vue {
 
     private fileChosen = false;
     private file : File | null = null;
+
+    private numDisplayedErrors: number = 5;
+    private displayAllErrors: boolean = false;
+
+    @Prop()
+    private errors!: ValidationError | string | null;
+
+    mounted() {
+      this.file = this.value;
+    }
 
     @Prop()
     private value!: File;
@@ -72,5 +127,26 @@
       this.$emit('input', this.file);
     }
 
+    get isValidationError(): boolean {
+      return this.errors instanceof ValidationError;
+    }
+
+    get allErrors(): string[] {
+      let errors = [];
+      if (this.isValidationError){
+        const validationErrors = this.errors as ValidationError;
+        for (const error of validationErrors.rows){
+          for (const fieldError of error.errors){
+            errors.push(`${fieldError.field}: ${fieldError.errorMessage} in row ${error.rowIndex}`);
+          }
+        }
+
+        return errors;
+      } else if (this.errors != null) {
+        return [this.errors!] as string[];
+      } else {
+        return [];
+      }
+    }
   }
 </script>

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -106,7 +106,7 @@
     private fileChosen = false;
     private file : File | null = null;
 
-    private numDisplayedErrors: number = 5;
+    private numDisplayedErrors: number = 10;
     private displayAllErrors: boolean = false;
 
     @Prop()

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -43,7 +43,7 @@
               </template>
               <template v-else>
                 <span>... and {{allErrors.length - numDisplayedErrors}} more.</span>
-                <a href="#" v-on:click="displayAllErrors = true" class="is-underlined">
+                <a href="#" v-on:click="displayAllErrors = true" class="is-underlined ml-3">
                   View All Errors &gt;
                 </a>
               </template>

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -74,7 +74,7 @@
     >
       <template v-slot="validations">
         <div class="columns">
-          <div class="column is-two-fifths">
+          <div class="column is-one-fourth">
             <BasicInputField
               v-model="newUser.name"
               v-bind:validations="validations.name"
@@ -82,7 +82,7 @@
               v-bind:field-help="'Full name as preferred. All Unicode special characters accepted.'"
             />
           </div>
-          <div class="column is-two-fifths">
+          <div class="column is-one-fourth">
             <BasicInputField
               v-model="newUser.email"
               v-bind:validations="validations.email"
@@ -90,7 +90,14 @@
               v-bind:field-help="'New users will receive an email at this address to activate their account.'"
             />
           </div>
-          <div class="column is-one-fifth">
+          <div class="column is-one-fourth">
+            <BasicInputField
+                v-model="newUserOrcid"
+                v-bind:field-name="'Orcid'"
+                v-bind:field-help="'Orcid Id to link account to.'"
+            />
+          </div>
+          <div class="column is-one-fourth">
             <BasicSelectField
               v-model="newUser.roleId"
               v-bind:validations="validations.roleId"
@@ -203,12 +210,13 @@ export default class ProgramUsersTable extends Vue {
   public users: ProgramUser[] = [];
   public systemUsers: User[] = [];
   private usersPagination?: Pagination = new Pagination();
-  userTableHeaders: string[] = ['Name', 'Email', 'Role'];
+  userTableHeaders: string[] = ['Name', 'Email', 'Orcid', 'Role'];
 
   private deactivateActive: boolean = false;
   private newUserActive: boolean = false;
   private deactivateWarningTitle: string = "Remove user's access to Program name?";
   private newUser = new ProgramUser();
+  private newUserOrcid = "";
   private roles: Array<Role> = [];
 
   private deleteUser?: ProgramUser;
@@ -279,11 +287,12 @@ export default class ProgramUsersTable extends Vue {
   saveUser() {
 
     this.newUser.program = this.activeProgram;
-    this.newUser = this.checkExistingUserByEmail(this.newUser, this.systemUsers);
+    this.newUser = this.checkExistingUserByEmailOrOrcid(this.newUser, this.newUserOrcid, this.systemUsers);
 
-    ProgramUserService.create(this.newUser).then((user: ProgramUser) => {
+    ProgramUserService.create(this.newUser, this.newUserOrcid).then((user: ProgramUser) => {
       this.paginationController.updatePage(1);
       this.getUsers();
+      this.getSystemUsers();
 
       // See if the user already existed
       //TODO: Reconsider when user search feature is added
@@ -295,9 +304,12 @@ export default class ProgramUsersTable extends Vue {
 
       this.getSystemUsers();
       this.newUser = new ProgramUser();
+      this.newUserOrcid = "";
       this.newUserActive = false;
     }).catch((error) => {
       this.$emit('show-error-notification', error.errorMessage);
+      this.getUsers();
+      this.getSystemUsers();
     })
 
   }
@@ -316,9 +328,10 @@ export default class ProgramUsersTable extends Vue {
   }
 
   //TODO: Reconsider when user search feature is added
-  checkExistingUserByEmail(user: ProgramUser, systemUsers: User[]): ProgramUser {
+  checkExistingUserByEmailOrOrcid(user: ProgramUser, userOrcid: string, systemUsers: User[]): ProgramUser {
+    user.id = undefined;
     for (const systemUser of systemUsers){
-      if (user.email === systemUser.email){
+      if (user.email === systemUser.email || userOrcid === systemUser.orcid){
         if (systemUser.id){
           user.id = systemUser.id;
         }
@@ -339,6 +352,7 @@ export default class ProgramUsersTable extends Vue {
 
   cancelNewUser() {
     this.newUser = new ProgramUser();
+    this.newUserOrcid = "";
     this.newUserActive = false;
   }
 

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -90,6 +90,7 @@
               v-bind:field-help="'New users will receive an email at this address to activate their account.'"
             />
           </div>
+          <!--TODO: Remove when registration flow is complete -->
           <div class="column is-one-fourth">
             <BasicInputField
                 v-model="newUserOrcid"

--- a/src/views/TraitsImport.vue
+++ b/src/views/TraitsImport.vue
@@ -69,6 +69,14 @@
       <traits-import-table v-on:loaded="importService.send(ImportEvent.TABLE_LOADED)"/>
     </template>
 
+    <template v-if="state === ImportState.IMPORT_ERROR">
+        <h1 class="title">Importing...</h1>
+        <file-select-message-box v-model="file"
+                                 v-bind:fileTypes="'.csv, .xls, .xlsx'"
+                                 v-bind:errors="import_errors"
+                                 v-on:import="importService.send(ImportEvent.IMPORT_STARTED)"/>
+    </template>
+
   </div>
 </template>
 
@@ -84,18 +92,19 @@
   import FileSelectMessageBox from "@/components/file-import/FileSelectMessageBox.vue"
   import WarningModal from '@/components/modals/WarningModal.vue'
 
-  import {ProgramUpload} from '@/breeding-insight/model/ProgramUpload'
   import {Program} from '@/breeding-insight/model/Program'
   import {TraitUploadService} from "@/breeding-insight/service/TraitUploadService";
 
   import { createMachine, interpret } from '@xstate/fsm';
+  import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 
   enum ImportState {
     CHOOSE_FILE = "CHOOSE_FILE",
     FILE_CHOSEN = "FILE_CHOSEN",
     IMPORTING = "IMPORTING",
     LOADING = "LOADING",
-    CURATE = "CURATE"
+    CURATE = "CURATE",
+    IMPORT_ERROR = "IMPORT_ERROR"
   }
 
   enum ImportEvent {
@@ -136,6 +145,7 @@
   export default class TraitsImport extends ProgramsBase {
 
     private file : File | null = null;
+    private import_errors: ValidationError | string | null = null;
     private activeProgram?: Program;
     private tableLoaded = false;
     private numTraits = 0;
@@ -169,7 +179,7 @@
               actions: ImportAction.ABORT
             },
             [ImportEvent.IMPORT_SUCCESS]: ImportState.LOADING,
-            [ImportEvent.IMPORT_ERROR]: ImportState.CHOOSE_FILE,
+            [ImportEvent.IMPORT_ERROR]: ImportState.IMPORT_ERROR,
           }
         },
         [ImportState.LOADING]: {
@@ -190,6 +200,11 @@
               target: ImportState.CHOOSE_FILE,
               actions: ImportAction.DELETE
             },
+          }
+        },
+        [ImportState.IMPORT_ERROR]: {
+          on: {
+            [ImportEvent.IMPORT_STARTED]: ImportState.IMPORTING
           }
         }
       }
@@ -239,9 +254,8 @@
       TraitUploadService.uploadFile(this.activeProgram!.id!, this.file!).then((response) => {
         this.numTraits = response.data!.length;
         this.importService.send(ImportEvent.IMPORT_SUCCESS);
-      }).catch((error) => {
-        // proper error handling is not part of ONT-21
-        this.$emit('show-error-notification', error.response.statusText);
+      }).catch((error: ValidationError | string) => {
+        this.import_errors = error;
         this.importService.send(ImportEvent.IMPORT_ERROR);
       });
     }

--- a/src/views/TraitsImport.vue
+++ b/src/views/TraitsImport.vue
@@ -71,6 +71,7 @@
 
     <template v-if="state === ImportState.IMPORT_ERROR">
         <h1 class="title">Importing...</h1>
+      <trait-import-template-message-box class="mb-5"/>
         <file-select-message-box v-model="file"
                                  v-bind:fileTypes="'.csv, .xls, .xlsx'"
                                  v-bind:errors="import_errors"


### PR DESCRIPTION
Implements error states for the trait upload. Follows the design reference created by Liz in ONT-79. Added the template in there after talking to Liz so that the user would have access to it during an error state. 

## Note

Is based onto PRO-78 so there will be extra changes included in this until that is merged. If doing a code review, review PRO-78 first. 

## Dependencies

Should be used with ONT-68 for multiple error returns. 

## Details

- If the error is a single error return, it displays next to the caution sign like the original design reference. If it is a multiple error return it will display in list fashion like the new design reference, even if there is only one error in the multiple error return. 
- I removed the notification popups on the top bar. 

## Testing

- I have been using the test files from bi-api to test this. These are nice because you can test specific errors to see how they behave. You can find those tests at, `bi-api/src/test/resources/files`.
- If you have other error files it would be good to try and break it!


## How it should look

![screencapture-localhost-8080-programs-c17e3206-fb91-47b8-90d9-f8c2f61bc756-traits-import-2020-08-07-09_09_58](https://user-images.githubusercontent.com/17887341/89649390-ac8b7e00-d88e-11ea-9bc7-dd8a5bcc7c1a.png)

![screencapture-localhost-8080-programs-c17e3206-fb91-47b8-90d9-f8c2f61bc756-traits-import-2020-08-07-09_08_54](https://user-images.githubusercontent.com/17887341/89649396-af866e80-d88e-11ea-9ed0-17417b1e3ef2.png)

![screencapture-localhost-8080-programs-c17e3206-fb91-47b8-90d9-f8c2f61bc756-traits-import-2020-08-07-09_14_53](https://user-images.githubusercontent.com/17887341/89649382-a8f7f700-d88e-11ea-962c-0f9ba087004c.png)


