### PR TITLE
[ISSUE-8],[BI-540] Fix orcid overwrite when adding new program user for existing system user

### DIFF
--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -28,8 +28,8 @@ export class ProgramUserService {
 
   static errorEmailInUse: String = "Error creating user, a user with this email already exists";
   static errorCreatingUser: String = "Error while creating user";
-  static errorAssignedUserToProgramErrorOrcid = "Successfully assigned user to program, error assigning orcid to user.";
-  static errorOrcidRequired = "Orcid required when creating a new user to add to the program";
+  static errorAssignedUserToProgramErrorOrcid = "Successfully assigned user to program, error assigning ORCID iD to user.";
+  static errorOrcidRequired = "ORCID iD required when creating a new user to add to the program";
 
   static create(programUser: ProgramUser, orcid: string | undefined): Promise<ProgramUser> {
 

--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -34,10 +34,10 @@ export class UserService {
   static errorDeleteUserNotFound: string = 'Unable to find user to deactivate';
   static errorDeleteUserNotAllowed: string = 'You are not allowed to deactivate this user.';
   static errorPermissionsEditUser: string = "You don't have permissions to edit the roles of this user.";
-  static errorUpdatingOrcidOnPost: string = "User created, but could not assign orcid";
-  static errorUpdatingOrcidOnPut: string = "User updated, but could not update orcid";
-  static errorUpdatingOrcidOnPostDuplicate: string = "User created, but could not assign orcid. Orcid Id already in use.";
-  static errorUpdatingOrcidOnPutDuplicate: string = "User updated, but could not update orcid. Orcid Id already in use.";
+  static errorUpdatingOrcidOnPost: string = "User created, but could not assign ORCID iD";
+  static errorUpdatingOrcidOnPut: string = "User updated, but could not update ORCID iD";
+  static errorUpdatingOrcidOnPostDuplicate: string = "User created, but could not assign ORCID iD. ORCID iD Id already in use.";
+  static errorUpdatingOrcidOnPutDuplicate: string = "User updated, but could not update ORCID iD. ORCID iD Id already in use.";
 
   static getUserInfo(): Promise<User> {
 

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -127,7 +127,7 @@
             <BasicInputField
                 v-model="newUser.orcid"
                 v-bind:validations="validations.orcid"
-                v-bind:field-name="'Orcid'"
+                v-bind:field-name="'ORCID iD'"
             />
           </div>
           <div class="column is-one-fourth">
@@ -162,7 +162,7 @@
           {{ data.email }}
         </TableColumn>
         <!--TODO: Remove when registration flow is complete -->
-        <TableColumn name="orcid" v-bind:label="'Orcid'" v-bind:visible="!isMobile">
+        <TableColumn name="orcid" v-bind:label="'ORCID iD'" v-bind:visible="!isMobile">
           {{ data.orcid }}
         </TableColumn>
         <TableColumn name="roles" v-bind:label="'Role'">
@@ -220,8 +220,8 @@
             <BasicInputField
                 v-model="editData.orcid"
                 v-bind:validations="validations.orcid"
-                v-bind:field-name="'Orcid'"
-                v-bind:field-help="'Orcid to link account to.'"
+                v-bind:field-name="'ORCID iD'"
+                v-bind:field-help="'ORCID iD to link account to.'"
             />
           </div>
           <div class="column is-one-third">

--- a/src/components/forms/BasicInputField.vue
+++ b/src/components/forms/BasicInputField.vue
@@ -22,7 +22,7 @@
     v-bind:field-name="fieldName"
   >
     <input
-        v-bind:id="fieldName"
+        v-bind:id="fieldName.replace(' ', '-')"
         :value="value"
         @input="$emit('input', $event.target.value)"
         class="input"

--- a/src/components/forms/BasicSelectField.vue
+++ b/src/components/forms/BasicSelectField.vue
@@ -23,7 +23,7 @@
   >
     <div class="select is-fullwidth">
       <select
-          v-bind:id="fieldName"
+          v-bind:id="fieldName.replace(' ', '-')"
           v-on:input="$emit('input', $event.target.value)"
           class="select is-fullwidth"
       >

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -96,8 +96,8 @@
             <BasicInputField
                 v-model="newUser.orcid"
                 v-bind:validations="validations.orcid"
-                v-bind:field-name="'Orcid'"
-                v-bind:field-help="'Orcid Id to link account to.'"
+                v-bind:field-name="'ORCID iD'"
+                v-bind:field-help="'ORCID iD to link account to.'"
             />
           </div>
           <div class="column is-one-fourth">
@@ -354,7 +354,7 @@ export default class ProgramUsersTable extends Vue {
     }
 
     if (usersFound > 1){
-      throw "Email and Orcid match two different users.";
+      throw "Email and ORCID iD match two different users.";
     }
 
     return user;

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -52,6 +52,7 @@
       v-show="!newUserActive & users.length > 0"
       class="button is-primary has-text-weight-bold is-pulled-right"
       v-on:click="newUserActive = true"
+      data-testid="newUserBtn"
     >
       <span class="icon is-small">
         <PlusCircleIcon

--- a/tests/unit/components/program/ProgramUsersTable.spec.ts
+++ b/tests/unit/components/program/ProgramUsersTable.spec.ts
@@ -116,7 +116,7 @@ describe('New Program User action works properly', () => {
         expect(nameInput.exists()).toBeTruthy();
         let emailInput = newUserForm.find('input#Email');
         expect(emailInput.exists()).toBeTruthy();
-        let orcidInput = newUserForm.find('input#Orcid');
+        let orcidInput = newUserForm.find('input#ORCID-iD');
         expect(orcidInput.exists()).toBeTruthy();
         let roleInput = newUserForm.find('select#Role');
         expect(roleInput.exists()).toBeTruthy();
@@ -135,12 +135,12 @@ describe('New Program User action works properly', () => {
         expect(error!.length).toEqual(1);
         let notification = error!.pop();
         expect(notification.length).toEqual(1);
-        expect(notification.pop()).toEqual('Email and Orcid match two different users.')
+        expect(notification.pop()).toEqual('Email and ORCID iD match two different users.')
     });
 
     it('does not overwrite orcid when email matches existing system user', async () => {
         let newUserForm = wrapper.findComponent(NewDataForm);
-        let orcidInput = newUserForm.find('input#Orcid');
+        let orcidInput = newUserForm.find('input#ORCID-iD');
         await orcidInput.setValue('111');
 
         let saveBtn = newUserForm.find('button[data-testid="save"]');
@@ -159,7 +159,7 @@ describe('New Program User action works properly', () => {
         let newUserForm = wrapper.findComponent(NewDataForm);
         let nameInput = newUserForm.find('input#Name');
         let emailInput = newUserForm.find('input#Email');
-        let orcidInput = newUserForm.find('input#Orcid');
+        let orcidInput = newUserForm.find('input#ORCID-iD');
         let roleInput = newUserForm.find('select#Role');
 
         await roleInput.find('option:last-child').setSelected();

--- a/tests/unit/components/program/ProgramUsersTable.spec.ts
+++ b/tests/unit/components/program/ProgramUsersTable.spec.ts
@@ -10,6 +10,8 @@ import {ProgramUserDAO} from "@/breeding-insight/dao/ProgramUserDAO";
 import {RoleDAO} from "@/breeding-insight/dao/RoleDAO";
 import {UserDAO} from "@/breeding-insight/dao/UserDAO";
 import ExpandableRowTable from "@/components/tables/ExpandableRowTable.vue";
+import NewDataForm from "@/components/forms/NewDataForm.vue";
+import BasicSelectField from "@/components/forms/BasicSelectField.vue";
 
 jest.mock('@/breeding-insight/dao/ProgramUserDAO');
 jest.mock('@/breeding-insight/dao/RoleDAO');
@@ -38,7 +40,17 @@ function setup() {
     const systemUser = {'id':'1', 'name':'Test user', 'email':'testuser@test.com', 'active':'true',
                         'systemRoles': [{'id':'1', 'domain':'admin'}],
                         'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]};
-    systemUsers.push(systemUser);
+    const systemUser1 = {
+        'id':'2', 'name':'Test user 2', 'email':'testuser1@test.com', 'active':'true', 'orcid': '123',
+        'systemRoles': [{'id':'1', 'domain':'admin'}],
+        'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]
+    };
+    const systemUser2 = {
+        'id':'2', 'name':'Test user 2', 'email':'testuse2@test.com', 'active':'true', 'orcid': '456',
+        'systemRoles': [{'id':'1', 'domain':'admin'}],
+        'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]
+    }
+    systemUsers.push(systemUser, systemUser1, systemUser2);
     const systemUsersResponse = DaoUtils.formatBiResponse(systemUsers);
 
     const userDAO = mocked(UserDAO, true);
@@ -84,3 +96,43 @@ describe('Edit data form works properly', () => {
     });
 
 });
+
+describe('New Program User action works properly', () => {
+    const store = defaultStore;
+    const wrapper = mount(ProgramUsersTable, {localVue, store});
+
+    it('throws error when email and orcid reference different system users', async ()=> {
+        let newUserBtn = wrapper.find('button[data-testid="newUserBtn"]');
+        expect(newUserBtn.exists()).toBeTruthy();
+        await newUserBtn.trigger('click');
+        let newUserForm = wrapper.findComponent(NewDataForm);
+        let nameInput = newUserForm.find('input#Name');
+        expect(nameInput.exists()).toBeTruthy();
+        let emailInput = newUserForm.find('input#Email');
+        expect(emailInput.exists()).toBeTruthy();
+        let orcidInput = newUserForm.find('input#Orcid');
+        expect(orcidInput.exists()).toBeTruthy();
+        let roleInput = newUserForm.find('select#Role');
+        expect(roleInput.exists()).toBeTruthy();
+        await roleInput.find('option:last-child').setSelected();
+        await roleInput.trigger('input');
+        await nameInput.setValue('test');
+        await emailInput.setValue(systemUsers[1].email);
+        await orcidInput.setValue(systemUsers[2].orcid);
+
+        let saveBtn = newUserForm.find('button[data-testid="save"]');
+        await saveBtn.trigger('click');
+        await wrapper.vm.$nextTick();
+
+        let error = wrapper.emitted('show-error-notification');
+        console.log(error);
+        expect(error!.length).toEqual(1);
+        let notification = error!.pop();
+        expect(notification.length).toEqual(1);
+        expect(notification.pop()).toEqual('Email and Orcid match two different users.')
+    });
+
+    it('does not overwrite orcid when email matches existing system user', () => {
+        //TODO: Spy on createUser service method
+    });
+})

--- a/tests/unit/test-utils/DaoUtils.ts
+++ b/tests/unit/test-utils/DaoUtils.ts
@@ -37,4 +37,21 @@ export default class DaoUtils {
       }
     });
   }
+
+  static formatBiResponseSingle(data: any): BiResponse {
+    const metadata: Metadata = new Metadata({
+      pagination: {
+        totalPages: 1,
+        currentPage: 1,
+        totalCount: 1,
+        pageSize: 1
+      },
+      status: []
+    });
+
+    return new BiResponse({
+      metadata,
+      result: data
+    });
+  }
 }


### PR DESCRIPTION
Based off bug/PRO-80, so review and approve that one first. 

This bug fix fixes a bug where you can update the orcid when creating a program user for a system user that already exists. Previously, if there was an email match, the orcid would be updated for the existing user. Bug fix makes it so the update orcid action is not made when there is an email match. 

Also adds a not documented bug where if the email and orcid you enter reference two different users, it would arbitrarily choose one. I made it so it throws an error if this condition is met. 

![screencapture-localhost-8080-programs-6d7a6ab8-4b25-4cc1-b572-4531efd0533b-program-management-users-2020-09-10-09_27_07](https://user-images.githubusercontent.com/17887341/92736192-10024300-f348-11ea-97d7-95ac853a3610.png)
![screencapture-localhost-8080-programs-6d7a6ab8-4b25-4cc1-b572-4531efd0533b-program-management-users-2020-09-10-09_27_37](https://user-images.githubusercontent.com/17887341/92736208-12fd3380-f348-11ea-980e-3f89ebfeb633.png)
![screencapture-localhost-8080-programs-6d7a6ab8-4b25-4cc1-b572-4531efd0533b-program-management-users-2020-09-10-09_28_18](https://user-images.githubusercontent.com/17887341/92736218-14c6f700-f348-11ea-8885-34bbe3d21da6.png)
