### PR TITLE
BI-57 - Set up sandbox sites

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,6 @@
+# Sandbox mode control {public, coordinator}
+VUE_APP_SANDBOX=public
+
 # Only edit this one
 VUE_APP_BI_API_ROOT=http://localhost:8081
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -100,6 +100,7 @@ import UserSideBarLayout from './components/layouts/UserSideBarLayout.vue'
 import NoSideBarLayout from './components/layouts/NoSideBarLayout.vue'
 import SandboxPublicNotification from "@/components/notifications/SandboxPublicNotification.vue";
 import SandboxCoordinatorNotification from "@/components/notifications/SandboxCoordinatorNotification.vue";
+import {SandboxMode} from "@/util/config";
 
 @Component({
   watch: {
@@ -151,9 +152,9 @@ export default class App extends Vue {
   @Watch('firstVisit', {immediate: true})
   onFirstVisitChanged(newVal: any, oldVal: any) {
     if(newVal) {
-      if (process.env.VUE_APP_SANDBOX === 'public') {
+      if (process.env.VUE_APP_SANDBOX === SandboxMode.Public) {
         this.showPublicSandboxNotification = true;
-      } else if (process.env.VUE_APP_SANDBOX === 'coordinator') {
+      } else if (process.env.VUE_APP_SANDBOX === SandboxMode.Coordinator) {
         this.showCoordinatorSandboxNotification = true;
       }
     }
@@ -163,9 +164,9 @@ export default class App extends Vue {
     // load the appropriate JIRA issue collector script depending on sandbox type
     let issueCollectorScript = document.createElement('script');
     issueCollectorScript.setAttribute('type', 'text/javascript');
-    if (process.env.VUE_APP_SANDBOX === 'public') {
+    if (process.env.VUE_APP_SANDBOX === SandboxMode.Public) {
       issueCollectorScript.setAttribute('src', 'https://breedinginsight.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/-egccmf/b/24/a44af77267a987a660377e5c46e0fb64/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=d2cbfe89');
-    } else if (process.env.VUE_APP_SANDBOX === 'coordinator') {
+    } else if (process.env.VUE_APP_SANDBOX === SandboxMode.Coordinator) {
       issueCollectorScript.setAttribute('src', 'https://breedinginsight.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/vd1cif/b/24/a44af77267a987a660377e5c46e0fb64/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=b57acf4a');
     }
     document.head.appendChild(issueCollectorScript);

--- a/src/components/layouts/BaseSideBarLayout.vue
+++ b/src/components/layouts/BaseSideBarLayout.vue
@@ -40,12 +40,12 @@
             </a>
           </div>
           <div v-if="sandboxConfig !== undefined" class="level-item">
-            <div v-bind:class="{'notification is-warning px-5 has-text-centered': sandboxConfig === 'public',
-                                'notification is-info px-5 has-text-centered': sandboxConfig === 'coordinator'}">
+            <div v-bind:class="{'notification is-warning px-5 has-text-centered': sandboxConfig === SandboxMode.Public,
+                                'notification is-info px-5 has-text-centered': sandboxConfig === SandboxMode.Coordinator}">
               <p class="title is-size-4">Sandbox</p>
               <p>
-                <a href="#" v-on:click="$showCollectorDialog()" v-bind:class="{'has-text-link': sandboxConfig === 'public',
-                                                                               'has-text-white': sandboxConfig === 'coordinator'}">Feedback
+                <a href="#" v-on:click="$showCollectorDialog()" v-bind:class="{'has-text-link': sandboxConfig === SandboxMode.Public,
+                                                                               'has-text-white': sandboxConfig === SandboxMode.Coordinator}">Feedback
                 </a>
               </p>
             </div>
@@ -96,6 +96,7 @@
 <script lang="ts">
   import {Component, Prop, Watch, Vue} from 'vue-property-decorator'
   import { MenuIcon } from 'vue-feather-icons'
+  import {SandboxMode} from '@/util/config'
 
 
   @Component( {
@@ -103,6 +104,7 @@
   })
   export default class SideBarMaster extends Vue {
     sideMenuShownMobile: boolean = false;
+    SandboxMode = SandboxMode;
 
     @Prop()
     username!: string;

--- a/src/components/layouts/BaseSideBarLayout.vue
+++ b/src/components/layouts/BaseSideBarLayout.vue
@@ -114,7 +114,7 @@
       this.sideMenuShownMobile = false;
     }
 
-    get sandboxConfig() : string {
+    get sandboxConfig() {
       return process.env.VUE_APP_SANDBOX;
     }
   }

--- a/src/components/layouts/BaseSideBarLayout.vue
+++ b/src/components/layouts/BaseSideBarLayout.vue
@@ -39,6 +39,17 @@
               <MenuIcon></MenuIcon>
             </a>
           </div>
+          <div v-if="sandboxConfig !== undefined" class="level-item">
+            <div v-bind:class="{'notification is-warning px-5 has-text-centered': sandboxConfig === 'public',
+                                'notification is-info px-5 has-text-centered': sandboxConfig === 'coordinator'}">
+              <p class="title is-size-4">Sandbox</p>
+              <p>
+                <a href="#" v-on:click="$showCollectorDialog()" v-bind:class="{'has-text-link': sandboxConfig === 'public',
+                                                                               'has-text-white': sandboxConfig === 'coordinator'}">Feedback
+                </a>
+              </p>
+            </div>
+          </div>
         </div>
         <div class="level-right program-selection-level">
           <slot name="title"></slot>
@@ -99,6 +110,10 @@
     @Watch('$route')
     onUrlChange(){
       this.sideMenuShownMobile = false;
+    }
+
+    get sandboxConfig() : string {
+      return process.env.VUE_APP_SANDBOX;
     }
   }
 

--- a/src/components/layouts/SimpleLayout.vue
+++ b/src/components/layouts/SimpleLayout.vue
@@ -17,50 +17,6 @@
 
 <template>
   <div class="is-full-length">
-    <header class="container">
-      <div>
-        <nav
-          class="navbar"
-          role="navigation"
-          aria-label="main navigation"
-        >
-          <div class="navbar-menu">
-            <ul class="navbar-start">
-              <li class="navbar-item">
-                <router-link to="/">
-                  Home
-                </router-link>
-              </li>
-              <li class="navbar-item">
-                <router-link to="/about">
-                  About
-                </router-link>
-              </li>
-              <li class="navbar-item">
-                <router-link to="/style-guide">
-                  Style Guide
-                </router-link>
-              </li>
-              <li class="navbar-item">
-                <router-link to="/user-management">
-                  Manage Users
-                </router-link>
-              </li>
-              <li class="navbar-item">
-                <router-link to="/program-management">
-                  Program Management
-                </router-link>
-              </li>
-              <li v-if="activeUser" class="navbar-item">
-                <a @click="$emit('logout')">
-                  Logout
-                </a>
-              </li>
-            </ul>
-          </div>
-        </nav>
-      </div>
-    </header>
     <main>
       <section class="section">
         <slot></slot>

--- a/src/components/notifications/SandboxCoordinatorNotification.vue
+++ b/src/components/notifications/SandboxCoordinatorNotification.vue
@@ -1,0 +1,57 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <b-notification type="is-info" v-bind:active.sync="notificationActive" aria-close-label="Close Notification"
+                  role="alert">
+    <div class="content">
+      <h1 class="title is-4">Coordinator Sandbox</h1>
+      <ul class="is-size-5">
+        <li>Data submitted to this site is private, but may be shared if screenshots or Zoom sessions with other groups are shared.
+          Only use data that is cleared for public viewing.</li>
+        <li><strong>This database will be refreshed by the development team on request.</strong> If there is a need to delete
+        data that you have submitted, contact the development team for assistance.</li>
+        <p><a href="#" v-on:click="$showCollectorDialog()" class="has-text-white">If you find a bug or need support, use this link.</a></p>
+      </ul>
+      <div class="buttons is-centered">
+        <button class="button is-dark" v-on:click="$emit('update:active', false)">I understand, close this message</button>
+      </div>
+    </div>
+  </b-notification>
+</template>
+
+<script lang="ts">
+import {Component, Prop, Vue, Watch} from 'vue-property-decorator';
+import { InfoIcon } from 'vue-feather-icons'
+
+@Component({
+  components: {InfoIcon}
+})
+export default class SandboxCoordinatorNotificationNotification extends Vue {
+  @Prop({default: false})
+  public active!: boolean;
+
+  get notificationActive() {
+    return this.active;
+  }
+
+  set notificationActive(active: boolean) {
+    this.$emit('update:active', active);
+  }
+}
+
+</script>

--- a/src/components/notifications/SandboxPublicNotification.vue
+++ b/src/components/notifications/SandboxPublicNotification.vue
@@ -1,0 +1,58 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <b-notification type="is-warning" v-bind:active.sync="notificationActive" aria-close-label="Close Notification"
+                  role="alert">
+    <div class="content">
+      <h1 class="title is-4">This is a sandbox site open to the general public.</h1>
+      <ul class="is-size-5">
+        <li>Anything you submit to this site is viewable by others. Please use discretion and courtesy.</li>
+        <li>Data submitted to this site is not private in any way. Only enter data that is cleared for public viewing.</li>
+        <li>This site is refreshed regularly as development updates occur to demonstrate new features. <strong>The database is frequently deleted during updates.</strong></li>
+        <li><a href="#" v-on:click="$showCollectorDialog()" class="has-text-link">Send feedback or report issues</a> to the development team.</li>
+      </ul>
+      <div class="buttons is-centered">
+        <button class="button is-dark" v-on:click="$emit('update:active', false)">I understand, close this message</button>
+      </div>
+    </div>
+  </b-notification>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Watch, Vue } from 'vue-property-decorator';
+import { InfoIcon } from 'vue-feather-icons'
+
+@Component({
+  components: {InfoIcon}
+})
+export default class SandboxPublicNotification extends Vue {
+  @Prop({default: false})
+  public active!: boolean;
+
+  get notificationActive() {
+    return this.active;
+  }
+
+  set notificationActive(active: boolean) {
+    this.$emit('update:active', active);
+  }
+
+}
+</script>
+
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,9 +49,16 @@ Vue.use(VueLogger, options);
 
 // Vue constants
 const cookieNames = {
-  loginRedirectUrl: 'redirect-login'
+  loginRedirectUrl: 'redirect-login',
+  firstVisit: 'first-visit'
 }
 Vue.prototype.$cookieNames = cookieNames;
