### PR TITLE
[BI-379] Display web and API build version on UI

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,6 @@ name: Release Drafter
 on:
   workflow_dispatch:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - master
   pull_request:
@@ -15,9 +14,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - name: Update Draft
+        id: update_draft
+        uses: release-drafter/release-drafter@v5
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        if: github.event_name == 'push'
+        uses: actions/checkout@v2
+      - name: Update version
+        if: github.event_name == 'push'
+        run: 'sed -i -E "s/\"version\": \"(v[0-9]*\.[0-9]*\.[0-9]*).*,/\"version\": \"\1+${{ steps.update_draft.outputs.name }}\",/" package.json'
+      - name: Update version info
+        if: github.event_name == 'push'
+        run: 'sed -i -E "s~\"versionInfo\": \".*~\"versionInfo\": \"https://github.com/Breeding-Insight/test-project/releases/tag/${{ steps.update_draft.outputs.tag_name }}\",~" package.json'
+      - name: Commit files
+        if: github.event_name == 'push'
+        run: |
+          git config --local user.email "bidevteam@cornell.edu"
+          git config --local user.name "rob-ouser-bi"
+          git add .
+          git commit -m "[autocommit] Updating version info in package.json"
+      - name: Push changes  # push the output folder to your repo
+        if: github.event_name == 'push'
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.ROB_OUSER_TOKEN }}
+          branch: ${{ github.ref }}
+          force: true

--- a/.github/workflows/versioner-develop.yml
+++ b/.github/workflows/versioner-develop.yml
@@ -1,0 +1,29 @@
+name: Versioning (develop)
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update version
+        run: sed -i -E 's/"version": "(v[0-9]*\.[0-9]*\.[0-9]*).*,/"version": "\1+${{ github.run_number }}",/' package.json
+      - name: Update version info
+        run: sed -i -E 's/"versionInfo": "(http.*\/).*/"versionInfo": "\1${{ github.sha }}",/' package.json
+      - name: Commit package.json
+        run: |
+          git config --local user.email "bidevteam@cornell.edu"
+          git config --local user.name "rob-ouser-bi"
+          git add .
+          git commit -m "bumping build # of version info"
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.ROB_OUSER_TOKEN }}
+          branch: ${{ github.ref }}
+          force: true

--- a/.github/workflows/versioner-develop.yml
+++ b/.github/workflows/versioner-develop.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Update version
-        run: sed -i -E 's/"version": "(v[0-9]*\.[0-9]*\.[0-9]*).*,/"version": "\1+${{ github.run_number }}",/' package.json
+        run: 'sed -i -E "s/\"version\": \"(v[0-9]*\.[0-9]*\.[0-9]*).*,/\"version\": \"\1+${{ github.run_number }}\",/" package.json'
       - name: Update version info
-        run: sed -i -E 's/"versionInfo": "(http.*\/).*/"versionInfo": "\1${{ github.sha }}",/' package.json
+        run: 'sed -i -E "s/\"versionInfo\": \"(http.*\/).*/\"versionInfo\": \"\1${{ github.sha }}\",/" package.json'
       - name: Commit package.json
         run: |
           git config --local user.email "bidevteam@cornell.edu"

--- a/.github/workflows/versioner-develop.yml
+++ b/.github/workflows/versioner-develop.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Update version
         run: 'sed -i -E "s/\"version\": \"(v[0-9]*\.[0-9]*\.[0-9]*).*,/\"version\": \"\1+${{ github.run_number }}\",/" package.json'
       - name: Update version info
-        run: 'sed -i -E "s/\"versionInfo\": \"(http.*\/).*/\"versionInfo\": \"\1${{ github.sha }}\",/" package.json'
+        run: 'sed -i -E "s~\"versionInfo\": \".*~\"versionInfo\": \"https://github.com/Breeding-Insight/bi-api/commit/${{ github.sha }}\",~" package.json'
       - name: Commit package.json
         run: |
           git config --local user.email "bidevteam@cornell.edu"
           git config --local user.name "rob-ouser-bi"
           git add .
