### PR TITLE
[BI-637] orcid last character X fix plus test

### DIFF
--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -276,7 +276,7 @@ export default class AdminUsersTable extends Vue {
   private roles: Role[] = [];
   private rolesMap: Map<string, Role> = new Map();
   private isMobile = false;
-  private orcidCheck = helpers.regex('alpha', /^\d{4}-\d{4}-\d{4}-\d{4}$/);
+  private orcidCheck = helpers.regex('alpha', /^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$/);
 
   userValidations = {
     name: {required},

--- a/tests/unit/components/admin/AdminUsersTable.spec.ts
+++ b/tests/unit/components/admin/AdminUsersTable.spec.ts
@@ -90,6 +90,17 @@ describe('validations work properly', () => {
 
     expect(orcidWrapper.element.classList.contains('field--error')).toBeFalsy();
 
+  });
+
+  it('does not show validation error when orcid has X in last character', async () => {
+
+    let orcidWrapper = wrapper.findAllComponents(BaseFieldWrapper).at(2);
+    let orcidInput = orcidWrapper.find('input#ORCID-iD');
+    expect(orcidInput.exists()).toBeTruthy();
+    await orcidInput.setValue('1234-5678-9101-112X');
+
+    expect(orcidWrapper.element.classList.contains('field--error')).toBeFalsy();
+
     // close form
     let closeBtn = wrapper.find('button[data-testid="cancel"]');
     expect(closeBtn.exists()).toBeTruthy();


### PR DESCRIPTION
Allows OrcID's to have `X` as the last character. 