### PR TITLE
[BI-72] - Error adding new user with already existing orcid, form stays open

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,7 @@
       <SuccessNotification ref="successNotification" class="is-marginless"></SuccessNotification>
       <ErrorNotification ref="errorNotification" class="is-marginless"></ErrorNotification>
       <InfoNotification ref="infoNotification" class="is-marginless"></InfoNotification>
+      <WarningNotification ref="warningNotification" class="is-marginless"></WarningNotification>
     </div>
     
     <component v-bind:is="layout" v-bind:username="username" @logout="logOut">
@@ -28,6 +29,7 @@
             @show-success-notification="showSuccessNotification"
             @show-info-notification="showInfoNotification"
             @show-error-notification="showErrorNotification"
+            @show-warning-notification="showWarningNotification"
         />
     </component>
 
@@ -96,6 +98,7 @@ import ErrorNotification from '@/components/notifications/ErrorNotification.vue'
 import SimpleLayout from '@/components/layouts/SimpleLayout.vue'
 import UserSideBarLayout from './components/layouts/UserSideBarLayout.vue'
 import NoSideBarLayout from './components/layouts/NoSideBarLayout.vue'
+import WarningNotification from "@/components/notifications/WarningNotification.vue";
 
 @Component({
   watch: {
@@ -121,6 +124,7 @@ import NoSideBarLayout from './components/layouts/NoSideBarLayout.vue'
     }
   },
   components: {
+    WarningNotification,
     SuccessNotification,
     InfoNotification,
     ErrorNotification,
@@ -137,6 +141,7 @@ export default class App extends Vue {
     successNotification: SuccessNotification,
     infoNotification: InfoNotification, 
     errorNotification: ErrorNotification
+    warningNotification: WarningNotification
   };
 
   get loggedIn () {
@@ -168,6 +173,11 @@ export default class App extends Vue {
   showErrorNotification(msg: string) {
     this.$refs.errorNotification.active = true;
     this.$refs.errorNotification.msg = msg;
+  }
+
+  showWarningNotification(msg: string) {
+    this.$refs.warningNotification.active = true;
+    this.$refs.warningNotification.msg = msg;
   }
 }
 </script>

--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -34,10 +34,10 @@ export class UserService {
   static errorDeleteUserNotFound: string = 'Unable to find user to deactivate';
   static errorDeleteUserNotAllowed: string = 'You are not allowed to deactivate this user.';
   static errorPermissionsEditUser: string = "You don't have permissions to edit the roles of this user.";
-  static errorUpdatingOrcidOnPost: string = "User created, but could not assign ORCID iD";
+  static errorUpdatingOrcid: string = "Error assigning ORCID iD to user.";
+  static errorUpdatingOrcidDuplicate: string = "ORCID iD already in use by another user.";
+  static errorUpdatingOrcidOnPutDuplicate: string = "User updated, but could not update ORCID iD. ORCID iD already in use.";
   static errorUpdatingOrcidOnPut: string = "User updated, but could not update ORCID iD";
-  static errorUpdatingOrcidOnPostDuplicate: string = "User created, but could not assign ORCID iD. ORCID iD Id already in use.";
-  static errorUpdatingOrcidOnPutDuplicate: string = "User updated, but could not update ORCID iD. ORCID iD Id already in use.";
 
   static getUserInfo(): Promise<User> {
 
@@ -64,21 +64,7 @@ export class UserService {
           const result: any = biResponse.result;
           const role: Role | undefined = this.parseSystemRoles(result.systemRoles);
           let newUser = new User(result.id, result.name, result.orcid, result.email, role);
-
-          //TODO: Remove this when registration flow is complete
-          let copyUser: User = new User(newUser.id, user.name, user.orcid, user.email);
-          this.updateOrcid(copyUser).then((updatedUser) => {
-            newUser.orcid = updatedUser.orcid;
-            resolve(newUser);
-          }).catch((error) => {
-            if (error.response && error.response.status === 409) {
-              error['errorMessage'] = this.errorUpdatingOrcidOnPostDuplicate;
-            } else {
-              error['errorMessage'] = this.errorUpdatingOrcidOnPost;
-            }
-            reject(error);
-          })
-
+          resolve(newUser);
         }).catch((error) => {
           if (error.response && error.response.status === 409) {
             Vue.$log.info('Email already exists');
@@ -223,16 +209,21 @@ export class UserService {
     });
   }
 
+  //TODO: Remove when registration flow is complete
   static updateOrcid(user: User) {
 
     return new Promise<User>((resolve, reject) => {
-      //TODO: Remove when registration flow is complete
-      if (user.id){
+      if (user.id && user.orcid){
         UserDAO.updateOrcid(user.id, user.orcid!).then((biResponse) => {
           const result: any = biResponse.result;
           user.orcid = result.orcid;
           resolve(user);
         }).catch((error) => {
+          if (error.response && error.response.status === 409) {
+            error['errorMessage'] = this.errorUpdatingOrcidDuplicate;
+          } else {
+            error['errorMessage'] = this.errorUpdatingOrcid;
+          }
           Vue.$log.fatal(error);
           reject(error);
         })

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -386,7 +386,6 @@ export default class AdminUsersTable extends Vue {
       user = await UserService.create(this.newUser);
       this.paginationController.updatePage(1);
       this.newUserActive = false;
-      this.$emit('show-success-notification', 'User sucessfully created');
     } catch (error) {
       this.$emit('show-error-notification', error.errorMessage);
       return;
@@ -396,8 +395,9 @@ export default class AdminUsersTable extends Vue {
     try {
       user.orcid = this.newUser.orcid;
       await UserService.updateOrcid(user!);
+      this.$emit('show-success-notification', 'User successfully created');
     } catch (error) {
-      this.$emit('show-error-notification', error.errorMessage);
+      this.$emit('show-warning-notification', 'User created, but could not assign ORCID iD. ORCID iD already in use');
     }
 
     this.newUser = new User();

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -252,12 +252,10 @@
   import BasicInputField from "@/components/forms/BasicInputField.vue";
   import {UserService} from "@/breeding-insight/service/UserService";
   import NewDataForm from "@/components/forms/NewDataForm.vue";
-  import {RoleService} from "@/breeding-insight/service/RoleService";
   import {Role} from "@/breeding-insight/model/Role";
   import {SystemRoleService} from "@/breeding-insight/service/SystemRoleService";
   import BasicSelectField from "@/components/forms/BasicSelectField.vue";
   import {PromiseHandler} from "@/breeding-insight/service/PromiseHandler";
-  import {PromiseResult} from "promise.allsettled/types";
   import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
   import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
   import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
@@ -374,7 +372,7 @@ export default class AdminUsersTable extends Vue {
       [allUsers] = await UserService.getAll();
       const matchingUsers: User[] = allUsers.filter(user => user.orcid === this.newUser.orcid);
       if (matchingUsers.length > 0){
-        this.$emit('show-error-notification', 'Orcid is in use by another user.');
+        this.$emit('show-error-notification', 'ORCID iD is in use by another user.');
         return;
       }
     } catch (error) {

--- a/src/components/notifications/WarningNotification.vue
+++ b/src/components/notifications/WarningNotification.vue
@@ -16,41 +16,31 @@
   -->
 
 <template>
-  <div class="admin-user-management">
-    <h1 class="title">
-      Users
-    </h1>
-    <AdminUsersTable
-        v-on="$listeners"
-    >
-    </AdminUsersTable>
-  </div>
+  <b-notification type="is-warning" v-bind:active.sync="active" aria-close-label="Close Notification"
+                  role="alert">
+    <div class="level">
+      <div class="level-left">
+        <div class="level-item">
+          <AlertTriangleIcon size="1.5x"></AlertTriangleIcon>
+        </div>
+        <div class="level-item">
+          {{msg}}
+        </div>
+      </div>
+    </div>
+  </b-notification>
 </template>
 
 <script lang="ts">
-  import { Component, Prop, Vue } from 'vue-property-decorator'
-  import AdminUsersTable from '@/components/admin/AdminUsersTable.vue'
+  import { Component, Vue } from 'vue-property-decorator';
+  import { AlertTriangleIcon } from 'vue-feather-icons'
 
   @Component({
-    components: {AdminUsersTable}
+    components: {AlertTriangleIcon}
   })
-  export default class AdminUserManagement extends Vue {
-
-    // get this when endpoint is implemented
-    private programName: string = "Program Name";
-
-    mounted() {
-
-    }
-
-    showSuccessNotification(msg: string) {
-      this.$emit('show-success-notification', msg);
-    }
-
-    showErrorNotification(msg: string) {
-      this.$emit('show-error-notification', msg);
-    }
-
-
+  export default class WarningNotification extends Vue {
+    public active: boolean = false;
+    public msg : string = '';
   }
+
 </script>

--- a/tests/unit/components/admin/AdminUsersTable.spec.ts
+++ b/tests/unit/components/admin/AdminUsersTable.spec.ts
@@ -7,6 +7,7 @@ import {mount} from "@vue/test-utils";
 import AdminUsersTable from "@/components/admin/AdminUsersTable.vue";
 import NewDataForm from "@/components/forms/NewDataForm.vue";
 import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
+import BasicInputField from "@/components/forms/BasicInputField.vue";
 import ExpandableTableRow from "@/components/tables/ExpandableTableRow.vue";
 import EditDataRowForm from "@/components/forms/EditDataRowForm.vue";
 import {UserService} from "@/breeding-insight/service/UserService";
@@ -57,33 +58,33 @@ describe('validations work properly', () => {
     await saveBtn.trigger('click');
 
     // Get orcid field
-    let orcidWrapper = wrapper.findAll(BaseFieldWrapper).at(2);
-    let orcidInput = orcidWrapper.find('input#Orcid');
+    let orcidWrapper = wrapper.findAllComponents(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#ORCID-iD');
     expect(orcidInput.exists()).toBeTruthy();
     expect(orcidWrapper.element.classList.contains('field--error')).toBeTruthy()
     await orcidInput.setValue('');
     let error = orcidWrapper.find('span[data-testid="formError"]:not(.is-hidden)');
     expect(error.exists()).toBeTruthy();
-    expect(error.text()).toEqual('Orcid is required');
+    expect(error.text()).toEqual('ORCID iD is required');
   });
 
   it ('shows validation error when new form orcid is improper format', async () => {
 
-    let orcidWrapper = wrapper.findAll(BaseFieldWrapper).at(2);
-    let orcidInput = orcidWrapper.find('input#Orcid');
+    let orcidWrapper = wrapper.findAllComponents(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#ORCID-iD');
     expect(orcidInput.exists()).toBeTruthy();
     await orcidInput.setValue('1234');
 
     expect(orcidWrapper.element.classList.contains('field--error')).toBeTruthy()
     let error = orcidWrapper.find('span[data-testid="formError"]:not(.is-hidden)');
     expect(error.exists()).toBeTruthy();
-    expect(error.text()).toEqual('Orcid must be in orcid format');
+    expect(error.text()).toEqual('ORCID iD must be in orcid format');
   });
 
   it('does not show validation error when orcid in proper format', async () => {
 
-    let orcidWrapper = wrapper.findAll(BaseFieldWrapper).at(2);
-    let orcidInput = orcidWrapper.find('input#Orcid');
+    let orcidWrapper = wrapper.findAllComponents(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#ORCID-iD');
     expect(orcidInput.exists()).toBeTruthy();
     await orcidInput.setValue('1234-5678-9101-1121');
 
@@ -105,8 +106,8 @@ describe('validations work properly', () => {
 
     let editForm = wrapper.findComponent(EditDataRowForm);
     expect(editForm.exists()).toBeTruthy();
-    let orcidWrapper = editForm.findAll(BaseFieldWrapper).at(2);
-    let orcidInput = orcidWrapper.find('input#Orcid');
+    let orcidWrapper = editForm.findAllComponents(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#ORCID-iD');
     expect(orcidInput.exists()).toBeTruthy();
     await orcidInput.setValue('');
 
@@ -114,31 +115,32 @@ describe('validations work properly', () => {
     expect(saveBtn.exists()).toBeTruthy();
     await saveBtn.trigger('click');
 
+    console.log(wrapper.html());
     expect(orcidWrapper.element.classList.contains('field--error')).toBeTruthy();
     let error = orcidWrapper.find('span[data-testid="formError"]:not(.is-hidden)');
     expect(error.exists()).toBeTruthy();
-    expect(error.text()).toEqual('Orcid is required');
+    expect(error.text()).toEqual('ORCID iD is required');
   });
 
   it ('shows validation error when edit form orcid is improper format', async () => {
 
     let editForm = wrapper.findComponent(EditDataRowForm);
-    let orcidWrapper = editForm.findAll(BaseFieldWrapper).at(2);
-    let orcidInput = orcidWrapper.find('input#Orcid');
+    let orcidWrapper = editForm.findAllComponents(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#ORCID-iD');
     expect(orcidInput.exists()).toBeTruthy();
     await orcidInput.setValue('1234');
 
     expect(orcidWrapper.element.classList.contains('field--error')).toBeTruthy();
     let error = orcidWrapper.find('span[data-testid="formError"]:not(.is-hidden)');
     expect(error.exists()).toBeTruthy();
-    expect(error.text()).toEqual('Orcid must be in orcid format');
+    expect(error.text()).toEqual('ORCID iD must be in orcid format');
   });
 
   it('does not show validation error when edit form orcid is properly formatted', async () => {
 
     let editForm = wrapper.findComponent(EditDataRowForm);
-    let orcidWrapper = editForm.findAll(BaseFieldWrapper).at(2);
-    let orcidInput = orcidWrapper.find('input#Orcid');
+    let orcidWrapper = editForm.findAllComponents(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#ORCID-iD');
     expect(orcidInput.exists()).toBeTruthy();
     await orcidInput.setValue('1234-6789-1012-1234');
 
@@ -156,12 +158,12 @@ describe('new data form works properly', () => {
     expect(newFormBtn.exists()).toBeTruthy();
     await newFormBtn.trigger('click');
 
-    let newForm = wrapper.find(NewDataForm);
+    let newForm = wrapper.findComponent(NewDataForm);
     expect(newForm.exists()).toBeTruthy();
 
     let nameInput = newForm.find('input#Name');
     let emailInput = newForm.find('input#Email');
-    let orcidInput = newForm.find('input#Orcid');
+    let orcidInput = newForm.find('input#ORCID-iD');
     expect(nameInput.exists()).toBeTruthy();
     expect(emailInput.exists()).toBeTruthy();
     expect(orcidInput.exists()).toBeTruthy();
@@ -183,7 +185,7 @@ describe('new data form works properly', () => {
     expect(error!.length).toEqual(1);
     let notification = error!.pop();
     expect(notification.length).toEqual(1);
-    expect(notification.pop()).toEqual('Orcid is in use by another user.');
+    expect(notification.pop()).toEqual('ORCID iD is in use by another user.');
   });
 
   it('closes new data form when user successfully created, but update orcid returns error', async () => {
@@ -191,7 +193,7 @@ describe('new data form works properly', () => {
     let newForm = wrapper.find(NewDataForm);
     expect(newForm.exists()).toBeTruthy();
 
-    let orcidInput = newForm.find('input#Orcid');
+    let orcidInput = newForm.find('input#ORCID-iD');
     expect(orcidInput.exists()).toBeTruthy();
 
     await orcidInput.setValue('2222-2222-2222-2222');
@@ -206,7 +208,7 @@ describe('new data form works properly', () => {
     // Wait another DOM update. A little hacky, probably should find better way to do this in the future.
     await wrapper.vm.$nextTick();
 
-    newForm = wrapper.find(NewDataForm);
+    newForm = wrapper.findComponent(NewDataForm);
     expect(newForm.exists()).toBeFalsy();
   });
 });

--- a/tests/unit/components/admin/AdminUsersTable.spec.ts
+++ b/tests/unit/components/admin/AdminUsersTable.spec.ts
@@ -1,0 +1,214 @@
+import DaoUtils from "../../test-utils/DaoUtils";
+import {mocked} from "ts-jest";
+import {SystemRoleDao} from "@/breeding-insight/dao/SystemRoleDao";
+import {UserDAO} from "@/breeding-insight/dao/UserDAO";
+import localVue, {defaultStore} from "../../index";
+import {mount} from "@vue/test-utils";
+import ProgramUsersTable from "@/components/program/ProgramUsersTable.vue";
+import AdminUsersTable from "@/components/admin/AdminUsersTable.vue";
+import NewDataForm from "@/components/forms/NewDataForm.vue";
+import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
+import ExpandableTableRow from "@/components/tables/ExpandableTableRow.vue";
+import EditDataRowForm from "@/components/forms/EditDataRowForm.vue";
+import {UserService} from "@/breeding-insight/service/UserService";
+import flushPromises from "flush-promises";
+
+jest.mock('@/breeding-insight/dao/SystemRoleDao');
+jest.mock('@/breeding-insight/dao/UserDAO');
+let roles: any[] = [];
+let systemUsers: any[] = [];
+
+function setup() {
+
+  const systemUser = {'id':'1', 'name':'Test user', 'email':'testuser@test.com', 'active':'true', 'orcid':'1111-1111-1111-1111',
+    'systemRoles': [{'id':'1', 'domain':'admin'}],
+    'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]};
+  systemUsers.push(systemUser);
+  const systemUsersResponse = DaoUtils.formatBiResponse(systemUsers);
+  const userDAO = mocked(UserDAO, true);
+  userDAO.getAll.mockResolvedValue(systemUsersResponse);
+
+  roles.push({'id':'1', 'domain':'test role'});
+  const rolesResponse = DaoUtils.formatBiResponse(roles);
+
+  const roleDAO = mocked(SystemRoleDao, true);
+  roleDAO.getAll.mockResolvedValue(rolesResponse);
+
+}
+
+setup();
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('validations work properly', () => {
+  const store = defaultStore;
+  const wrapper = mount(AdminUsersTable, {localVue, store});
+
+  it('shows validation error when new form orcid is empty', async () => {
+    let newFormBtn = wrapper.find('button[data-testid="newFormBtn"]');
+    expect(newFormBtn.exists()).toBeTruthy();
+    await newFormBtn.trigger('click');
+
+    let newForm = wrapper.find(NewDataForm);
+    expect(newForm.exists()).toBeTruthy();
+
+    let saveBtn = newForm.find('button[data-testid="save"]');
+    expect(saveBtn.exists()).toBeTruthy();
+    await saveBtn.trigger('click');
+
+    // Get orcid field
+    let orcidWrapper = wrapper.findAll(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#Orcid');
+    expect(orcidInput.exists()).toBeTruthy();
+    expect(orcidWrapper.element.classList.contains('field--error')).toBeTruthy()
+    await orcidInput.setValue('');
+    let error = orcidWrapper.find('span[data-testid="formError"]:not(.is-hidden)');
+    expect(error.exists()).toBeTruthy();
+    expect(error.text()).toEqual('Orcid is required');
+  });
+
+  it ('shows validation error when new form orcid is improper format', async () => {
+
+    let orcidWrapper = wrapper.findAll(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#Orcid');
+    expect(orcidInput.exists()).toBeTruthy();
+    await orcidInput.setValue('1234');
+
+    expect(orcidWrapper.element.classList.contains('field--error')).toBeTruthy()
+    let error = orcidWrapper.find('span[data-testid="formError"]:not(.is-hidden)');
+    expect(error.exists()).toBeTruthy();
+    expect(error.text()).toEqual('Orcid must be in orcid format');
+  });
+
+  it('does not show validation error when orcid in proper format', async () => {
+
+    let orcidWrapper = wrapper.findAll(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#Orcid');
+    expect(orcidInput.exists()).toBeTruthy();
+    await orcidInput.setValue('1234-5678-9101-1121');
+
+    expect(orcidWrapper.element.classList.contains('field--error')).toBeFalsy();
+
+    // close form
+    let closeBtn = wrapper.find('button[data-testid="cancel"]');
+    expect(closeBtn.exists()).toBeTruthy();
+    await closeBtn.trigger('click');
+  })
+
+  it('shows validation error when edit form orcid is empty', async () => {
+
+    let row = wrapper.findComponent(ExpandableTableRow);
+    expect(row.exists()).toBeTruthy();
+    const editBtn = row.find('a[data-testid="edit"]');
+    expect(editBtn.exists()).toBeTruthy();
+    await editBtn.trigger('click');
+
+    let editForm = wrapper.findComponent(EditDataRowForm);
+    expect(editForm.exists()).toBeTruthy();
+    let orcidWrapper = editForm.findAll(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#Orcid');
+    expect(orcidInput.exists()).toBeTruthy();
+    await orcidInput.setValue('');
+
+    let saveBtn = editForm.find('button[data-testid="save"]');
+    expect(saveBtn.exists()).toBeTruthy();
+    await saveBtn.trigger('click');
+
+    expect(orcidWrapper.element.classList.contains('field--error')).toBeTruthy();
+    let error = orcidWrapper.find('span[data-testid="formError"]:not(.is-hidden)');
+    expect(error.exists()).toBeTruthy();
+    expect(error.text()).toEqual('Orcid is required');
+  });
+
+  it ('shows validation error when edit form orcid is improper format', async () => {
+
+    let editForm = wrapper.findComponent(EditDataRowForm);
+    let orcidWrapper = editForm.findAll(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#Orcid');
+    expect(orcidInput.exists()).toBeTruthy();
+    await orcidInput.setValue('1234');
+
+    expect(orcidWrapper.element.classList.contains('field--error')).toBeTruthy();
+    let error = orcidWrapper.find('span[data-testid="formError"]:not(.is-hidden)');
+    expect(error.exists()).toBeTruthy();
+    expect(error.text()).toEqual('Orcid must be in orcid format');
+  });
+
+  it('does not show validation error when edit form orcid is properly formatted', async () => {
+
+    let editForm = wrapper.findComponent(EditDataRowForm);
+    let orcidWrapper = editForm.findAll(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#Orcid');
+    expect(orcidInput.exists()).toBeTruthy();
+    await orcidInput.setValue('1234-6789-1012-1234');
+
+    expect(orcidWrapper.element.classList.contains('field--error')).toBeFalsy();
+  });
+});
+
+describe('new data form works properly', () => {
+  const store = defaultStore;
+  const wrapper = mount(AdminUsersTable, {localVue, store});
+
+  it('cancels save if orcid is already in use', async () => {
+
+    let newFormBtn = wrapper.find('button[data-testid="newFormBtn"]');
+    expect(newFormBtn.exists()).toBeTruthy();
+    await newFormBtn.trigger('click');
+
+    let newForm = wrapper.find(NewDataForm);
+    expect(newForm.exists()).toBeTruthy();
+
+    let nameInput = newForm.find('input#Name');
+    let emailInput = newForm.find('input#Email');
+    let orcidInput = newForm.find('input#Orcid');
+    expect(nameInput.exists()).toBeTruthy();
+    expect(emailInput.exists()).toBeTruthy();
+    expect(orcidInput.exists()).toBeTruthy();
+
+    await nameInput.setValue('new test user');
+    await emailInput.setValue('newtestuser@tester.com');
+    await orcidInput.setValue(systemUsers[0].orcid);
+
+    let saveBtn = newForm.find('button[data-testid="save"]');
+    expect(saveBtn.exists()).toBeTruthy();
+    await saveBtn.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    // make sure the create function was not called
+    const createSpy = jest.spyOn(UserService, 'create');
+    expect(createSpy).toHaveBeenCalledTimes(0);
+
+    let error = wrapper.emitted('show-error-notification');
+    expect(error!.length).toEqual(1);
+    let notification = error!.pop();
+    expect(notification.length).toEqual(1);
+    expect(notification.pop()).toEqual('Orcid is in use by another user.');
+  });
+
+  it('closes new data form when user successfully created, but update orcid returns error', async () => {
+
+    let newForm = wrapper.find(NewDataForm);
+    expect(newForm.exists()).toBeTruthy();
+
+    let orcidInput = newForm.find('input#Orcid');
+    expect(orcidInput.exists()).toBeTruthy();
+
+    await orcidInput.setValue('2222-2222-2222-2222');
+
+    const userDAO = mocked(UserDAO, true);
+    userDAO.updateOrcid.mockRejectedValueOnce({error: {response: {status: 409}}});
+    userDAO.create.mockResolvedValue(DaoUtils.formatBiResponseSingle(systemUsers[0]));
+    let saveBtn = newForm.find('button[data-testid="save"]');
+    expect(saveBtn.exists()).toBeTruthy();
+    await saveBtn.trigger('click');
+    await wrapper.vm.$nextTick();
+    // Wait another DOM update. A little hacky, probably should find better way to do this in the future.
+    await wrapper.vm.$nextTick();
+
+    newForm = wrapper.find(NewDataForm);
+    expect(newForm.exists()).toBeFalsy();
+  });
+});

--- a/tests/unit/components/admin/AdminUsersTable.spec.ts
+++ b/tests/unit/components/admin/AdminUsersTable.spec.ts
@@ -4,14 +4,12 @@ import {SystemRoleDao} from "@/breeding-insight/dao/SystemRoleDao";
 import {UserDAO} from "@/breeding-insight/dao/UserDAO";
 import localVue, {defaultStore} from "../../index";
 import {mount} from "@vue/test-utils";
-import ProgramUsersTable from "@/components/program/ProgramUsersTable.vue";
 import AdminUsersTable from "@/components/admin/AdminUsersTable.vue";
 import NewDataForm from "@/components/forms/NewDataForm.vue";
 import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
 import ExpandableTableRow from "@/components/tables/ExpandableTableRow.vue";
 import EditDataRowForm from "@/components/forms/EditDataRowForm.vue";
 import {UserService} from "@/breeding-insight/service/UserService";
-import flushPromises from "flush-promises";
 
 jest.mock('@/breeding-insight/dao/SystemRoleDao');
 jest.mock('@/breeding-insight/dao/UserDAO');

--- a/tests/unit/components/program/ProgramUsersTable.spec.ts
+++ b/tests/unit/components/program/ProgramUsersTable.spec.ts
@@ -131,7 +131,6 @@ describe('New Program User action works properly', () => {
         await wrapper.vm.$nextTick();
 
         let error = wrapper.emitted('show-error-notification');
-        console.log(error);
         expect(error!.length).toEqual(1);
         let notification = error!.pop();
         expect(notification.length).toEqual(1);


### PR DESCRIPTION
Fixes the issue of the new data form being left open when a user is successfully saved but their orcid is not updated properly. 

Additions:
- Added a duplicate orcid check before making POST check.
- Closed new data form if user POST is successful, but orcid PUT is not. 
- Added validation for orcid
- Changed addUser method to use async/await for clearer error handling and request flow. 

Note: 

Updating the users uses a similar request flow to what adding users used to be before updating to use async/await. I did not change update users because I did not want this card to get too out of scope. 

## Limitations

The pre-check for a duplicate orcid does not take into account deactivated users. Our API is not capable of returning inactive users yet. The backend will still catch duplicates for inactive users though. See attached error state. 

Bad ORCiD iD
![screencapture-localhost-8080-admin-user-management-2020-09-10-14_53_03](https://user-images.githubusercontent.com/17887341/92786458-422a9980-f376-11ea-8baa-01fc1f86156b.png)
Duplicate orcid precheck
![screencapture-localhost-8080-admin-user-management-2020-09-10-14_52_48](https://user-images.githubusercontent.com/17887341/92786984-b5341000-f376-11ea-970b-f1dc16afc16e.png)
Duplicate email
![screencapture-localhost-8080-admin-user-management-2020-09-10-14_53_38](https://user-images.githubusercontent.com/17887341/92786473-45258a00-f376-11ea-9bc8-744fc361324f.png)
Duplicate orcid with inactive user
![screencapture-192-168-10-72-8080-admin-user-management-2020-09-18-11_45_43](https://user-images.githubusercontent.com/17887341/93618006-b8498480-f9a4-11ea-8cd5-7b09bcd26196.png)