-          git commit -m "bumping build # of version info"
+          git commit -m "[autocommit] bumping build number"
       - name: Push changes
         uses: ad-m/github-push-action@v0.6.0
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "0.1.0",
+  "version": "v0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2015,16 +2015,6 @@
       "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
       "dev": true
     },
-    "@types/mini-css-extract-plugin": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.1.tgz",
-      "integrity": "sha512-+mN04Oszdz9tGjUP/c1ReVwJXxSniLd7lF++sv+8dkABxVNthg6uccei+4ssKxRHGoMmPxdn7uBdJWONSJGTGQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/webpack": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2694,6 +2684,16 @@
           "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "array-union": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -2731,6 +2731,34 @@
               }
             }
           }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
         },
         "dir-glob": {
           "version": "2.2.2",
@@ -2778,6 +2806,39 @@
             }
           }
         },
+        "fork-ts-checker-webpack-plugin-v5": {
+          "version": "npm:fork-ts-checker-webpack-plugin@5.2.0",
+          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.0.tgz",
+          "integrity": "sha512-NEKcI0+osT5bBFZ1SFGzJMQETjQWZrSvMO1g0nAR/w0t328Z41eN8BJEIZyFCl2HsuiJpa9AN474Nh2qLVwGLQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@types/json-schema": "^7.0.5",
+            "chalk": "^4.1.0",
+            "cosmiconfig": "^6.0.0",
+            "deepmerge": "^4.2.2",
+            "fs-extra": "^9.0.0",
+            "memfs": "^3.1.2",
+            "minimatch": "^3.0.4",
+            "schema-utils": "2.7.0",
+            "semver": "^7.3.2",
+            "tapable": "^1.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -2815,6 +2876,13 @@
             "slash": "^2.0.0"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2839,6 +2907,17 @@
                 "is-buffer": "^1.1.5"
               }
             }
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
           }
         },
         "micromatch": {
@@ -2879,11 +2958,28 @@
             }
           }
         },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true,
+          "optional": true
+        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         },
         "to-regex-range": {
           "version": "2.1.1",
@@ -2894,6 +2990,13 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3152,6 +3255,17 @@
             }
           }
         },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "chownr": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -3353,6 +3467,13 @@
               "dev": true
             }
           }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
         },
         "ignore": {
           "version": "3.3.10",
@@ -3583,6 +3704,16 @@
             "strip-ansi": "^6.0.0"
           }
         },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
         "terser-webpack-plugin": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
@@ -3725,6 +3856,42 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
+          }
+        },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.0.0-beta.8",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-beta.8.tgz",
+          "integrity": "sha512-oouKUQWWHbSihqSD7mhymGPX1OQ4hedzAHyvm8RdyHh6m3oIvoRF+NM45i/bhNOlo8jCnuJhaSUf/6oDjv978g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
+          },
+          "dependencies": {
+            "json5": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+              "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "loader-utils": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+              "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+              }
+            }
           }
         },
         "wrap-ansi": {
@@ -5920,9 +6087,9 @@
       "dev": true
     },
     "bulma": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.0.tgz",
-      "integrity": "sha512-rV75CJkubNUroAt0qCRkjznZLoaXq/ctfMXsMvKSL84UetbSyx5REl96e8GoQ04G4Tkw0XF3STECffTOQrbzOQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.1.tgz",
+      "integrity": "sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA==",
       "dev": true
     },
     "bulma-divider": {
@@ -9507,122 +9674,6 @@
         }
       }
     },
