### PR TITLE
[BI-85,BI-646] - Create new trait UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,6 +1155,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "@creativebulma/bulma-divider": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@creativebulma/bulma-divider/-/bulma-divider-1.1.0.tgz",
+      "integrity": "sha512-Lx5MlUhgAnTF+wNZ5LXcaE1K0F2m0Pkwte1p08FBsIyRV6Oq7BuKPk/O9XJPcF+vR6BjCxNy/hjYFXtNmoXbNg==",
+      "dev": true
+    },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
@@ -2578,16 +2584,6 @@
           "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "array-union": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -2625,34 +2621,6 @@
               }
             }
           }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
         },
         "dir-glob": {
           "version": "2.2.2",
@@ -2700,39 +2668,6 @@
             }
           }
         },
-        "fork-ts-checker-webpack-plugin-v5": {
-          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@types/json-schema": "^7.0.5",
-            "chalk": "^4.1.0",
-            "cosmiconfig": "^6.0.0",
-            "deepmerge": "^4.2.2",
-            "fs-extra": "^9.0.0",
-            "memfs": "^3.1.2",
-            "minimatch": "^3.0.4",
-            "schema-utils": "2.7.0",
-            "semver": "^7.3.2",
-            "tapable": "^1.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -2770,13 +2705,6 @@
             "slash": "^2.0.0"
           }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2800,26 +2728,6 @@
               "requires": {
                 "is-buffer": "^1.1.5"
               }
-            }
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true,
-              "optional": true
             }
           }
         },
@@ -2861,28 +2769,11 @@
             }
           }
         },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true,
-          "optional": true
-        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         },
         "to-regex-range": {
           "version": "2.1.1",
@@ -2893,13 +2784,6 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -3156,17 +3040,6 @@
             }
           }
         },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "chownr": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -3306,13 +3179,6 @@
             }
           }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
         "ignore": {
           "version": "3.3.10",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
@@ -3443,16 +3309,6 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         },
         "terser-webpack-plugin": {
@@ -3597,42 +3453,6 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.0.0-rc.1",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-rc.1.tgz",
-          "integrity": "sha512-yR+BS90EOXTNieasf8ce9J3TFCpm2DGqoqdbtiwQ33hon3FyIznLX7sKavAq1VmfBnOeV6It0Htg4aniv8ph1g==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
-          },
-          "dependencies": {
-            "json5": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-              "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minimist": "^1.2.5"
-              }
-            },
-            "loader-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-              "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-              }
-            }
           }
         },
         "wrap-ansi": {
@@ -5764,18 +5584,12 @@
       }
     },
     "buefy": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.8.20.tgz",
-      "integrity": "sha512-pg8Cn0m9cjqp2/vaKT4VIfU8KIumuX/gAT1GtearXRs56+kKqAPx3j9O8cm9W6P4jPUCHajKX6H8AqD0ram2Bg==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.4.tgz",
+      "integrity": "sha512-LRSIYVNrKTPQhmNRegASkntX+ObtZ7aSSA/3cybDKXzGtPNy8g8cl2tp79Rl8/LBVH/KkRT5rmmzJ21nxz9IcQ==",
+      "dev": true,
       "requires": {
-        "bulma": "0.7.5"
-      },
-      "dependencies": {
-        "bulma": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.5.tgz",
-          "integrity": "sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw=="
-        }
+        "bulma": "0.9.1"
       }
     },
     "buffer": {
@@ -9703,6 +9517,130 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
+        }
+      }
+    },
+    "fork-ts-checker-webpack-plugin-v5": {
+      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@types/json-schema": "^7.0.5",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^6.0.0",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^9.0.0",
+        "memfs": "^3.1.2",
+        "minimatch": "^3.0.4",
+        "schema-utils": "2.7.0",
+        "semver": "^7.3.2",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -19205,6 +19143,87 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
+          }
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.0.0-rc.2.tgz",
+      "integrity": "sha512-cz8GK4dgIf1UTC+do80pGvh8BHcCRHLIQVHV9ONVQ8wtoqS9t/+H02rKcQP+TVNg7khgLyQV2+8eHUq7/AFq3g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/promise.allsettled": "^1.0.3",
     "@types/vuelidate": "^0.7.10",
     "@xstate/fsm": "^1.4.0",
-    "buefy": "^0.8.8",
     "core-js": "^3.4.3",
     "focus-trap": "^5.1.0",
     "focus-trap-vue": "0.0.6",
