### PR TITLE
[BI-626] Handle login error and logout user before starting login process

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,6 @@
+# Optional Open ID logout url
+VUE_APP_OPENID_LOGOUT_URL=https://sandbox.orcid.org/userStatus.json?logUserOut=true
+
 # Sandbox mode control {public, coordinator}
 VUE_APP_SANDBOX=public
 

--- a/src/breeding-insight/dao/UserDAO.ts
+++ b/src/breeding-insight/dao/UserDAO.ts
@@ -118,7 +118,10 @@ export class UserDAO {
         }).catch((error) => reject(error));
 
     });
+  }
 
+  static openIdLogout(logoutUrl: string) {
+    return api.call({url: logoutUrl, method: 'get'});
   }
 
 }

--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -283,4 +283,14 @@ export class UserService {
     }
   }
 
+  static openIdLogout(): Promise<any> {
+    if (process.env.VUE_APP_OPENID_LOGOUT_URL) {
+      return UserDAO.openIdLogout(process.env.VUE_APP_OPENID_LOGOUT_URL);
+    } else {
+      Vue.$log.info("Open ID logout url not specified. Skipping forced login.");
+      return new Promise((resolve) => {resolve()});
+    }
+
+  }
+
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -67,7 +67,8 @@ const routes = [
     component: Index,
     props: (route: Route) => ({
       loginRedirect: route.params.loginRedirect || false,
-      sessionExpired: route.params.sessionExpired || false
+      sessionExpired: route.params.sessionExpired || false,
+      loginError: route.query.loginError || false
     })
   },
   {
@@ -243,7 +244,7 @@ router.beforeEach((to: Route, from: Route, next: Function) => {
   Vue.$cookies.remove(loginRedirectUrlCookieName);
 
   // Check the url for a redirect-login url. Also check if they were redirected because of expired session
-  if (store.state.requestedPath){
+  if (store.state.requestedPath && to.params.loginRedirect) {
     // Expires in 1 hr
     Vue.$cookies.set(loginRedirectUrlCookieName, store.state.requestedPath, 60*60);
     // reset our state

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -181,6 +181,12 @@
         Your session has expired. Please login again to continue.
       </h1>
       <h1
+        v-else-if="loginError"
+        class="is-size-5 has-text-primary"
+      >
+        An error has occurred during login. Please try again.
+      </h1>
+      <h1
         v-else
         class="is-size-5 has-text-primary"
       >
@@ -190,18 +196,19 @@
         To access to your breeding program, please log in.
       </p>
       <button
-        id="connect-orcid-button"
-        class="orcidBtn"
-        v-on:click="orcidLogin"
+          id="connect-orcid-button"
+          class="button orcidBtn"
+          v-bind:class="{'is-loading': loginProcessing, 'disabled': loginProcessing}"
+          v-on:click="orcidLogin"
       >
         SIGN IN with ORCID
         <img
-          id="orcid-id-icon"
-          src="https://orcid.org/sites/default/files/images/orcid_24x24.png"
-          width="24"
-          height="24"
-          class="is-pulled-right"
-          alt="ORCID iD icon"
+            id="orcid-id-icon"
+            src="https://orcid.org/sites/default/files/images/orcid_24x24.png"
+            width="24"
+            height="24"
+            class="is-pulled-right"
+            alt="ORCID iD icon"
         >
       </button>
       <p class="is-size-7 has-text-left">
@@ -245,6 +252,7 @@
   import InfoModal from '@/components/modals/InfoModal.vue'
   import WarningModal from '@/components/modals/WarningModal.vue'
   import {ServerManagementService} from "@/breeding-insight/service/ServerManagementService";
+  import {UserService} from "@/breeding-insight/service/UserService";
 
   @Component({
     components: {InfoModal, BaseModal, WarningModal}
@@ -253,26 +261,43 @@
 
     public isLoginModalActive: boolean = false;
     public isLoginServerErrorModalActive: boolean = false;
+    public loginProcessing: boolean = false;
     @Prop()
     public loginRedirect!: boolean;
     @Prop()
     public sessionExpired!: boolean;
+    @Prop()
+    public loginError!: boolean;
+    @Prop()
+    public openIdLogoutUrl!: String;
 
     mounted() {
-      if (this.loginRedirect || this.sessionExpired){
+      if (this.loginRedirect || this.sessionExpired || this.loginError){
         this.isLoginModalActive = true;
       }
     }
 
     // Methods
-    orcidLogin() {
+    async orcidLogin() {
       // Check the server can be contacted
-      this.isLoginModalActive = false;
-      ServerManagementService.checkHealth().then((response) => {
-        window.location.href = process.env.VUE_APP_BI_API_ROOT+'/sso/start';
-      }).catch((error) => {
+      this.loginProcessing = true;
+      try {
+        await ServerManagementService.checkHealth();
+      } catch (error) {
         this.isLoginServerErrorModalActive = true;
-      })
+        this.loginProcessing = false;
+        return;
+      }
+
+      // Log them out of openid
+      try {
+        await UserService.openIdLogout();
+      } catch (error) {
+        Vue.$log.error(error);
+      }
+
+      // Start login process
+      window.location.href = process.env.VUE_APP_BI_API_ROOT+'/sso/start';
     }
 
   }

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -268,8 +268,6 @@
     public sessionExpired!: boolean;
     @Prop()
     public loginError!: boolean;
-    @Prop()
-    public openIdLogoutUrl!: String;
 
     mounted() {
       if (this.loginRedirect || this.sessionExpired || this.loginError){

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -198,7 +198,8 @@
       <button
           id="connect-orcid-button"
           class="button orcidBtn"
-          v-bind:class="{'is-loading': loginProcessing, 'disabled': loginProcessing}"
+          v-bind:class="{'is-loading': loginProcessing}"
+          v-bind:disabled="loginProcessing"
           v-on:click="orcidLogin"
       >
         SIGN IN with ORCID

--- a/src/views/NotAuthorized.vue
+++ b/src/views/NotAuthorized.vue
@@ -25,7 +25,7 @@
           <a href="#!">contact your breeding program leader</a> or
           <a href="#!">Breeding Insight support</a>.
         </p>
-        <router-link v-bind:to="{name:'home'}">
+        <router-link v-bind:to="{name:'home'}" v-bind:replace="true">
           Return to Home Page
         </router-link>
       </div>


### PR DESCRIPTION
Fixes issue with the nonce token (a token in the openid handshake that identifies a request upon return to open id requestor) expiring during the login process. The token still expires, but a bad token validation is handled and the user is notified on the front page to try again. I increase the expiration time to 10 minutes (it was 5 minutes). 

I also included a way to log out of open id before beginning the login process. This should be able to handle any Open ID provider if they have a logout URI. The logout url isn't required, and the process skips over that part if the logout attempt fails, or if the url isn't provided in the config. 

# Dependent PRs
https://github.com/Breeding-Insight/bi-api/pull/51

# Testing

1. Try changing the cookie expiration to 1s and check that you get the right page (see below)
2. Try logging in with an OrcID without a BI account, make sure you still get the right not authorized page. Make sure you can log into a good OrcID account after that. 
3. Try logging into an OrcID account, then log out, and then try logging in again. Make sure the orcid page pops up. 

# The way things should look

Here is the message the user gets when the authentication has timed out. 

![screencapture-localhost-8080-2020-10-19-15_28_55](https://user-images.githubusercontent.com/17887341/96508306-65bfea00-1228-11eb-96c1-8454631e6143.png)

Here is a loading wheel I added to the OrcID button after you click it. I added this because we now have two calls in the login process, a BI backend health check and an orcid logout. If they take a few beats it lets the user know we are doing stuff. 
![screencapture-localhost-8080-401-2020-10-19-16_33_04](https://user-images.githubusercontent.com/17887341/96508554-c6e7bd80-1228-11eb-86de-006ac6a6db32.png)

Unchanged is our not authorized screen.  
![screencapture-localhost-8080-2020-10-19-15_27_48](https://user-images.githubusercontent.com/17887341/96508364-7a03e700-1228-11eb-83d8-8b88b444329a.png)