-    "fork-ts-checker-webpack-plugin-v5": {
-      "version": "npm:fork-ts-checker-webpack-plugin@5.1.0",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.1.0.tgz",
-      "integrity": "sha512-vuKyEjSLGbhQbEr5bifXXOkr9iV73L6n72mHoHIv7okvrf7O7z6RKeplM6C6ATPsukoQivij+Ba1vcptL60Z2g==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@types/json-schema": "^7.0.5",
-        "chalk": "^4.1.0",
-        "cosmiconfig": "^6.0.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^9.0.0",
-        "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
-        "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
-        "tapable": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -13128,30 +13179,6 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
       "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
       "dev": true
-    },
-    "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
-      }
     },
     "locate-path": {
       "version": "5.0.0",
@@ -19096,79 +19123,6 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
-          }
-        }
-      }
-    },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-beta.5.tgz",
-      "integrity": "sha512-ciWfzNefqWlmzKznCWY9hl+fPP4KlQ0A9MtHbJ/8DpyY+dAM8gDrjufIdxwTgC4szE4EZC3A6ip/BbrqM84GqA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/mini-css-extract-plugin": "^0.9.1",
-        "chalk": "^3.0.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^1.2.3",
-        "merge-source-map": "^1.1.0",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "0.1.0",
+  "version": "v0.2.0",
   "private": true,
   "scripts": {
     "build": "node $npm_package_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -52,7 +52,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.9.0",
     "babel-preset-env": "^1.7.0",
-    "bulma": "^0.9.0",
+    "bulma": "^0.9.1",
     "bulma-divider": "^0.2.0",
     "chai": "^4.1.2",
     "eslint": "^5.16.0",
@@ -71,5 +71,6 @@
     "vue-template-compiler": "^2.6.10"
   },
   "devport": "8080",
-  "task_path": "./task"
+  "task_path": "./task",
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/c5f0c0676347564f7b3efab88feb62e3884e889c"
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,7 @@
       <SandboxCoordinatorNotification v-bind:active.sync="showCoordinatorSandboxNotification" class="is-marginless"></SandboxCoordinatorNotification>
       <WarningNotification ref="warningNotification" class="is-marginless"></WarningNotification>
     </div>
-    
+
     <component v-bind:is="layout" v-bind:username="username" @logout="logOut">
         <router-view
             @show-success-notification="showSuccessNotification"
@@ -35,60 +35,8 @@
         />
     </component>
 
-    <footer class="footer">
-      <div class="level">
-        <div class="level-left">
-          <nav class="level-item">
-            <div class="level">
-              <div class="level-item">
-                <a href="/">Terms of Use</a>
-              </div>
-              <div class="level-item">
-                <a href="/">Privacy Policy</a>
-              </div>
-              <div class="level-item">
-                <a href="/">Contact Us</a>
-              </div>
-              <div class="level-item">
-                <a href="/">About</a>
-              </div>
-            </div>
-          </nav>
-        </div>
+    <Footer />
 
-        <div class="level-right">
-
-          <div class="level-item">
-            <p class="has-text-right is-hidden-touch">
-              <strong>&copy; 2020 Breeding Insight</strong>
-              <br>
-              Funded by the USDA through Cornell University
-            </p>
-            <p class="has-text-centered is-hidden-desktop">
-              <strong>&copy; 2020 Breeding Insight</strong>
-              <br>
-              Funded by the USDA through Cornell University
-            </p>
-          </div>
-          <div class="level-item">
-            <img 
-            src="./assets/img/usda.svg" 
-            alt="USDA Logo" 
-            width="75" 
-            >
-          </div>
-          <div class="level-item">
-            <img 
-            src="./assets/img/cornell_seal.svg" 
-            alt="Cornell University Logo" 
-            width="56" 
-            >
-          </div>
-          
-        </div>
-      </div>
-    </footer>
-      
   </div>
 </template>
 
@@ -104,6 +52,7 @@ import SandboxPublicNotification from "@/components/notifications/SandboxPublicN
 import SandboxCoordinatorNotification from "@/components/notifications/SandboxCoordinatorNotification.vue";
 import {SandboxMode} from "@/util/config";
 import WarningNotification from "@/components/notifications/WarningNotification.vue";