@@ -37,6 +36,7 @@
     "vuex-class": "^0.3.2"
   },
   "devDependencies": {
+    "@creativebulma/bulma-divider": "^1.1.0",
     "@types/chai": "^4.2.7",
     "@types/jest": "^24.9.0",
     "@vue/cli-plugin-babel": "^4.1.0",
@@ -54,6 +54,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.9.0",
     "babel-preset-env": "^1.7.0",
+    "buefy": "^0.9.4",
     "bulma": "^0.9.1",
     "bulma-divider": "^0.2.0",
     "chai": "^4.1.2",

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -79,12 +79,23 @@ $table-striped-row-even-hover-background-color:$link-light;
 
 //$margin-right: 2 rem;
 
+// Import buefy before bulma
+@import "~bulma/sass/utilities/_all";
+
+// Customize buefy if you want to here
+
+
 // Update some of Bulma's component variables
 
 //Enable this import line when Bulma is in a local folder called "bulma"
 //@import 'bulma/bulma';
 // Enable this import line instead when Bulma is in package.json
-@import '../../../node_modules/bulma/bulma.sass';
+@import '~bulma';
+@import "~buefy/src/scss/buefy";
+
+// Bulma extensions
+$divider-margin-inner-size: 0;
+@import "~@creativebulma/bulma-divider";
 
 // Overrides that can't be done with variables go here
 // may be broken out into a separate file later
@@ -170,12 +181,12 @@ footer {
 
 .field {
   &.field--error {
-    & span.form-error {
+    & .field span.form-error {
       display: block;
     }
   }
   &:not(.field--error) {
-    & span.form-error {
+    & .field span.form-error {
       display: none;
     }
   }
@@ -430,4 +441,20 @@ a.is-underlined {
   a {
     color: white;
   }
+}
+
+div.sentence-input {
+  display: flex;
+  align-items: flex-start;
+  p.is-input-prepend {
+  }
+  .field {
+    margin-left: 10px;
+  }
+}
+
+// Buefy messes this up
+.icon svg {
+  fill: none;
+  stroke-width: 2;
 }

--- a/src/breeding-insight/dao/ProgramDAO.ts
+++ b/src/breeding-insight/dao/ProgramDAO.ts
@@ -16,9 +16,10 @@
  */
 
 import {Program} from "@/breeding-insight/model/Program";
-import {BiResponse} from "@/breeding-insight/model/BiResponse";
+import {BiResponse, Response} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+
 
 export class ProgramDAO {
 
@@ -86,6 +87,15 @@ export class ProgramDAO {
       })
 
     }))
+  }
+
+  static async getObservationLevels(programId: string): Promise<BiResponse> {
+
+    const { data } =  await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/observation_level`,
+      method: 'get'
+    }) as Response;
+    return new BiResponse(data);
   }
 
 }

--- a/src/breeding-insight/dao/ProgramDAO.ts
+++ b/src/breeding-insight/dao/ProgramDAO.ts
@@ -92,7 +92,7 @@ export class ProgramDAO {
   static async getObservationLevels(programId: string): Promise<BiResponse> {
 
     const { data } =  await api.call({
-      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/observation_level`,
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/observation-level`,
       method: 'get'
     }) as Response;
     return new BiResponse(data);

--- a/src/breeding-insight/dao/ProgramDAO.ts
+++ b/src/breeding-insight/dao/ProgramDAO.ts
@@ -92,7 +92,7 @@ export class ProgramDAO {
   static async getObservationLevels(programId: string): Promise<BiResponse> {
 
     const { data } =  await api.call({
-      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/observation-level`,
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/observation-levels`,
       method: 'get'
     }) as Response;
     return new BiResponse(data);

--- a/src/breeding-insight/dao/TraitDAO.ts
+++ b/src/breeding-insight/dao/TraitDAO.ts
@@ -16,13 +16,9 @@
  */
 
 import {Trait} from "@/breeding-insight/model/Trait";
-import {BiResponse} from "@/breeding-insight/model/BiResponse";
+import {BiResponse, Response} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
-
-interface Response {
-  data: any
-}
 
 export class TraitDAO {
 

--- a/src/breeding-insight/dao/TraitUploadDAO.ts
+++ b/src/breeding-insight/dao/TraitUploadDAO.ts
@@ -61,5 +61,11 @@ export class TraitUploadDAO {
     }))
   }
 
+  static async confirmUpload(programId: string, traitUploadId: string) {
+    await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/trait-upload/${traitUploadId}`,
+      method: 'post' });
+  }
+
 
 }

--- a/src/breeding-insight/model/BiResponse.ts
+++ b/src/breeding-insight/model/BiResponse.ts
@@ -66,3 +66,7 @@ class Status {
     this.message = statusMap.message;
   }
 }
+
+export interface Response {
+  data: any
+}

