### PR TITLE
[BI-611] make daos work with pagination in backend

### DIFF
--- a/src/breeding-insight/dao/ProgramDAO.ts
+++ b/src/breeding-insight/dao/ProgramDAO.ts
@@ -62,7 +62,7 @@ export class ProgramDAO {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get', params: paginationQuery})
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get'})
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/ProgramLocationDAO.ts
+++ b/src/breeding-insight/dao/ProgramLocationDAO.ts
@@ -62,7 +62,7 @@ export class ProgramLocationDAO {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations`, method: 'get', params: paginationQuery })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations`, method: 'get' })
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/ProgramUserDAO.ts
+++ b/src/breeding-insight/dao/ProgramUserDAO.ts
@@ -74,7 +74,7 @@ export class ProgramUserDAO {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users`, method: 'get', params: paginationQuery })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users`, method: 'get' })
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/TraitDAO.ts
+++ b/src/breeding-insight/dao/TraitDAO.ts
@@ -30,7 +30,7 @@ export class TraitDAO {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-        api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/traits`, method: 'get', params: {full, paginationQuery} })
+        api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/traits`, method: 'get', params: {full} })
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/TraitUploadDAO.ts
+++ b/src/breeding-insight/dao/TraitUploadDAO.ts
@@ -50,7 +50,7 @@ export class TraitUploadDAO {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/trait-upload`, method: 'get', params: paginationQuery })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/trait-upload`, method: 'get' })
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/UserDAO.ts
+++ b/src/breeding-insight/dao/UserDAO.ts
@@ -77,7 +77,7 @@ export class UserDAO {
 
     return new Promise<BiResponse>(((resolve, reject) => {
 
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users`, method: 'get', params: paginationQuery })
+      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users`, method: 'get'})
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);


### PR DESCRIPTION
Change to DAOs to work with new backend pagination. The DAOs now do not send back any params so that all results are returned by default. 

Poked around and tested out each page table. Seems to work. 