+import Footer from "@/components/layouts/Footer";
 
 @Component({
   watch: {
@@ -137,7 +86,8 @@ import WarningNotification from "@/components/notifications/WarningNotification.
     ErrorNotification,
     simpleLayout: SimpleLayout,
     userSideBarLayout: UserSideBarLayout,
-    noSideBarLayout: NoSideBarLayout
+    noSideBarLayout: NoSideBarLayout,
+    Footer
   }
 })
 export default class App extends Vue {

--- a/src/App.vue
+++ b/src/App.vue
@@ -52,7 +52,7 @@ import SandboxPublicNotification from "@/components/notifications/SandboxPublicN
 import SandboxCoordinatorNotification from "@/components/notifications/SandboxCoordinatorNotification.vue";
 import {SandboxMode} from "@/util/config";
 import WarningNotification from "@/components/notifications/WarningNotification.vue";
-import Footer from "@/components/layouts/Footer";
+import Footer from "@/components/layouts/Footer.vue";
 
 @Component({
   watch: {

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -300,6 +300,7 @@ nav.tabs li.is-active {
 }
 
 .side-menu {
+  position: relative;
   background-color: $darkmenu;
   padding: 1em 1em 1em 0;
   p {
@@ -418,4 +419,15 @@ a.is-underlined {
   margin: 0 .5em 0 .5em;
   padding: 0;
   float: left;
+}
+
+#versionInfo {
+  position: absolute;
+  bottom: 10px;
+  color: white;
+  width: 100%;
+
+  a {
+    color: white;
+  }
 }

--- a/src/breeding-insight/dao/ServerManagementDAO.ts
+++ b/src/breeding-insight/dao/ServerManagementDAO.ts
@@ -17,6 +17,7 @@
 
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
+import { ApiInfo } from '@/breeding-insight/model/ApiInfo';
 
 export class ServerManagementDAO {
 
@@ -30,6 +31,19 @@ export class ServerManagementDAO {
         reject(error);
       })
 
+    }))
+  }
+
+  static getApiInfo() {
+    return new Promise<ApiInfo>(((resolve, reject) => {
+      api.call({
+        url: `${process.env.VUE_APP_BI_API_V1_PATH}/server-info`,
+        method: 'get'
+      }).then((response:any) => {
+        resolve(new ApiInfo(response.data.version, response.data.versionInfo));
+      }).catch((error) => {
+        reject(error);
+      })
     }))
   }
 }

--- a/src/breeding-insight/model/ApiInfo.ts
+++ b/src/breeding-insight/model/ApiInfo.ts
@@ -1,6 +1,5 @@
 /*
- * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +14,12 @@
  * limitations under the License.
  */
 