--- a/src/breeding-insight/model/Method.ts
+++ b/src/breeding-insight/model/Method.ts
@@ -16,11 +16,11 @@
  */
 
 export enum MethodClass {
-  Computation = "COMPUTATION",
-  Observation = "OBSERVATION",
-  Measurement = "MEASUREMENT",
-  Counting = "COUNTING",
-  Estimation = "ESTIMATION"
+  Computation = "Computation",
+  Observation = "Observation",
+  Measurement = "Measurement",
+  Counting = "Counting",
+  Estimation = "Estimation"
 }
 
 export class Method {
@@ -37,6 +37,6 @@ export class Method {
   }
 
   static methodClassEquals(classString: string, type: MethodClass): boolean {
-    return classString.toUpperCase() === type;
+    return classString.toUpperCase() === type.toUpperCase();
   }
 }

--- a/src/breeding-insight/model/ObservationLevel.ts
+++ b/src/breeding-insight/model/ObservationLevel.ts
@@ -15,14 +15,12 @@
  * limitations under the License.
  */
 
-import {Trait} from "@/breeding-insight/model/Trait";
-
-export class ProgramUpload {
+export class ObservationLevel {
   id?: string;
-  data?: Trait[];
+  name?: string;
 
-  constructor(id?:string, data?:Array<Trait>) {
+  constructor(id?:string, name?:string) {
     this.id = id;
-    this.data = data;
+    this.name = name;
   }
 }

--- a/src/breeding-insight/model/Scale.ts
+++ b/src/breeding-insight/model/Scale.ts
@@ -18,7 +18,6 @@
 import {Category} from "@/breeding-insight/model/Category";
 
 export enum DataType {
-  Code = "CODE",
   Date = "DATE",
   Duration = "DURATION",
   Nominal = "NOMINAL",

--- a/src/breeding-insight/model/Scale.ts
+++ b/src/breeding-insight/model/Scale.ts
@@ -18,12 +18,12 @@
 import {Category} from "@/breeding-insight/model/Category";
 
 export enum DataType {
-  Date = "DATE",
-  Duration = "DURATION",
-  Nominal = "NOMINAL",
-  Numerical = "NUMERICAL",
-  Ordinal = "ORDINAL",
-  Text = "TEXT"
+  Date = "Date",
+  Duration = "Duration",
+  Nominal = "Nominal",
+  Numerical = "Numerical",
+  Ordinal = "Ordinal",
+  Text = "Text"
 }
 
 export class Scale {
@@ -44,6 +44,6 @@ export class Scale {
   }
 
   static dataTypeEquals(typeString: string, type: DataType): boolean {
-    return typeString.toUpperCase() === type;
+    return typeString.toUpperCase() === type.toUpperCase();
   }
 }

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -27,6 +27,7 @@ export class Trait {
   scale?: Scale;
   abbreviations?: Array<string>;
   synonyms?: Array<string>;
+  mainAbbreviation?: string;
 
   constructor(id?:string,
               traitName?:string, 

--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -20,6 +20,7 @@ import {Program} from "@/breeding-insight/model/Program";
 import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
+import {ProgramObservationLevel} from "@/breeding-insight/model/ProgramObservationLevel";
 
 export class ProgramService {
 
@@ -120,6 +121,14 @@ export class ProgramService {
       }).catch((error) => reject(error));
 
     }));
+  }
+
+  static async getObservationLevels(programId: string): Promise<[ProgramObservationLevel[], Metadata] | void> {
+    if (programId) {
+      const { result: { data }, metadata } = await ProgramDAO.getObservationLevels(programId);
+      return [data, metadata];
+    }
+    else return;
   }
 
 }

--- a/src/breeding-insight/service/TraitUploadService.ts
+++ b/src/breeding-insight/service/TraitUploadService.ts
@@ -22,6 +22,7 @@ import {Trait} from "@/breeding-insight/model/Trait";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+import {ProgramDAO} from "@/breeding-insight/dao/ProgramDAO";
 
 export class TraitUploadService {
 
@@ -73,8 +74,8 @@ export class TraitUploadService {
     });
   }
 
