### PR TITLE
[ISSUE-4] update multiple calls error handling to better report partial success

### DIFF
--- a/src/breeding-insight/service/PromiseHandler.ts
+++ b/src/breeding-insight/service/PromiseHandler.ts
@@ -20,7 +20,7 @@ import {PromiseResultTuple} from "promise.allsettled/types";
 
 export class PromiseHandler {
   promises: Promise<any>[] = [];
-  static fulfilled: String = 'fulfilled';
+  static FULFILLED: String = 'fulfilled';
 
   constructor(promises: Promise<any>[]) {
     this.promises = promises;
@@ -35,7 +35,7 @@ export class PromiseHandler {
     return new Promise<any>((resolve, reject) => {
       Promise.allSettled(this.promises).then( (results: PromiseResult<any, any>[]) => {
         const successResults: PromiseResolution<any>[] = results as PromiseResolution<any>[];
-        if (successResults.every((result: PromiseResolution<any>) => result.status === 'fulfilled')) {
+        if (successResults.every((result: PromiseResolution<any>) => result.status === PromiseHandler.FULFILLED)) {
           resolve(successResults.map((result: PromiseResolution<any>) => result.value));
         } else {
           reject(results);

--- a/src/breeding-insight/service/PromiseHandler.ts
+++ b/src/breeding-insight/service/PromiseHandler.ts
@@ -20,6 +20,7 @@ import {PromiseResultTuple} from "promise.allsettled/types";
 
 export class PromiseHandler {
   promises: Promise<any>[] = [];
+  static fulfilled: String = 'fulfilled';
 
   constructor(promises: Promise<any>[]) {
     this.promises = promises;
@@ -37,10 +38,7 @@ export class PromiseHandler {
         if (successResults.every((result: PromiseResolution<any>) => result.status === 'fulfilled')) {
           resolve(successResults.map((result: PromiseResolution<any>) => result.value));
         } else {
-          const rejectionResults: PromiseRejection<any>[] = results as PromiseRejection<any>[];
-          const failedResults = rejectionResults.filter((result: PromiseRejection<any>) => result.reason !== undefined)
-            .map((failedResult: PromiseRejection<any>) => failedResult.reason);
-          reject(failedResults);
+          reject(results);
         }
       })
     });

--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -33,7 +33,7 @@ export class UserService {
   static errorGetUsers: string = 'Error while trying to load roles';
   static errorDeleteUserNotFound: string = 'Unable to find user to deactivate';
   static errorDeleteUserNotAllowed: string = 'You are not allowed to deactivate this user.';
-  static errorPermissionsEditUser: string = "You don't have permissions to edit this user.";
+  static errorPermissionsEditUser: string = "You don't have permissions to edit the roles of this user.";
   static errorUpdatingOrcidOnPost: string = "User created, but could not assign orcid";
   static errorUpdatingOrcidOnPut: string = "User updated, but could not update orcid";
   static errorUpdatingOrcidOnPostDuplicate: string = "User created, but could not assign orcid. Orcid Id already in use.";

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -389,16 +389,16 @@ export default class AdminUsersTable extends Vue {
         this.$emit('show-success-notification', 'User successfully updated');
       }).catch((errors: any[]) => {
         // Show success if one of them succeeded
-        if (errors[0].status === PromiseHandler.fulfilled){
+        if (errors[0].status === PromiseHandler.FULFILLED){
           this.$emit('show-success-notification', 'User roles successfully updated');
         }
-        if (errors[1].status === PromiseHandler.fulfilled){
+        if (errors[1].status === PromiseHandler.FULFILLED){
           this.$emit('show-success-notification', 'User info (name/email/ORCID/program) successfully updated');
         }
 
         // Shows any that are errors
         for (const error of errors) {
-          if (error.status !== PromiseHandler.fulfilled){
+          if (error.status !== PromiseHandler.FULFILLED){
             //TODO: This is where multiple error messages could be handy
             this.$emit('show-error-notification', error.reason.errorMessage);
           }

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -393,7 +393,7 @@ export default class AdminUsersTable extends Vue {
           this.$emit('show-success-notification', 'User roles successfully updated');
         }
         if (errors[1].status === PromiseHandler.fulfilled){
-          this.$emit('show-success-notification', 'User info successfully updated');
+          this.$emit('show-success-notification', 'User info (name/email/ORCID/program) successfully updated');
         }
 
         // Shows any that are errors

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -383,14 +383,25 @@ export default class AdminUsersTable extends Vue {
     const updateUserPromise = UserService.update(user);
     const updateRolesPromise = UserService.updateSystemRoles(user);
 
-    const promiseHandler = new PromiseHandler([updateUserPromise, updateRolesPromise]);
+    const promiseHandler = new PromiseHandler([updateRolesPromise, updateUserPromise]);
     promiseHandler.resolvePromises()
       .then((result:User[]) => {
         this.$emit('show-success-notification', 'User successfully updated');
       }).catch((errors: any[]) => {
+        // Show success if one of them succeeded
+        if (errors[0].status === PromiseHandler.fulfilled){
+          this.$emit('show-success-notification', 'User roles successfully updated');
+        }
+        if (errors[1].status === PromiseHandler.fulfilled){
+          this.$emit('show-success-notification', 'User info successfully updated');
+        }
+
+        // Shows any that are errors
         for (const error of errors) {
-          //TODO: This is where multiple error messages could be handy
-          this.$emit('show-error-notification', error.errorMessage);
+          if (error.status !== PromiseHandler.fulfilled){
+            //TODO: This is where multiple error messages could be handy
+            this.$emit('show-error-notification', error.reason.errorMessage);
+          }
         }
       }).finally(() => {
         this.getUsers();


### PR DESCRIPTION
There are two updates that are being made when you edit the user:

1. Update user info
2. Update user roles

From the card, when you try to edit your user in the admin users table, it shows an error, but updates the name successfully. It shows as an error because in #2 a user can't edit their own roles. I edited the error reporting to show a success for the update of the user, and a failure for the role update. If there is more than one error (both user info, and user roles calls fail), the user info error will be shown. We can show both once we implement the feature for multiple notifications of the same type. 

![screencapture-localhost-8080-admin-user-management-2020-08-17-12_27_56](https://user-images.githubusercontent.com/17887341/90432375-6efdd080-e098-11ea-9a86-fb41d7568b32.png)