-const fs = require('fs')
-const packageJson = fs.readFileSync('./package.json')
-const version = JSON.parse(packageJson).version || 0
-const versionInfo = JSON.parse(packageJson).versionTag || 0
+export class ApiInfo {
+  version?: string;
+  versionInfo?: string;
 
-process.env.VUE_APP_VERSION = version;
-process.env.VUE_APP_VERSION_INFO = versionInfo;
-
-module.exports = {
-  devServer: {
-    disableHostCheck: true
+  constructor(version?:string, versionInfo?:string) {
+    this.version = version;
+    this.versionInfo = versionInfo;
   }
-};
+}

--- a/src/components/layouts/BaseSideBarLayout.vue
+++ b/src/components/layouts/BaseSideBarLayout.vue
@@ -67,6 +67,11 @@
             <slot name="menu"></slot>
           </aside>
         </nav>
+        <div id="versionInfo" class="is-size-7 is-justify-content-center is-align-content-center is-flex">
+          <span class="is-centered">
+            <a :href="versionInfo" target="_blank">web {{versionName}}</a> / <a :href="apiVersionInfo" target="_blank">api {{ apiVersionName }}</a>
+          </span>
+        </div>
       </div>
 
 
@@ -97,6 +102,8 @@
   import {Component, Prop, Watch, Vue} from 'vue-property-decorator'
   import { MenuIcon } from 'vue-feather-icons'
   import {SandboxMode} from '@/util/config'
+  import * as api from "@/util/api";
+  import {ApiInfo} from "@/breeding-insight/model/ApiInfo";
 
 
   @Component( {
@@ -105,9 +112,14 @@
   export default class SideBarMaster extends Vue {
     sideMenuShownMobile: boolean = false;
     SandboxMode = SandboxMode;
+    apiInfo: ApiInfo = new ApiInfo("v0.0.0", "");
 
     @Prop()
     username!: string;
+
+    mounted() {
+      this.fetchApiVersion();
+    }
 
     @Watch('$route')
     onUrlChange(){
@@ -116,6 +128,31 @@
 
     get sandboxConfig() {
       return process.env.VUE_APP_SANDBOX;
+    }
+
+    get versionName() {
+      return process.env.VUE_APP_VERSION;
+    }
+
+    get versionInfo () {
+      return process.env.VUE_APP_VERSION_INFO;
+    }
+
+    get apiVersionName() {
+      return this.apiInfo.version;
+    }
+
+    get apiVersionInfo () {
+      return this.apiInfo.versionInfo;
+    }
+
+    private fetchApiVersion () {
+      api.call({
+        url: `${process.env.VUE_APP_BI_API_V1_PATH}/serverInfo`,
+        method: 'get'
+      }).then((response:any) => {
+        this.apiInfo = new ApiInfo(response.data.version, response.data.versionInfo);
+      })
     }
   }
 

--- a/src/components/layouts/BaseSideBarLayout.vue
+++ b/src/components/layouts/BaseSideBarLayout.vue
@@ -69,7 +69,7 @@
         </nav>
         <div id="versionInfo" class="is-size-7 is-justify-content-center is-align-content-center is-flex">
           <span class="is-centered">
-            <a :href="versionInfo" target="_blank">web {{versionName}}</a> / <a :href="apiVersionInfo" target="_blank">api {{ apiVersionName }}</a>
+            <VersionInfo />
           </span>
         </div>
       </div>
@@ -99,27 +99,21 @@
 </template>
 
 <script lang="ts">
-  import {Component, Prop, Watch, Vue} from 'vue-property-decorator'
-  import { MenuIcon } from 'vue-feather-icons'
-  import {SandboxMode} from '@/util/config'
-  import * as api from "@/util/api";
-  import {ApiInfo} from "@/breeding-insight/model/ApiInfo";
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { MenuIcon } from 'vue-feather-icons';
+import { SandboxMode } from '@/util/config';
+import VersionInfo from '@/components/layouts/VersionInfo.vue';
 
 
-  @Component( {
-    components: {MenuIcon}
+@Component( {
+    components: { VersionInfo, MenuIcon}
   })
   export default class SideBarMaster extends Vue {
     sideMenuShownMobile: boolean = false;
     SandboxMode = SandboxMode;
-    apiInfo: ApiInfo = new ApiInfo("v0.0.0", "");
 
     @Prop()
     username!: string;
-
-    mounted() {
-      this.fetchApiVersion();
-    }
 
     @Watch('$route')
     onUrlChange(){
@@ -128,31 +122,6 @@
 
     get sandboxConfig() {
       return process.env.VUE_APP_SANDBOX;
-    }
-
-    get versionName() {
-      return process.env.VUE_APP_VERSION;
-    }
-
-    get versionInfo () {
-      return process.env.VUE_APP_VERSION_INFO;
-    }
-
-    get apiVersionName() {
-      return this.apiInfo.version;
-    }
-
-    get apiVersionInfo () {
-      return this.apiInfo.versionInfo;
-    }
-
-    private fetchApiVersion () {
-      api.call({
-        url: `${process.env.VUE_APP_BI_API_V1_PATH}/serverInfo`,
-        method: 'get'
-      }).then((response:any) => {
-        this.apiInfo = new ApiInfo(response.data.version, response.data.versionInfo);
-      })
     }
   }
 

--- a/src/components/layouts/BaseSideBarLayout.vue
+++ b/src/components/layouts/BaseSideBarLayout.vue
@@ -63,7 +63,7 @@
           :class="{ 'is-hidden-touch': !sideMenuShownMobile }"
       >
         <nav role="navigation" aria-label="main navigation">
-          <aside id="sideMenu" class="menu">
+          <aside id="sideMenu" class="menu mb-5">
             <slot name="menu"></slot>
           </aside>
         </nav>

--- a/src/components/layouts/Footer.vue
+++ b/src/components/layouts/Footer.vue
@@ -68,13 +68,13 @@
         </div>
       </div>
     </div>
-    <div class="level">
-      <div class="level-left"></div>
-      <div class="level-right">
+    <div v-if="showVersionInfo" class="level">
+      <div class="level-left">
         <div class="level-item is-size-7">
           <a :href="versionInfo" target="_blank">web {{ versionName }}</a> / <a :href="apiVersionInfo" target="_blank">api {{ apiVersionName }}</a>
         </div>
       </div>
+      <div class="level-right"></div>
     </div>
   </footer>
 </template>
@@ -106,6 +106,10 @@ export default class Footer extends Vue {
 
   get apiVersionInfo () {
     return this.apiInfo.versionInfo;
+  }
+
+  get showVersionInfo() {
+    return !this.$route.meta.layout || this.$route.meta.layout == "simple" || this.$route.meta.layout == "noSideBar";
   }
 
   fetchApiVersion () {

--- a/src/components/layouts/Footer.vue
+++ b/src/components/layouts/Footer.vue
@@ -1,0 +1,125 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <footer class="footer">
+    <div class="level mb-4">
+      <div class="level-left">
+        <nav class="level-item">
+          <div class="level">
+            <div class="level-item">
+              <a href="/">Terms of Use</a>
+            </div>
+            <div class="level-item">
+              <a href="/">Privacy Policy</a>
+            </div>
+            <div class="level-item">
+              <a href="/">Contact Us</a>
+            </div>
+            <div class="level-item">
+              <a href="/">About</a>
+            </div>
+          </div>
+        </nav>
+      </div>
+
+      <div class="level-right">
+
+        <div class="level-item">
+          <div class="level-item">
+            <p class="has-text-right is-hidden-touch">
+              <strong>&copy; 2020 Breeding Insight</strong>
+              <br>
+              Funded by the USDA through Cornell University
+            </p>
+            <p class="has-text-centered is-hidden-desktop">
+              <strong>&copy; 2020 Breeding Insight</strong>
+              <br>
+              Funded by the USDA through Cornell University
+            </p>
+          </div>
+          <div class="level-item">
+            <img
+                src="../../assets/img/usda.svg"
+                alt="USDA Logo"
+                width="75"
+            >
+          </div>
+          <div class="level-item">
+            <img
+                src="../../assets/img/cornell_seal.svg"
+                alt="Cornell University Logo"
+                width="56"
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="level">
+      <div class="level-left"></div>
+      <div class="level-right">
+        <div class="level-item is-size-7">
+          <a :href="versionInfo" target="_blank">web {{ versionName }}</a> / <a :href="apiVersionInfo" target="_blank">api {{ apiVersionName }}</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<script lang="ts">
+import {Component, Prop, Watch, Vue} from 'vue-property-decorator'
+import * as api from "@/util/api";
+import {ApiInfo} from "@/breeding-insight/model/ApiInfo";
+
+@Component
+export default class Footer extends Vue {
+  private apiInfo: ApiInfo = new ApiInfo("v0.0.0", "");
+
+  mounted() {
+    this.fetchApiVersion();
+  }
+
+  get versionName() {
+    console.log("version name: "+process.env.VUE_APP_VERSION);
+    return process.env.VUE_APP_VERSION;
+  }
+
+  get versionInfo () {
+    console.log("version info: "+process.env.VUE_APP_VERSION_INFO);
+    return process.env.VUE_APP_VERSION_INFO;
+  }
+
+  get apiVersionName() {
+    // console.log("api version name: "+this.apiInfo.version);
+    return this.apiInfo.version;
+  }
+
+  get apiVersionInfo () {
+    // console.log("api version info: "+this.apiInfo.versionInfo);
+    return this.apiInfo.versionInfo;
+  }
+
+  fetchApiVersion () {
+    api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/serverInfo`,
+      method: 'get'
+    }).then((response:any) => {
+      this.apiInfo = new ApiInfo(response.data.version, response.data.versionInfo);
+    })
+  }
+}
+
+</script>

--- a/src/components/layouts/Footer.vue
+++ b/src/components/layouts/Footer.vue
@@ -71,7 +71,7 @@
     <div v-if="showVersionInfo" class="level">
       <div class="level-left">
         <div class="level-item is-size-7">
-          <a :href="versionInfo" target="_blank">web {{ versionName }}</a> / <a :href="apiVersionInfo" target="_blank">api {{ apiVersionName }}</a>
+          <VersionInfo/>
         </div>
       </div>
       <div class="level-right"></div>
@@ -80,45 +80,15 @@
 </template>
 
 <script lang="ts">
-import {Component, Prop, Watch, Vue} from 'vue-property-decorator'
-import * as api from "@/util/api";
-import {ApiInfo} from "@/breeding-insight/model/ApiInfo";
+import { Component, Vue } from 'vue-property-decorator';
+import VersionInfo from '@/components/layouts/VersionInfo.vue';
 
-@Component
+@Component({
+  components: { VersionInfo }
+})
 export default class Footer extends Vue {
-  private apiInfo: ApiInfo = new ApiInfo("v0.0.0", "");
-
-  mounted() {
-    this.fetchApiVersion();
-  }
-
-  get versionName() {
-    return process.env.VUE_APP_VERSION;
-  }
-
-  get versionInfo () {
-    return process.env.VUE_APP_VERSION_INFO;
-  }
-
-  get apiVersionName() {
-    return this.apiInfo.version;
-  }
-
-  get apiVersionInfo () {
-    return this.apiInfo.versionInfo;
-  }
-
-  get showVersionInfo() {
-    return !this.$route.meta.layout || this.$route.meta.layout == "simple" || this.$route.meta.layout == "noSideBar";
-  }
-
-  fetchApiVersion () {
-    api.call({
-      url: `${process.env.VUE_APP_BI_API_V1_PATH}/serverInfo`,
-      method: 'get'
-    }).then((response:any) => {
-      this.apiInfo = new ApiInfo(response.data.version, response.data.versionInfo);
-    })
+  get showVersionInfo () {
+    return !this.$route.meta.layout || this.$route.meta.layout == 'simple' || this.$route.meta.layout == 'noSideBar';
   }
 }
 

--- a/src/components/layouts/Footer.vue
+++ b/src/components/layouts/Footer.vue
@@ -93,22 +93,18 @@ export default class Footer extends Vue {
   }
 
   get versionName() {
-    console.log("version name: "+process.env.VUE_APP_VERSION);
     return process.env.VUE_APP_VERSION;
   }
 
   get versionInfo () {
-    console.log("version info: "+process.env.VUE_APP_VERSION_INFO);
     return process.env.VUE_APP_VERSION_INFO;
   }
 
   get apiVersionName() {
-    // console.log("api version name: "+this.apiInfo.version);
     return this.apiInfo.version;
   }
 
   get apiVersionInfo () {
-    // console.log("api version info: "+this.apiInfo.versionInfo);
     return this.apiInfo.versionInfo;
   }
 

--- a/src/components/layouts/VersionInfo.vue
+++ b/src/components/layouts/VersionInfo.vue
@@ -1,0 +1,67 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <span>
+    <a :href="versionInfo" target="_blank">web {{ versionName }}</a> /
+    <a :href="apiVersionInfo" target="_blank"> api
+      <template v-if="apiInfoLoading"><span class="is-italic">loading</span></template>
+      <template v-else>{{ apiVersionName }}</template>
+    </a>
+  </span>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import { ApiInfo } from '@/breeding-insight/model/ApiInfo';
+import { ServerManagementDAO } from '@/breeding-insight/dao/ServerManagementDAO';
+
+@Component
+export default class VersionInfo extends Vue {
+  private apiInfo: ApiInfo = new ApiInfo('', '');
+  private apiInfoLoading = true;
+
+  mounted () {
+    this.fetchApiVersion();
+  }
+
+  get versionName () {
+    return process.env.VUE_APP_VERSION;
+  }
+
+  get versionInfo () {
+    return process.env.VUE_APP_VERSION_INFO;
+  }
+
+  get apiVersionName () {
+    return this.apiInfo.version;
+  }
+
+  get apiVersionInfo () {
+    return this.apiInfo.versionInfo;
+  }
+
+  fetchApiVersion () {
+    ServerManagementDAO.getApiInfo().then(value => {
+      this.apiInfo = value;
+      this.apiInfoLoading = false;
+    }).catch(() => {
+      this.apiInfo = new ApiInfo("unknown", "");
+      this.apiInfoLoading = false;
+    });
+  }
+}
+</script>


### PR DESCRIPTION
# Overview
Display the current version of both bi-web and bi-api on the page, and provide a link to the GitHub release (or commit if running `develop`).  This can be useful for debugging purposes, as well as for identifying what features are deployed to a given server.  The implementation of updating and sharing version info of bi-api is in https://github.com/Breeding-Insight/bi-api/pull/54.  Here's a design of placement of the version info:

![image](https://user-images.githubusercontent.com/3004635/97366006-fa57c700-187c-11eb-8931-0f0cc3158bd4.png)

## Implementation
The version information for bi-web is stored in `package.json`.  The version name is stored in the `version` property, and a link to the release (or commit) is stored in a custom property named `versionInfo`.  These properties are automatically updated and committed to the repo via GitHub Actions.  

When merging to `master`, the action will use the output from release-drafter to set `version` to the name generated by release-drafter and `versionInfo` to a link to the eventual tag that will be created for the release.

When merging to `develop`, a different action will update the `version` property to be whatever the current version number is, and then append the build number of the action.  For example, if the version name is `v0.2.0`, and the action is running for the 10th time, then the resulting version name on the `develop` branch will be `v0.2.0+10`.  The `versionInfo` property will be set to the merge commit that triggered the action.

## Changes from design
The version info shows both the web and api versions separated by a forward slash.  For example: `web 0.2.0 / api 0.2.1`

## Requested Input

The design has the version information in the footer of the menu side panel.  However, if the user is not logged in, or is on a page that doesn't display a side panel, then they will not see any version information.  I took some liberty in seeing what it would look like if the version information was in the page footer.  If you could, please let me know your thoughts, and I'll adjust the display after collecting feedback:

![Screen Shot 2020-10-27 at 5 55 25 PM](https://user-images.githubusercontent.com/3004635/97366531-d943a600-187d-11eb-8d00-0c8b1118603b.png)

![Screen Shot 2020-10-27 at 5 56 00 PM](https://user-images.githubusercontent.com/3004635/97366533-da74d300-187d-11eb-8656-c05e474d43d8.png)