-  static getTraits(programId: string, paginationQuery?: PaginationQuery): Promise<[Trait[], Metadata]> {
-    return new Promise<[Trait[], Metadata]>(((resolve, reject) => {
+  static getTraits(programId: string, paginationQuery?: PaginationQuery): Promise<[ProgramUpload, Metadata]> {
+    return new Promise<[ProgramUpload, Metadata]>(((resolve, reject) => {
 
       if (paginationQuery === undefined){
         paginationQuery = new PaginationQuery(0, 0, true);
@@ -96,7 +97,9 @@ export class TraitUploadService {
           [traits, newPagination] = PaginationController.mockPagination(traits, paginationQuery!.page, paginationQuery!.pageSize, paginationQuery!.showAll);
           biResponse.metadata.pagination = newPagination;
 
-          resolve([traits, biResponse.metadata]);
+          let upload: ProgramUpload = new ProgramUpload(biResponse.result.id, traits);
+
+          resolve([upload, biResponse.metadata]);
 
         }).catch((error) => reject(error));
 
@@ -104,6 +107,15 @@ export class TraitUploadService {
         reject();
       }
     }));
+  }
+
+  static async confirmUpload(programId: string, traitUploadId: string): Promise<void|Error> {
+    try {
+      await TraitUploadDAO.confirmUpload(programId, traitUploadId);
+      return;
+    } catch (error) {
+      throw 'Error saving traits';
+    }
   }
 
   static parseError(error: any): ValidationError | string {

--- a/src/components/forms/BaseFieldWrapper.vue
+++ b/src/components/forms/BaseFieldWrapper.vue
@@ -17,27 +17,33 @@
 
 <template>
   <div class="field" v-bind:class="{ 'field--error': fieldError }">
-    <label class="label" v-bind:for="fieldName">
-      {{ fieldName }}
-    </label>
-    <div class="control">
-      <slot></slot>
-      <template v-for="(validationMap, index) in validationSpec">
-        <span
-            data-testid="formError"
-            v-bind:key="fieldName + validationMap.name + index"
-            class="form-error has-text-danger"
-            :class="{ 'is-hidden': ( validateTypeError(validationMap.name) ) }"
-        >
-          {{ validationMap.message }}
-        </span>
-      </template>
-      <p
-          v-if="fieldHelp !== null"
-          class="help"
-      >
-        {{ fieldHelp }}
-      </p>
+    <div class="field-label is-normal has-text-left">
+      <label class="label is-left" v-bind:for="fieldName" v-bind:class="{'is-sr-only': !showLabel}">
+        {{ fieldName }}
+      </label>
+    </div>
+    <div class="field-body">
+      <div class="field">
+        <div class="control">
+          <slot></slot>
+          <template v-for="(validationMap, index) in validationSpec">
+            <span
+                data-testid="formError"
+                v-bind:key="fieldName + validationMap.name + index"
+                class="form-error has-text-danger"
+                :class="{ 'is-hidden': ( validateTypeError(validationMap.name) ) }"
+            >
+              {{ validationMap.message }}
+            </span>
+          </template>
+          <p
+              v-if="fieldHelp !== null"
+              class="help"
+          >
+            {{ fieldHelp }}
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -55,6 +61,8 @@
     fieldHelp!: string;
     @Prop()
     validations!: any;
+    @Prop({default: true})
+    showLabel!: boolean;
 
     get validationSpec(): Object[] {
 

--- a/src/components/forms/BasicSelectField.vue
+++ b/src/components/forms/BasicSelectField.vue
@@ -20,6 +20,7 @@
       v-bind:validations="validations"
       v-bind:field-help="fieldHelp"
       v-bind:field-name="fieldName"
+      v-bind:show-label="showLabel"
   >
     <div class="select is-fullwidth">
       <select
@@ -35,11 +36,11 @@
         </template>
         <option
             v-for="option in options"
-            v-bind:key="option.id"
-            v-bind:selected="option.id === selectedId"
-            v-bind:value="option.id"
+            v-bind:key="option.id || option"
+            v-bind:selected="option.id ? option.id === selectedId : option === selectedId"
+            v-bind:value="option.id || option"
         >
-          {{ option.name }}
+          {{ option.name || option }}
         </option>
       </select>
     </div>
@@ -66,6 +67,8 @@
     validations!: any;
     @Prop()
     emptyValueName!: string;
+    @Prop()
+    showLabel!: boolean;
 
 
     displayDefault() {

--- a/src/components/forms/NewDataForm.vue
+++ b/src/components/forms/NewDataForm.vue
@@ -71,20 +71,22 @@
     }
 
     checkSubmit() {
-      this.$v.newRecord.$touch();
-      if (this.$v.newRecord.$anyError){
+
+      if (this.$v.newRecord) { this.$v.newRecord.$touch(); }
+
+      if (this.$v.newRecord && this.$v.newRecord.$anyError){
 
         this.$emit('show-error-notification', 'Fix Invalid Fields');
         return;
       } else {
 
         this.$emit('submit');
-        this.$v.newRecord.$reset();
+        if (this.$v.newRecord) { this.$v.newRecord.$reset(); }
       }
     }
 
     checkCancel() {
-      this.$v.newRecord.$reset();
+      if (this.$v.newRecord) { this.$v.newRecord.$reset(); }
       this.$emit('cancel');
     }
 

--- a/src/components/forms/NewDataForm.vue
+++ b/src/components/forms/NewDataForm.vue
@@ -23,7 +23,7 @@
     <slot v-bind="getValidation()"></slot>
     <div class="columns">
       <div class="column is-whole has-text-centered buttons">
-        <button data-testid="save" type="button" class="button is-primary" @click="checkSubmit()">
+        <button data-testid="save" type="button" class="button is-primary" @click="checkSubmit()" v-bind:disabled="!saveBtnActive">
           <span class="icon is-small">
             <CheckCircleIcon size="1.5x" aria-hidden="true"></CheckCircleIcon>
             <span class="is-sr-only">Confirm Edits</span>
@@ -52,6 +52,8 @@
     rowValidations!: Object;
     @Prop()
     newRecord!: Object;
+    @Prop({default: true})
+    saveBtnActive!: boolean;
 
     @Validations()
     validations() {

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -55,10 +55,6 @@
         <p class="mb-0">Maximum valid value: {{valueOrNA(trait.scale.validValueMax)}}</p>
       </template>
 
-      <template v-if="scaleType && Scale.dataTypeEquals(scaleType, DataType.Code)">
-        <!-- TODO: Not showing anything for this now -->
-      </template>
-
       <!-- if computation method, show formula as well -->
       <template v-if="methodClass && Method.methodClassEquals(methodClass, MethodClass.Computation)">
         <p class="has-text-weight-bold mt-3 mb-0">Formula</p>

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -35,6 +35,44 @@
       </div>              
     </WarningModal>
 
+    <div class="columns has-text-right mb-0">
+      <div class="column">
+        <button
+            data-testid="newDataForm"
+            v-show="!newTraitActive & traits.length > 0"
+            class="button is-primary has-text-weight-bold"
+            v-on:click="newTraitActive = true"
+        >
+        <span class="icon is-small">
+          <PlusCircleIcon
+              size="1.5x"
+              aria-hidden="true"
+          />
+        </span>
+          <span>
+          New Trait
+        </span>
+        </button>
+      </div>
+    </div>
+
+    <NewDataForm
+        v-if="newTraitActive"
+        v-bind:new-record.sync="newTrait"
+        v-on:submit="saveTrait"
+        v-on:cancel="cancelNewTrait"
+        v-on:show-error-notification="$emit('show-error-notification', $event)"
+    >
+      <template v-slot="validations">
+        <BaseTraitForm
+            v-on:trait-change="newTrait = $event"
+            v-bind:scale-options="scaleClassOptions"
+            v-bind:method-options="methodClassOptions"
+            v-bind:program-observation-levels="observationLevelOptions"
+        ></BaseTraitForm>
+      </template>
+    </NewDataForm>
+
     <SidePanelTable
       v-bind:records.sync="traits"
       v-bind:editable="false"
@@ -76,6 +114,9 @@
 
       <template v-slot:emptyMessage>
         <EmptyTableMessage
+            v-bind:button-view-toggle="!newTraitActive"
+            v-bind:button-text="'New Trait'"
+            v-on:newClick="newTraitActive = true"
         >
           <p class="has-text-weight-bold">
             No traits are currently defined for this program.
@@ -107,10 +148,17 @@ import {PaginationController} from "@/breeding-insight/model/view_models/Paginat
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import { StringFormatters } from '@/breeding-insight/utils/StringFormatters';
 import { TraitStringFormatters } from '@/breeding-insight/utils/TraitStringFormatters';
+import BaseTraitForm from "@/components/trait/forms/BaseTraitForm.vue";
+import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+import {FieldError} from "@/breeding-insight/model/errors/FieldError";
+import {ProgramService} from "@/breeding-insight/service/ProgramService";
+import {MethodClass} from "@/breeding-insight/model/Method";
+import {DataType} from "@/breeding-insight/model/Scale";
 
 @Component({
   mixins: [validationMixin],
-  components: { NewDataForm, BasicInputField, SidePanelTable, EmptyTableMessage, TableColumn,
+  components: {
+    BaseTraitForm, NewDataForm, BasicInputField, SidePanelTable, EmptyTableMessage, TableColumn,
                 WarningModal, TraitDetailPanel,
                 PlusCircleIcon },
   computed: {
@@ -123,6 +171,7 @@ export default class TraitTable extends Vue {
 
   private activeProgram?: Program;
   private traits: Trait[] = [];
+  private newTrait: Trait = new Trait();
   private traitsPagination?: Pagination = new Pagination();
   private paginationController: PaginationController = new PaginationController();
   private deactivateActive: boolean = false;
@@ -131,9 +180,16 @@ export default class TraitTable extends Vue {
   private collapseColumns = false;
   private StringFormatters = StringFormatters;
   private TraitStringFormatters = TraitStringFormatters;
+  private newTraitActive = false;
+  private methodClassOptions: string[] = Object.values(MethodClass);
+  private observationLevelOptions?: string[];
+  private scaleClassOptions: string[] = Object.values(DataType);
 
   mounted() {
     this.getTraits();
+    this.getObservationLevels();
+    console.log(this.methodClassOptions);
+    console.log(this.scaleClassOptions);
   }
 
   @Watch('paginationController', { deep: true})
@@ -152,6 +208,47 @@ export default class TraitTable extends Vue {
       this.$emit('show-error-notification', 'Error while trying to load traits');
       throw error;
     });
+  }
+
+  async saveTrait() {
+    try {
+      console.log(this.newTrait);
+      await TraitService.createTraits(this.activeProgram!.id!, [this.newTrait]);
+      this.$emit('show-success-notification', 'Trait creation successful.');
+      this.getTraits();
+      await this.getObservationLevels();
+      this.newTraitActive = false;
+    } catch (error) {
+      // TODO: Pass errors to the new data form
+      if (error instanceof ValidationError) {
+        const fieldErrors: FieldError[] = error.rows[0].errors;
+        for (const fieldError of fieldErrors) {
+          console.log(fieldError);
+        }
+      }
+
+      this.$emit('show-error-notification', 'Error creating');
+    }
+
+  }
+
+  cancelNewTrait() {
+    this.newTrait = new Trait();
+    this.newTraitActive = false;
+  }
+
+  async getObservationLevels() {
+    try {
+      const response = await ProgramService.getObservationLevels(this.activeProgram!.id!);
+      if (response) {
+        const [observationLevels, metadata] = response;
+        this.observationLevelOptions = observationLevels.map(value => value.name!);
+        return;
+      }
+    } catch (error) {
+      this.$emit('show-error-notification', 'Unable to retrieve observation levels');
+    }
+    this.$emit('show-error-notification', 'Unable to retrieve observation levels');
   }
 
 }

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -188,8 +188,6 @@ export default class TraitTable extends Vue {
   mounted() {
     this.getTraits();
     this.getObservationLevels();
-    console.log(this.methodClassOptions);
-    console.log(this.scaleClassOptions);
   }
 
   @Watch('paginationController', { deep: true})
@@ -212,7 +210,6 @@ export default class TraitTable extends Vue {
 
   async saveTrait() {
     try {
-      console.log(this.newTrait);
       await TraitService.createTraits(this.activeProgram!.id!, [this.newTrait]);
       this.$emit('show-success-notification', 'Trait creation successful.');
       this.getTraits();
@@ -223,7 +220,7 @@ export default class TraitTable extends Vue {
       if (error instanceof ValidationError) {
         const fieldErrors: FieldError[] = error.rows[0].errors;
         for (const fieldError of fieldErrors) {
-          console.log(fieldError);
+          this.$log.error(fieldError);
         }
       }
 

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -59,6 +59,7 @@
     <NewDataForm
         v-if="newTraitActive"
         v-bind:new-record.sync="newTrait"
+        v-bind:save-btn-active="newFormBtnActive"
         v-on:submit="saveTrait"
         v-on:cancel="cancelNewTrait"
         v-on:show-error-notification="$emit('show-error-notification', $event)"
@@ -172,6 +173,7 @@ export default class TraitTable extends Vue {
   private activeProgram?: Program;
   private traits: Trait[] = [];
   private newTrait: Trait = new Trait();
+  private newFormBtnActive: boolean = true;
   private traitsPagination?: Pagination = new Pagination();
   private paginationController: PaginationController = new PaginationController();
   private deactivateActive: boolean = false;
@@ -210,6 +212,7 @@ export default class TraitTable extends Vue {
 
   async saveTrait() {
     try {
+      this.newFormBtnActive = false;
       await TraitService.createTraits(this.activeProgram!.id!, [this.newTrait]);
       this.$emit('show-success-notification', 'Trait creation successful.');
       this.getTraits();
@@ -223,10 +226,10 @@ export default class TraitTable extends Vue {
           this.$log.error(fieldError);
         }
       }
-
       this.$emit('show-error-notification', 'Error creating');
     }
 
+    this.newFormBtnActive = true;
   }
 
   cancelNewTrait() {

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -93,6 +93,7 @@
   import { Method } from '../../breeding-insight/model/Method';
   import { StringFormatters } from '@/breeding-insight/utils/StringFormatters';
   import { TraitStringFormatters } from '@/breeding-insight/utils/TraitStringFormatters';
+  import {ProgramUpload} from "@/breeding-insight/model/ProgramUpload";
   
 @Component({
   mixins: [validationMixin],
@@ -112,6 +113,7 @@ export default class TraitsImportTable extends Vue {
   private traitsPagination?: Pagination = new Pagination();
   private paginationController: PaginationController = new PaginationController();
   private traits : Trait[] = [];
+  private upload?: ProgramUpload;
   private loaded = false;
   private collapseColumns = false;
 
@@ -129,9 +131,9 @@ export default class TraitsImportTable extends Vue {
       this.paginationController.currentPage, this.paginationController.pageSize, this.paginationController.showAll);
     this.paginationController.setCurrentCall(paginationQuery);
 
-    TraitUploadService.getTraits(this.activeProgram!.id!, paginationQuery).then(([traits, metadata]) => {
+    TraitUploadService.getTraits(this.activeProgram!.id!, paginationQuery).then(([upload, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
-        this.traits = traits;
+        this.traits = upload.data || [];
         this.traitsPagination = metadata.pagination;
       }
 

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -14,12 +14,14 @@
         <b-field
           label="Observation Level"
           v-bind:custom-class="'is-sr-only'"
+          class="is-flex-grow-1"
         >
           <b-autocomplete
             v-model="name"
             v-bind:open-on-focus="true"
             v-bind:data="filteredDataObj(programObservationLevels)"
             v-on:input="setObservationLevel($event)"
+            placeholder="Start typing to see suggestions"
           />
         </b-field>
       </div>
@@ -129,7 +131,6 @@ export default class TraitTable extends Vue {
     this.trait!.scale!.dataType = value;
   }
   setObservationLevel(value: string) {
-    // TODO: update model to accept id for program observation level
     this.trait!.programObservationLevel = new ProgramObservationLevel(value);
   }
   setAbbreviations(value: string) {

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -1,0 +1,145 @@
+<template>
+  <div class="columns">
+    <div class="column">
+      <BasicInputField
+        v-bind:field-name="'Trait name'"
+        v-bind:field-help="'All unicode characters are accepted.'"
+        :placeholder="'Trait Name'"
+        v-on:input="trait.traitName = $event"
+      />
+      <div class="sentence-input">
+        <p class="is-input-prepend mt-2">
+          is collected on
+        </p>
+        <b-field
+          label="Observation Level"
+          v-bind:custom-class="'is-sr-only'"
+        >
+          <b-autocomplete
+            v-model="name"
+            v-bind:open-on-focus="true"
+            v-bind:data="filteredDataObj(programObservationLevels)"
+            v-on:input="setObservationLevel($event)"
+          />
+        </b-field>
+      </div>
+      <div class="sentence-input">
+        <p class="is-input-prepend mt-3">
+          by
+        </p>
+        <BasicSelectField
+          v-bind:options="methodOptions"
+          v-bind:field-name="'Method'"
+          v-bind:show-label="false"
+          v-on:input="setMethodClass($event)"
+        />
+      </div>
+      <div class="sentence-input">
+        <p class="is-input-prepend mt-3">
+          using
+        </p>
+        <BasicSelectField
+          v-bind:options="scaleOptions"
+          v-bind:field-name="'Scale'"
+          v-bind:show-label="false"
+          v-bind:field-help="'Note: additional options for this field will appear after selection'"
+          v-on:input="setScaleClass($event)"
+        />
+      </div>
+
+      <!-- Scale options -->
+    </div>
+    <div class="divider is-vertical" />
+
+    <!-- Right Side -->
+    <div class="column">
+      <!--TODO: needs to be a paragraph -->
+      <BasicInputField
+        v-bind:field-name="'Description of collection method'"
+        v-bind:field-help="'All unicode characters are accepted.'"
+        v-bind:placeholder="'Trait Name'"
+        v-on:input="trait.method.description = $event"
+      />
+
+      <BasicInputField
+        v-bind:field-name="'Abbreviation(s)'"
+        v-bind:field-help="'Semicolon separated list, with primary abbreviation as first term.'"
+        v-on:input="trait.abbreviations = parseCommaList($event)"
+      />
+
+      <BasicInputField
+        v-bind:field-name="'Synonyms'"
+        v-bind:field-help="'Comma separated list.'"
+        v-on:input="trait.synonyms = parseCommaList($event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import {Component, Prop, Vue, Watch} from 'vue-property-decorator'
+import BasicInputField from "@/components/forms/BasicInputField.vue";
+import BasicSelectField from "@/components/forms/BasicSelectField.vue";
+import {Trait} from "@/breeding-insight/model/Trait";
+import {Method} from "@/breeding-insight/model/Method";
+import { Scale } from '@/breeding-insight/model/Scale';
+import { ProgramObservationLevel } from '@/breeding-insight/model/ProgramObservationLevel';
+
+@Component({
+  components: {BasicSelectField, BasicInputField}
+})
+export default class TraitTable extends Vue {
+  @Prop()
+  programObservationLevels?: string[];
+  @Prop()
+  methodOptions?: string[];
+  @Prop()
+  scaleOptions?: string[];
+
+  name: string = '';
+  private trait: Trait = new Trait();
+
+  mounted() {
+    this.trait.method = new Method();
+    this.trait.scale = new Scale();
+  }
+
+  @Watch('trait', {deep: true})
+  emitTrait(val: Trait) {
+    this.$emit('trait-change', val);
+  }
+
+  filteredDataObj(data: string[]): string[] {
+    const result = data.filter(option => {
+      return (
+        option
+          .toLowerCase()
+          .indexOf(this.name.toLowerCase()) >= 0
+      )
+    });
+
+    return result;
+  }
+
+  setMethodClass(value: string) {
+    this.trait!.method!.methodClass = value;
+  }
+  setScaleClass(value: string) {
+    this.trait!.scale!.scaleName = value;
+    this.trait!.scale!.dataType = value;
+  }
+  setObservationLevel(value: string) {
+    // TODO: update model to accept id for program observation level
+    this.trait!.programObservationLevel = new ProgramObservationLevel(value);
+  }
+  parseCommaList(value: string): string[] {
+    return value.split(',');
+  }
+
+}
+
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -69,8 +69,8 @@
 
       <BasicInputField
         v-bind:field-name="'Synonyms'"
-        v-bind:field-help="'Comma separated list.'"
-        v-on:input="trait.synonyms = parseCommaList($event)"
+        v-bind:field-help="'Semicolon separated list.'"
+        v-on:input="trait.synonyms = parseSemiColonList($event)"
       />
     </div>
   </div>
@@ -133,12 +133,12 @@ export default class TraitTable extends Vue {
     this.trait!.programObservationLevel = new ProgramObservationLevel(value);
   }
   setAbbreviations(value: string) {
-    const abbreviations = this.parseCommaList(value);
+    const abbreviations = this.parseSemiColonList(value);
     this.trait.abbreviations = abbreviations;
     if (abbreviations.length > 0) {this.trait.mainAbbreviation = this.trait.abbreviations[0]}
   }
-  parseCommaList(value: string): string[] {
-    return value.split(',');
+  parseSemiColonList(value: string): string[] {
+    return value.split(';');
   }
 
 }

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -64,7 +64,7 @@
       <BasicInputField
         v-bind:field-name="'Abbreviation(s)'"
         v-bind:field-help="'Semicolon separated list, with primary abbreviation as first term.'"
-        v-on:input="trait.abbreviations = parseCommaList($event)"
+        v-on:input="setAbbreviations($event)"
       />
 
       <BasicInputField
@@ -131,6 +131,11 @@ export default class TraitTable extends Vue {
   setObservationLevel(value: string) {
     // TODO: update model to accept id for program observation level
     this.trait!.programObservationLevel = new ProgramObservationLevel(value);
+  }
+  setAbbreviations(value: string) {
+    const abbreviations = this.parseCommaList(value);
+    this.trait.abbreviations = abbreviations;
+    if (abbreviations.length > 0) {this.trait.mainAbbreviation = this.trait.abbreviations[0]}
   }
   parseCommaList(value: string): string[] {
     return value.split(',');

--- a/src/views/TraitsImport.vue
+++ b/src/views/TraitsImport.vue
@@ -304,7 +304,6 @@ export default class TraitsImport extends ProgramsBase {
     try {
       // fetch uploaded traits
       const [ upload ] = await TraitUploadService.getTraits(this.activeProgram!.id!) as [ProgramUpload, Metadata];
-      console.log(upload);
       await TraitUploadService.confirmUpload(this.activeProgram!.id!, upload!.id!);
 
       // show all program traits

--- a/src/views/TraitsImport.vue
+++ b/src/views/TraitsImport.vue
@@ -101,6 +101,7 @@ import { createMachine, interpret } from '@xstate/fsm';
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {Trait} from "@/breeding-insight/model/Trait";
+import {ProgramUpload} from "@/breeding-insight/model/ProgramUpload";
 
 enum ImportState {
   CHOOSE_FILE = "CHOOSE_FILE",
@@ -302,14 +303,9 @@ export default class TraitsImport extends ProgramsBase {
     const name = this.activeProgram && this.activeProgram.name ? this.activeProgram.name : 'the program';  
     try {
       // fetch uploaded traits
-        const [ uploadedTraits ] = await TraitUploadService.getTraits(this.activeProgram!.id!) as [Trait[], Metadata];
-
-      // add traits to program
-      await TraitService.createTraits(this.activeProgram!.id!, uploadedTraits)
-
-      // delete uploaded traits
-      const err = await TraitUploadService.deleteTraits(this.activeProgram!.id!) as void|Error;
-      if(err) throw new Error('Uploaded traits were not deleted');
+      const [ upload ] = await TraitUploadService.getTraits(this.activeProgram!.id!) as [ProgramUpload, Metadata];
+      console.log(upload);
+      await TraitUploadService.confirmUpload(this.activeProgram!.id!, upload!.id!);
 
       // show all program traits
       this.$emit('show-success-notification', `Imported traits have been added to ${name}.`);


### PR DESCRIPTION
Adds the ability to create a basic trait from the UI. 

Error display is not implemented yet, so you will get a generic error when trait creation fails. Open the developer console to see the errors printed out. You might need the console open before submitting for the errors to be printed. 

Some scale classes may fail because the specific scale additionals aren't in there yet. You will get errors like "Missing categories for scale class 'Categories'" or something along those lines. 

Some updates to the components. One to allow hiding of the label. One to allow the select field component to accept strings and objects. 