+
+window.ATL_JQ_PAGE_PROPS =  {
+  "triggerFunction": function(showCollectorDialog: any) {
+    Vue.prototype.$showCollectorDialog = showCollectorDialog
+  }
+};
 
 new Vue({
   router,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -25,7 +25,15 @@ import ProgramManagement from '@/views/ProgramManagement.vue'
 import AdminProgramManagement from '@/views/AdminProgramManagement.vue'
 import AdminUserManagement from '@/views/AdminUserManagement.vue'
 import store from '@/store/index.ts';
-import {LOGIN, LOGOUT, REQUESTED_PATH, ERROR_STATE, SET_ACTIVE_PROGRAM} from '@/store/mutation-types';
+import {
+  LOGIN,
+  LOGOUT,
+  REQUESTED_PATH,
+  ERROR_STATE,
+  SET_ACTIVE_PROGRAM,
+  FIRST_VISIT,
+  RETURN_VISIT
+} from '@/store/mutation-types';
 import ProgramLocationsManagement from "@/views/ProgramLocationsManagement.vue";
 import ProgramUserManagement from "@/views/ProgramUsersManagement.vue";
 import Traits from '@/views/Traits.vue'
@@ -242,6 +250,15 @@ router.beforeEach((to: Route, from: Route, next: Function) => {
     store.commit(REQUESTED_PATH, {path: undefined});
   }
 
+  const firstVisitCookie = Vue.prototype.$cookieNames.firstVisit;
+  if (Vue.$cookies.get(firstVisitCookie) === null) {
+    // expires after 1 week
+    Vue.$cookies.set(firstVisitCookie, 'visited', 604800);
+    store.commit(FIRST_VISIT);
+  } else {
+    store.commit(RETURN_VISIT);
+  }
+
   // Clear path dependent store data for easier state management
   if (!isProgramsPath(to)){
     store.commit(SET_ACTIVE_PROGRAM, undefined);
@@ -278,8 +295,5 @@ router.beforeEach((to: Route, from: Route, next: Function) => {
   // Set page title
   document.title = to.meta.title + ' | Breeding Insight Platform' || 'Breeding Insight Platform'
 });
-
-
-
 
 export default router

--- a/src/shims-tsx.d.ts
+++ b/src/shims-tsx.d.ts
@@ -33,5 +33,9 @@ declare global {
     allSettled(arg0: Promise<any>[]): Promise<[]>;
   }
 
+  interface Window {
+    ATL_JQ_PAGE_PROPS: any;
+  }
+
 }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -32,7 +32,8 @@ const store: StoreOptions<RootState> = {
     loggedIn: false,
     requestedPath: undefined,
     user: undefined,
-    program: undefined
+    program: undefined,
+    firstVisit: undefined
   },
   mutations,
   actions,

--- a/src/store/mutation-types.ts
+++ b/src/store/mutation-types.ts
@@ -20,3 +20,5 @@ export const LOGOUT = 'logout';
 export const ERROR_STATE = 'errorState';
 export const REQUESTED_PATH = 'requestedPath';
 export const SET_ACTIVE_PROGRAM = 'setActiveProgram';
+export const FIRST_VISIT = 'firstVisit';
+export const RETURN_VISIT = 'returnVisit';

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -17,7 +17,15 @@
 
 import { MutationTree } from 'vuex';
 import { RootState } from '@/store/types';
-import { ERROR_STATE, LOGIN, LOGOUT, REQUESTED_PATH, SET_ACTIVE_PROGRAM } from '@/store/mutation-types';
+import {
+  ERROR_STATE,
+  FIRST_VISIT,
+  LOGIN,
+  LOGOUT,
+  REQUESTED_PATH,
+  RETURN_VISIT,
+  SET_ACTIVE_PROGRAM,
+} from '@/store/mutation-types';
 import {User} from "@/breeding-insight/model/User";
 import {Program} from "@/breeding-insight/model/Program";
 
@@ -44,5 +52,11 @@ export const mutations: MutationTree<RootState> = {
   },
   [SET_ACTIVE_PROGRAM] (state, program: Program) {
     state.program = program;
+  },
+  [FIRST_VISIT] (state) {
+    state.firstVisit = true;
+  },
+  [RETURN_VISIT] (state) {
+    state.firstVisit = false;
   }
 };

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -26,4 +26,5 @@ export interface RootState {
   apiUnavailable: boolean;
   loginServerError: boolean;
   requestedPath?: string;
+  firstVisit?: boolean;
 }

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-export const enum SandboxMode {
+export enum SandboxMode {
     Public = "public",
     Coordinator = "coordinator"
 }

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,0 +1,21 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const enum SandboxMode {
+    Public = "public",
+    Coordinator = "coordinator"
+}


### PR DESCRIPTION
## Changes

- Added configuration variable for setting sandbox mode if desired
- Added sandbox notifications that appear on first visit if in a sandbox mode
- Added sandbox header item that appears if in a sandbox mode
- Feedback form goes to JIRA issue collectors (BI Feedback project)
  - One issue collector for Public and one for Coordinator depending on sandbox mode

## Design

### First visit tracking
A cookie is used to track whether this is the user's first visit to the site. If it is and in a sandbox mode, then the sandbox notification will be displayed. The cookie currently is set to expire after 1 week but we can adjust the time frame to whatever.

## Testing

- Verify that setting the VUE_APP_SANDBOX config in `.env.development` to public, coordinator, and removing works as expected
- Verify first visit notification works
  - Can delete first-visit cookie in dev tools to excercise more test cases
  - Note: If you delete the cookie make sure to navigate to a new route after getting the notification before deleting the cookie again. Otherwise the state won't change due to the way the tracking works.
- Verify that feedback links open the JIRA issue collector form and feedback is recorded in the correct issue collector (public or coordinator depending on mode)
  - Note: If you're changing between sandbox types in the config make sure to restart biweb and refresh the page. Want to ensure that the config variable is updated and the correct JIRA issue collector script is loaded.