### PR TITLE
[BI-685] - Map backend trait validation errors to front end

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -464,9 +464,3 @@ div.sentence-input {
   fill: none;
   stroke-width: 2;
 }
-
-// Fix vie feather icons
-svg.feather {
-  vertical-align: middle;
-  margin-top: -4px;
-}

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -464,3 +464,9 @@ div.sentence-input {
   fill: none;
   stroke-width: 2;
 }
+
+// Fix vie feather icons
+svg.feather {
+  vertical-align: middle;
+  margin-top: -4px;
+}

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -184,6 +184,12 @@ footer {
     & .field span.form-error {
       display: block;
     }
+    & input {
+      border-color: $danger;
+    }
+    & select {
+      border-color: $danger;
+    }
   }
   &:not(.field--error) {
     & .field span.form-error {

--- a/src/breeding-insight/model/errors/RowError.ts
+++ b/src/breeding-insight/model/errors/RowError.ts
@@ -19,10 +19,22 @@ import {FieldError} from "@/breeding-insight/model/errors/FieldError";
 
 export class RowError {
   rowIndex: number;
-  errors: FieldError[];
+  errors?: FieldError[];
 
-  constructor(rowIndex: number, errors: FieldError[]){
+  constructor(rowIndex: number, errors?: FieldError[]){
     this.rowIndex = rowIndex;
-    this.errors = errors;
+    if (errors) {
+      this.errors = errors.map(error =>
+        new FieldError(error.field, error.errorMessage, error.httpStatus, error.httpStatusCode, error.rowErrors));
+    }
+  }
+
+  getValidation(errorName: string): FieldError[] {
+    if (this.errors) {
+      return this.errors
+        .filter(error => error.field === errorName);
+    } else {
+      return [];
+    }
   }
 }

--- a/src/breeding-insight/model/errors/TraitError.ts
+++ b/src/breeding-insight/model/errors/TraitError.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
-
 export enum TraitError {
   MethodDescription = "method.description",
   MethodClass = "method.methodClass",
@@ -29,8 +27,4 @@ export enum TraitError {
   Abbreviations = "abbreviations",
   CategoryLabel = "scale.categories.label",
   CategoryValue = "scale.categories.value"
-}
-
-export class TraitErrorHandler extends ValidationError {
-  
 }

--- a/src/breeding-insight/model/errors/TraitErrorHandler.ts
+++ b/src/breeding-insight/model/errors/TraitErrorHandler.ts
@@ -15,22 +15,22 @@
  * limitations under the License.
  */
 
-import {RowError} from "@/breeding-insight/model/errors/RowError";
+import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 
-export class FieldError {
-  field: string;
-  errorMessage: string;
-  httpStatus: string;
-  httpStatusCode: number;
-  rowErrors?: RowError[];
+export enum TraitError {
+  MethodDescription = "method.description",
+  MethodClass = "method.methodClass",
+  ScaleName = "scale.scaleName",
+  ScaleType = "scale.dataType",
+  TraitName = "traitName",
+  ObservationLevel = "programObservationLevel.name",
+  MethodFormula = "method.formula",
+  ScaleCategories = "scale.categories",
+  Abbreviations = "abbreviations",
+  CategoryLabel = "scale.categories.label",
+  CategoryValue = "scale.categories.value"
+}
 
-  constructor(field: string, errorMessage: string, httpStatus: string, httpStatusCode: number, rowErrors?: RowError[]){
-    this.field = field;
-    this.errorMessage = errorMessage;
-    this.httpStatus = httpStatus;
-    this.httpStatusCode = httpStatusCode;
-    if (rowErrors) {
-      this.rowErrors = rowErrors.map(row => new RowError(row.rowIndex, row.errors));
-    }
-  }
+export class TraitErrorHandler extends ValidationError {
+  
 }

--- a/src/breeding-insight/model/errors/ValidationError.ts
+++ b/src/breeding-insight/model/errors/ValidationError.ts
@@ -16,11 +16,37 @@
  */
 
 import {RowError} from "@/breeding-insight/model/errors/RowError";
+import {FieldError} from "@/breeding-insight/model/errors/FieldError";
 
 export class ValidationError {
-  rows: RowError[];
+  rows?: RowError[];
 
-  constructor(rows: RowError[]){
-    this.rows = rows;
+  constructor(rows?: RowError[]){
+    if (rows) {
+      this.rows = rows.map(row => new RowError(row.rowIndex, row.errors));
+    }
+  }
+
+  getValidation(rowIndex: number, errorName: string) {
+    return this.getFieldErrorMessage(rowIndex, errorName);
+  }
+
+  private getFieldErrorMessage(rowIndex: number, errorName: string): FieldError[] {
+
+    const rowError: RowError | undefined = this.rows ? this.rows[rowIndex] : undefined;
+    if (rowError) {
+      return rowError.getValidation(errorName);
+    } else {
+      return [];
+    }
+  }
+
+  overrideMessage(rowIndex: number, errorName: string, message: string, statusCode: number) {
+    let errors: FieldError[] = this.getFieldErrorMessage(rowIndex, errorName);
+    for (const [index, error] of errors.entries()) {
+      if (error.httpStatusCode === statusCode) {
+        errors[index].errorMessage = message;
+      }
+    }
   }
 }

--- a/src/breeding-insight/model/errors/ValidationError.ts
+++ b/src/breeding-insight/model/errors/ValidationError.ts
@@ -50,13 +50,25 @@ export class ValidationError {
     }
   }
 
-  condenseErrorsSingleRow() {
+  condenseErrorsSingleRow(deletions?: string[]) {
+
     let errorSentence: string = '';
     if (this.rows) {
       for (const row of this.rows) {
         if (row.errors) {
           for (const field of row.errors) {
-            errorSentence += `${field.errorMessage}; `;
+
+            // Check our deletions
+            let addMsg: boolean = true;
+            if (deletions && deletions.length) {
+              if (deletions.indexOf(field.field) !== -1) {
+                addMsg = false;
+              }
+            }
+
+            if (addMsg) {
+              errorSentence += `${field.errorMessage}; `;
+            }
           }
         }
       }

--- a/src/breeding-insight/model/errors/ValidationError.ts
+++ b/src/breeding-insight/model/errors/ValidationError.ts
@@ -49,4 +49,18 @@ export class ValidationError {
       }
     }
   }
+
+  condenseErrorsSingleRow() {
+    let errorSentence: string = '';
+    if (this.rows) {
+      for (const row of this.rows) {
+        if (row.errors) {
+          for (const field of row.errors) {
+            errorSentence += `${field.field}: ${field.errorMessage}; `;
+          }
+        }
+      }
+    }
+    return errorSentence;
+  }
 }

--- a/src/breeding-insight/model/errors/ValidationError.ts
+++ b/src/breeding-insight/model/errors/ValidationError.ts
@@ -56,7 +56,7 @@ export class ValidationError {
       for (const row of this.rows) {
         if (row.errors) {
           for (const field of row.errors) {
-            errorSentence += `${field.field}: ${field.errorMessage}; `;
+            errorSentence += `${field.errorMessage}; `;
           }
         }
       }

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -25,7 +25,7 @@
 
           <!-- Multiple errors list -->
           <template v-if="isValidationError">
-            <AlertTriangleIcon size="1x" aria-hidden="true"></AlertTriangleIcon>
+            <AlertTriangleIcon size="1x" aria-hidden="true" class="has-vertical-align-middle"></AlertTriangleIcon>
             <span class="has-text-weight-bold ml-1">File contains data errors</span>
             <ul>
               <template v-if="displayAllErrors">
@@ -52,7 +52,7 @@
 
           <!-- Single Error -->
           <template v-else>
-            <AlertTriangleIcon size="1x" aria-hidden="true"></AlertTriangleIcon>
+            <AlertTriangleIcon size="1x" aria-hidden="true" class="has-vertical-align-middle"></AlertTriangleIcon>
             <span class="has-text-weight-bold ml-1">{{allErrors[0]}}</span>
           </template>
 

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -25,8 +25,8 @@
 
           <!-- Multiple errors list -->
           <template v-if="isValidationError">
-            <AlertTriangleIcon size="1x" aria-hidden="true" class="has-vertical-align-middle pb-0"></AlertTriangleIcon>
-            <span class="has-text-weight-bold ml-1 has-vertical-align-middle">File contains data errors</span>
+            <AlertTriangleIcon size="1x" aria-hidden="true"></AlertTriangleIcon>
+            <span class="has-text-weight-bold ml-1">File contains data errors</span>
             <ul>
               <template v-if="displayAllErrors">
                 <li v-for="(errorMessage, rowIndex) of allErrors" v-bind:key="rowIndex">{{errorMessage}}</li>
@@ -52,8 +52,8 @@
 
           <!-- Single Error -->
           <template v-else>
-            <AlertTriangleIcon size="1x" aria-hidden="true" class="has-vertical-align-middle pb-0"></AlertTriangleIcon>
-            <span class="has-text-weight-bold ml-1 has-vertical-align-middle">{{allErrors[0]}}</span>
+            <AlertTriangleIcon size="1x" aria-hidden="true"></AlertTriangleIcon>
+            <span class="has-text-weight-bold ml-1">{{allErrors[0]}}</span>
           </template>
 
         </div>

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -135,12 +135,15 @@
       let errors = [];
       if (this.isValidationError){
         const validationErrors = this.errors as ValidationError;
-        for (const error of validationErrors.rows){
-          for (const fieldError of error.errors){
-            errors.push(`${fieldError.field}: ${fieldError.errorMessage} in row ${error.rowIndex}`);
+        if (validationErrors.rows) {
+          for (const error of validationErrors.rows){
+            if (error.errors) {
+              for (const fieldError of error.errors){
+                errors.push(`${fieldError.field}: ${fieldError.errorMessage} in row ${error.rowIndex}`);
+              }
+            }
           }
         }
-
         return errors;
       } else if (this.errors != null) {
         return [this.errors!] as string[];

--- a/src/components/forms/AutoCompleteField.vue
+++ b/src/components/forms/AutoCompleteField.vue
@@ -22,45 +22,32 @@
       v-bind:field-name="fieldName"
       v-bind:show-label="showLabel"
       v-bind:server-validations="serverValidations"
+      class="is-flex-grow-1"
   >
-    <div class="select is-fullwidth">
-      <select
-          v-bind:id="fieldName.replace(' ', '-')"
-          v-on:input="$emit('input', $event.target.value)"
-          class="select is-fullwidth"
-      >
-        <option disabled v-bind:selected="displayDefault()" value="">Select a {{fieldName.toLowerCase()}}</option>
-        <template v-if="emptyValueName">
-          <option v-bind:value="undefined" v-bind:selected="selectedId === undefined">
-            {{emptyValueName}}
-          </option>
-        </template>
-        <option
-            v-for="option in options"
-            v-bind:key="option.id || option"
-            v-bind:selected="option.id ? option.id === selectedId : option === selectedId"
-            v-bind:value="option.id || option"
-        >
-          {{ option.name || option }}
-        </option>
-      </select>
-    </div>
+    <b-autocomplete
+        v-bind:value="value"
+        v-bind:open-on-focus="true"
+        v-bind:data="filteredDataObj(options)"
+        v-on:input="$emit('input', $event)"
+        placeholder="Start typing to see suggestions"
+    />
   </BaseFieldWrapper>
-
 </template>
 
 <script lang="ts">
-  import { Component, Prop, PropSync, Vue } from 'vue-property-decorator';
+  import { Component, Prop, Vue } from 'vue-property-decorator';
   import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
   import {FieldError} from "@/breeding-insight/model/errors/FieldError";
+
   @Component({
     components: {BaseFieldWrapper}
   })
-  export default class BasicSelectField extends Vue {
+  export default class BasicInputField extends Vue {
     @Prop()
-    selectedId!: string;
+    options!: string[];
     @Prop()
-    options!: any;
+    value!: string;
+
     @Prop()
     fieldName!: string;
     @Prop()
@@ -70,13 +57,22 @@
     @Prop()
     serverValidations!: FieldError[];
     @Prop()
-    emptyValueName!: string;
-    @Prop()
     showLabel!: boolean;
 
+    filteredDataObj(data: string[]): string[] {
+      if (!this.value) {
+        return data;
+      }
 
-    displayDefault() {
-      return this.selectedId === null || this.selectedId === undefined;
+      const result = data.filter(option => {
+        return (
+          option
+            .toLowerCase()
+            .indexOf(this.value.toLowerCase()) >= 0
+        )
+      });
+
+      return result;
     }
   }
 

--- a/src/components/forms/BaseFieldWrapper.vue
+++ b/src/components/forms/BaseFieldWrapper.vue
@@ -33,7 +33,7 @@
                 class="form-error has-text-danger"
                 :class="{ 'is-hidden': ( validateTypeError(validationMap.name) ) }"
             >
-              <AlertTriangleIcon size="1x" aria-hidden="true" class="mr-1"></AlertTriangleIcon>
+              <AlertTriangleIcon size="1x" aria-hidden="true" class="has-vertical-align-middle mr-1"></AlertTriangleIcon>
               {{ validationMap.message }}
             </span>
           </template>
@@ -43,7 +43,7 @@
                   data-testid="formError"
                   class="form-error has-text-danger"
               >
-                <AlertTriangleIcon size="1x" aria-hidden="true" class="mr-1"></AlertTriangleIcon>
+                <AlertTriangleIcon size="1x" aria-hidden="true" class="has-vertical-align-middle mr-1"></AlertTriangleIcon>
                 {{ fieldError.errorMessage }}
               </span>
           </template>

--- a/src/components/forms/BaseFieldWrapper.vue
+++ b/src/components/forms/BaseFieldWrapper.vue
@@ -33,17 +33,19 @@
                 class="form-error has-text-danger"
                 :class="{ 'is-hidden': ( validateTypeError(validationMap.name) ) }"
             >
+              <AlertTriangleIcon size="1x" aria-hidden="true" class="mr-1"></AlertTriangleIcon>
               {{ validationMap.message }}
             </span>
           </template>
           <template v-for="(fieldError, index) in serverValidations">
-            <span
-                data-testid="formError"
-                v-bind:key="fieldName + fieldError.field + index"
-                class="form-error has-text-danger"
-            >
-              {{ fieldError.errorMessage }}
-            </span>
+              <span
+                  v-bind:key="fieldName + fieldError.field + index"
+                  data-testid="formError"
+                  class="form-error has-text-danger"
+              >
+                <AlertTriangleIcon size="1x" aria-hidden="true" class="mr-1"></AlertTriangleIcon>
+                {{ fieldError.errorMessage }}
+              </span>
           </template>
           <p
               v-if="fieldHelp !== null"
@@ -61,8 +63,11 @@
 
   import {Component, Prop, Vue} from "vue-property-decorator";
   import {FieldError} from "@/breeding-insight/model/errors/FieldError";
+  import { AlertTriangleIcon } from 'vue-feather-icons';
 
-  @Component
+  @Component({
+    components: {AlertTriangleIcon}
+  })
   export default class BaseFieldWrapper extends Vue {
 
     @Prop()

--- a/src/components/forms/BaseFieldWrapper.vue
+++ b/src/components/forms/BaseFieldWrapper.vue
@@ -36,6 +36,15 @@
               {{ validationMap.message }}
             </span>
           </template>
+          <template v-for="(fieldError, index) in serverValidations">
+            <span
+                data-testid="formError"
+                v-bind:key="fieldName + fieldError.field + index"
+                class="form-error has-text-danger"
+            >
+              {{ fieldError.errorMessage }}
+            </span>
+          </template>
           <p
               v-if="fieldHelp !== null"
               class="help"
@@ -51,6 +60,7 @@
 <script lang="ts">
 
   import {Component, Prop, Vue} from "vue-property-decorator";
+  import {FieldError} from "@/breeding-insight/model/errors/FieldError";
 
   @Component
   export default class BaseFieldWrapper extends Vue {
@@ -61,6 +71,8 @@
     fieldHelp!: string;
     @Prop()
     validations!: any;
+    @Prop()
+    serverValidations!: FieldError[];
     @Prop({default: true})
     showLabel!: boolean;
 
@@ -95,6 +107,8 @@
     get fieldError() {
       if (this.validations) {
         return this.validations.$anyError;
+      } else if (this.serverValidations) {
+        return this.serverValidations.length > 0;
       } else {
         return false;
       }

--- a/src/components/forms/BasicInputField.vue
+++ b/src/components/forms/BasicInputField.vue
@@ -21,6 +21,7 @@
     v-bind:field-help="fieldHelp"
     v-bind:field-name="fieldName"
     v-bind:show-label="showLabel"
+    v-bind:server-validations="serverValidations"
   >
     <input
         v-bind:id="inputId ? inputId : fieldName.replace(' ', '-')"
@@ -36,6 +37,7 @@
 <script lang="ts">
   import { Component, Prop, Vue } from 'vue-property-decorator';
   import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
+  import {FieldError} from "@/breeding-insight/model/errors/FieldError";
 
   @Component({
     components: {BaseFieldWrapper}
@@ -51,6 +53,8 @@
     fieldHelp!: string;
     @Prop()
     validations!: any;
+    @Prop()
+    serverValidations!: FieldError[];
     @Prop()
     showLabel!: boolean;
     @Prop()

--- a/src/components/notifications/ErrorNotification.vue
+++ b/src/components/notifications/ErrorNotification.vue
@@ -18,14 +18,12 @@
 <template>
   <b-notification type="is-danger" v-bind:active.sync="active" aria-close-label="Close Notification" 
     role="alert">
-    <div class="level">
-      <div class="level-left">
-        <div class="level-item">
-            <AlertCircleIcon size="1.5x"></AlertCircleIcon>
-        </div>
-        <div class="level-item">
-            {{msg}}
-        </div>
+    <div class="columns has-vertical-align-middle">
+      <div class="column is-flex-grow-0">
+          <AlertCircleIcon size="1.5x"></AlertCircleIcon>
+      </div>
+      <div class="column">
+        {{msg}}
       </div>
     </div>
   </b-notification>

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -223,8 +223,10 @@ export default class TraitTable extends Vue {
     } catch (error) {
       if (error instanceof ValidationError) {
         this.validationHandler = error;
+        this.$emit('show-error-notification', `Error creating trait. ${this.validationHandler.condenseErrorsSingleRow()}`);
+      } else {
+        this.$emit('show-error-notification', 'Error creating trait.');
       }
-      this.$emit('show-error-notification', 'Error creating');
     }
 
     this.newFormBtnActive = true;

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -186,7 +186,7 @@ export default class TraitTable extends Vue {
   private methodClassOptions: string[] = Object.values(MethodClass);
   private observationLevelOptions?: string[];
   private scaleClassOptions: string[] = Object.values(DataType);
-  private validationHandler = new ValidationError();
+  private validationHandler: ValidationError  = new ValidationError();
 
   mounted() {
     this.getTraits();
@@ -214,6 +214,7 @@ export default class TraitTable extends Vue {
   async saveTrait() {
     try {
       this.newFormBtnActive = false;
+      this.validationHandler = new ValidationError();
       await TraitService.createTraits(this.activeProgram!.id!, [this.newTrait]);
       this.$emit('show-success-notification', 'Trait creation successful.');
       this.getTraits();

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -70,6 +70,7 @@
             v-bind:scale-options="scaleClassOptions"
             v-bind:method-options="methodClassOptions"
             v-bind:program-observation-levels="observationLevelOptions"
+            v-bind:validation-handler="validationHandler"
         ></BaseTraitForm>
       </template>
     </NewDataForm>
@@ -151,7 +152,6 @@ import { StringFormatters } from '@/breeding-insight/utils/StringFormatters';
 import { TraitStringFormatters } from '@/breeding-insight/utils/TraitStringFormatters';
 import BaseTraitForm from "@/components/trait/forms/BaseTraitForm.vue";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
-import {FieldError} from "@/breeding-insight/model/errors/FieldError";
 import {ProgramService} from "@/breeding-insight/service/ProgramService";
 import {MethodClass} from "@/breeding-insight/model/Method";
 import {DataType} from "@/breeding-insight/model/Scale";
@@ -186,6 +186,7 @@ export default class TraitTable extends Vue {
   private methodClassOptions: string[] = Object.values(MethodClass);
   private observationLevelOptions?: string[];
   private scaleClassOptions: string[] = Object.values(DataType);
+  private validationHandler = new ValidationError();
 
   mounted() {
     this.getTraits();
@@ -219,12 +220,8 @@ export default class TraitTable extends Vue {
       await this.getObservationLevels();
       this.newTraitActive = false;
     } catch (error) {
-      // TODO: Pass errors to the new data form
       if (error instanceof ValidationError) {
-        const fieldErrors: FieldError[] = error.rows[0].errors;
-        for (const fieldError of fieldErrors) {
-          this.$log.error(fieldError);
-        }
+        this.validationHandler = error;
       }
       this.$emit('show-error-notification', 'Error creating');
     }

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -4,26 +4,22 @@
       <BasicInputField
         v-bind:field-name="'Trait name'"
         v-bind:field-help="'All unicode characters are accepted.'"
-        :placeholder="'Trait Name'"
+        v-bind:placeholder="'Trait Name'"
+        v-bind:server-validations="validationHandler.getValidation(0, TraitError.TraitName)"
         v-on:input="trait.traitName = $event"
       />
       <div class="sentence-input">
-        <p class="is-input-prepend mt-2">
+        <p class="is-input-prepend mt-3">
           is collected on
         </p>
-        <b-field
-          label="Observation Level"
-          v-bind:custom-class="'is-sr-only'"
-          class="is-flex-grow-1"
-        >
-          <b-autocomplete
-            v-model="name"
-            v-bind:open-on-focus="true"
-            v-bind:data="filteredDataObj(programObservationLevels)"
-            v-on:input="setObservationLevel($event)"
-            placeholder="Start typing to see suggestions"
-          />
-        </b-field>
+        <AutoCompleteField
+          v-bind:options="programObservationLevels"
+          v-bind:value="trait.programObservationLevel ? trait.programObservationLevel.name : undefined"
+          v-bind:field-name="'Observation Level'"
+          v-bind:show-label="false"
+          v-bind:server-validations="validationHandler.getValidation(0, TraitError.ObservationLevel)"
+          v-on:input="setObservationLevel($event)"
+        />
       </div>
       <div class="sentence-input">
         <p class="is-input-prepend mt-3">
@@ -33,6 +29,7 @@
           v-bind:options="methodOptions"
           v-bind:field-name="'Method'"
           v-bind:show-label="false"
+          v-bind:server-validations="validationHandler.getValidation(0, TraitError.MethodClass)"
           v-on:input="setMethodClass($event)"
         />
       </div>
@@ -46,6 +43,7 @@
           v-bind:field-name="'Scale'"
           v-bind:show-label="false"
           v-bind:field-help="'Note: additional options for this field will appear after selection'"
+          v-bind:server-validations="validationHandler.getValidation(0, TraitError.ScaleType)"
           v-on:input="setScaleClass($event)"
         />
       </div>
@@ -56,7 +54,8 @@
             v-bind:value="trait.method.formula"
             v-bind:field-name="'Formula'"
             v-bind:field-help="'Operations accepted: *^.+/(); calculations will use FOIL order of operations.'"
-            :placeholder="'Number of flowers on single plant / 100'"
+            v-bind:placeholder="'Number of flowers on single plant / 100'"
+            v-bind:server-validations="validationHandler.getValidation(0, TraitError.MethodFormula)"
             v-on:input="trait.method.formula = $event"
         />
       </template>
@@ -67,6 +66,8 @@
           v-bind:data="trait.scale.categories"
           v-on:update="trait.scale.categories = $event"
           v-bind:type="trait.scale.dataType"
+          v-bind:validation-handler="validationHandler"
+          v-bind:validation-index="0"
         />
       </template>
       <template v-if="trait.scale && trait.scale.dataType === DataType.Text">
@@ -82,7 +83,10 @@
             v-bind:valid-max="trait.scale.validValueMax"
             v-on:unit-change="trait.scale.scaleName = $event"
             v-on:min-change="trait.scale.validValueMin = $event"
-            v-on:max-change="trait.scale.validValueMax = $event"/>
+            v-on:max-change="trait.scale.validValueMax = $event"
+            v-bind:validation-handler="validationHandler"
+            v-bind:validation-index="0"
+        />
       </template>
       <template v-if="trait.scale && trait.scale.dataType === DataType.Numerical">
         <NumericalTraitForm
@@ -94,6 +98,8 @@
           v-on:decimal-change="trait.scale.decimalPlaces = $event"
           v-on:min-change="trait.scale.validValueMin = $event"
           v-on:max-change="trait.scale.validValueMax = $event"
+          v-bind:validation-handler="validationHandler"
+          v-bind:validation-index="0"
         />
       </template>
     </div>
@@ -105,12 +111,14 @@
         v-bind:field-name="'Description of collection method'"
         v-bind:field-help="'All unicode characters are accepted.'"
         v-bind:placeholder="'Trait Name'"
+        v-bind:server-validations="validationHandler.getValidation(0, TraitError.MethodDescription)"
         v-on:input="trait.method.description = $event"
       />
 
       <BasicInputField
         v-bind:field-name="'Abbreviation(s)'"
         v-bind:field-help="'Semicolon separated list, with primary abbreviation as first term.'"
+        v-bind:server-validations="validationHandler.getValidation(0, TraitError.Abbreviations)"
         v-on:input="setAbbreviations($event)"
       />
 
@@ -137,13 +145,17 @@ import DateTraitForm from "@/components/trait/forms/DateTraitForm.vue";
 import DurationTraitForm from "@/components/trait/forms/DurationTraitForm.vue";
 import NumericalTraitForm from "@/components/trait/forms/NumericalTraitForm.vue";
 import CategoryTraitForm from "@/components/trait/forms/CategoryTraitForm.vue";
+import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+import AutoCompleteField from "@/components/forms/AutoCompleteField.vue";
 
 @Component({
   components: {
+    AutoCompleteField,
     CategoryTraitForm,
     NumericalTraitForm,
     DurationTraitForm, DateTraitForm, TextTraitForm, OrdinalTraitForm, BasicSelectField, BasicInputField},
-  data: () => ({DataType, MethodClass})
+  data: () => ({DataType, MethodClass, TraitError})
 })
 export default class TraitTable extends Vue {
   @Prop()
@@ -152,6 +164,8 @@ export default class TraitTable extends Vue {
   methodOptions?: string[];
   @Prop()
   scaleOptions?: string[];
+  @Prop()
+  validationHandler!: ValidationError;
 
   name: string = '';
   private trait: Trait = new Trait();

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -149,7 +149,7 @@ import DateTraitForm from "@/components/trait/forms/DateTraitForm.vue";
 import DurationTraitForm from "@/components/trait/forms/DurationTraitForm.vue";
 import NumericalTraitForm from "@/components/trait/forms/NumericalTraitForm.vue";
 import CategoryTraitForm from "@/components/trait/forms/CategoryTraitForm.vue";
-import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+import {TraitError} from "@/breeding-insight/model/errors/TraitError";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 import AutoCompleteField from "@/components/forms/AutoCompleteField.vue";
 

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -2,6 +2,7 @@
   <div class="columns">
     <div class="column">
       <BasicInputField
+        v-bind:value="trait.traitName"
         v-bind:field-name="'Trait name'"
         v-bind:field-help="'All unicode characters are accepted.'"
         v-bind:placeholder="'Trait Name'"
@@ -108,6 +109,7 @@
     <!-- Right Side -->
     <div class="column">
       <BasicInputField
+        v-bind:value="trait.method.description"
         v-bind:field-name="'Description of collection method'"
         v-bind:field-help="'All unicode characters are accepted.'"
         v-bind:placeholder="'Trait Name'"
@@ -116,6 +118,7 @@
       />
 
       <BasicInputField
+        v-bind:value="trait.abbreviations"
         v-bind:field-name="'Abbreviation(s)'"
         v-bind:field-help="'Semicolon separated list, with primary abbreviation as first term.'"
         v-bind:server-validations="validationHandler.getValidation(0, TraitError.Abbreviations)"
@@ -123,6 +126,7 @@
       />
 
       <BasicInputField
+        v-bind:value="trait.synonyms"
         v-bind:field-name="'Synonyms'"
         v-bind:field-help="'Semicolon separated list.'"
         v-on:input="trait.synonyms = parseSemiColonList($event)"
@@ -157,7 +161,7 @@ import AutoCompleteField from "@/components/forms/AutoCompleteField.vue";
     DurationTraitForm, DateTraitForm, TextTraitForm, OrdinalTraitForm, BasicSelectField, BasicInputField},
   data: () => ({DataType, MethodClass, TraitError})
 })
-export default class TraitTable extends Vue {
+export default class BaseTraitForm extends Vue {
   @Prop()
   programObservationLevels?: string[];
   @Prop()
@@ -172,7 +176,7 @@ export default class TraitTable extends Vue {
   private methodHistory: {[key: string]: Method} = {};
   private scaleHistory: {[key: string]: Scale} = {};
 
-  mounted() {
+  created() {
     this.trait.method = new Method();
     this.trait.scale = new Scale();
   }
@@ -180,18 +184,6 @@ export default class TraitTable extends Vue {
   @Watch('trait', {deep: true})
   emitTrait(val: Trait) {
     this.$emit('trait-change', val);
-  }
-
-  filteredDataObj(data: string[]): string[] {
-    const result = data.filter(option => {
-      return (
-        option
-          .toLowerCase()
-          .indexOf(this.name.toLowerCase()) >= 0
-      )
-    });
-
-    return result;
   }
 
   getScaleOptions() {

--- a/src/components/trait/forms/CategoryTraitForm.vue
+++ b/src/components/trait/forms/CategoryTraitForm.vue
@@ -99,7 +99,7 @@ import {PlusCircleIcon} from "vue-feather-icons";
 import {DataType} from "@/breeding-insight/model/Scale";
 import ValueRow from "@/components/trait/forms/ValueRow.vue";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
-import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+import {TraitError} from "@/breeding-insight/model/errors/TraitError";
 import {FieldError} from "@/breeding-insight/model/errors/FieldError";
 import {RowError} from "@/breeding-insight/model/errors/RowError";
 

--- a/src/components/trait/forms/CategoryTraitForm.vue
+++ b/src/components/trait/forms/CategoryTraitForm.vue
@@ -57,6 +57,7 @@
           v-on:label-change="item.label = $event"
           v-bind:value-placeholder="placeholders[i]"
           v-bind:key="i"
+          v-bind:server-row-validation="getCategoryErrors(i)"
         />
       </template>
     </template>
@@ -68,6 +69,7 @@
             v-on:value-change="item.value = $event"
             v-bind:value-placeholder="placeholders[i]"
             v-bind:key="i"
+            v-bind:server-row-validation="getCategoryErrors(i)"
         />
       </template>
     </template>
@@ -96,10 +98,14 @@ import WarningModal from "@/components/modals/WarningModal.vue";
 import {PlusCircleIcon} from "vue-feather-icons";
 import {DataType} from "@/breeding-insight/model/Scale";
 import ValueRow from "@/components/trait/forms/ValueRow.vue";
+import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+import {FieldError} from "@/breeding-insight/model/errors/FieldError";
+import {RowError} from "@/breeding-insight/model/errors/RowError";
 
 @Component({
   components: {ValueRow, BasicInputField, LabelValueRow, WarningModal, PlusCircleIcon},
-  data: () => ({DataType})
+  data: () => ({DataType, TraitError})
 })
 export default class CategoryTraitForm extends Vue {
 
@@ -109,6 +115,10 @@ export default class CategoryTraitForm extends Vue {
   private new!: boolean;
   @Prop()
   private type!: DataType;
+  @Prop()
+  private validationHandler!: ValidationError;
+  @Prop()
+  private validationIndex!: number;
 
   private placeholders = ['ex. Very thin (< 4mm)', 'ex. Thin (4 - 6mm)', 'ex. Intermediate (7 - 9mm)', 'ex. Thick (10 - 12mm)', 'ex. Very Thick (> 12mm)'];
   private deleteWarningTitle: string = "Remove category?"
@@ -124,6 +134,24 @@ export default class CategoryTraitForm extends Vue {
   updateCategories() {
     if (this.data.length === 0) {
       this.prepopulateCategories();
+    }
+  }
+
+  getCategoryErrors(categoryIndex: number): RowError | undefined {
+    if (this.validationHandler) {
+      const fieldErrors: FieldError[] = this.validationHandler.getValidation(this.validationIndex, TraitError.ScaleCategories);
+      if (fieldErrors.length > 0) {
+        for (const [index, fieldError] of fieldErrors.entries()) {
+          // Check that it has nested errors for the catogeries
+          if (fieldError.rowErrors){
+            // Get the specific category index requested
+            const rowError: RowError[] = fieldError.rowErrors.filter(rowError => rowError.rowIndex === categoryIndex);
+            if (rowError && rowError.length > 0) {
+              return rowError[0];
+            }
+          }
+        }
+      }
     }
   }
 

--- a/src/components/trait/forms/DurationTraitForm.vue
+++ b/src/components/trait/forms/DurationTraitForm.vue
@@ -53,7 +53,7 @@
 
   import {Component, Prop, Vue, Watch} from "vue-property-decorator";
   import BasicInputField from "@/components/forms/BasicInputField.vue";
-  import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+  import {TraitError} from "@/breeding-insight/model/errors/TraitError";
   import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
   import AutoCompleteField from "@/components/forms/AutoCompleteField.vue";
 

--- a/src/components/trait/forms/DurationTraitForm.vue
+++ b/src/components/trait/forms/DurationTraitForm.vue
@@ -75,7 +75,7 @@
 
     private unitOptions: string[] = ["seconds","minutes","days","weeks","months"];
 
-    @Watch('validationHandler', {deep: true})
+    @Watch('validationHandler', {immediate: true, deep: true})
     overrideScaleName() {
       // Overwrite missing scale name message
       if (this.validationHandler && this.validationHandler.getValidation(this.validationIndex!, TraitError.ScaleName).length > 0) {

--- a/src/components/trait/forms/DurationTraitForm.vue
+++ b/src/components/trait/forms/DurationTraitForm.vue
@@ -19,17 +19,13 @@
   <div>
     <div class="columns is-vcentered">
       <div class="column">
-        <b-field
-            label="Unit of Time"
-        >
-          <b-autocomplete
-              v-bind:value="unit"
-              v-bind:open-on-focus="true"
-              v-bind:data="filteredDataObj(unitOptions)"
-              v-on:input="$emit('unit-change', $event)"
-              placeholder="Start typing to see suggestions"
-          />
-        </b-field>
+        <AutoCompleteField
+            v-bind:options="unitOptions"
+            v-bind:value="unit"
+            v-bind:field-name="'Unit of Time'"
+            v-bind:server-validations="validationHandler.getValidation(0, TraitError.ScaleName)"
+            v-on:input="$emit('unit-change', $event)"
+        />
       </div>
     </div>
     <div class="columns is-vcentered">
@@ -55,11 +51,15 @@
 
 <script lang="ts">
 
-  import {Component, Prop, Vue} from "vue-property-decorator";
+  import {Component, Prop, Vue, Watch} from "vue-property-decorator";
   import BasicInputField from "@/components/forms/BasicInputField.vue";
+  import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+  import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+  import AutoCompleteField from "@/components/forms/AutoCompleteField.vue";
 
   @Component({
-    components: {BasicInputField}
+    components: {AutoCompleteField, BasicInputField},
+    data: () => ({TraitError})
   })
   export default class DurationTraitForm extends Vue {
     @Prop()
@@ -68,20 +68,18 @@
     private validMin!: number;
     @Prop()
     private validMax!: number;
+    @Prop()
+    private validationHandler!: ValidationError;
+    @Prop()
+    private validationIndex!: number;
 
     private unitOptions: string[] = ["seconds","minutes","days","weeks","months"];
 
-    filteredDataObj(data: string[]): string[] {
-      if (this.unit) {
-        return data.filter(option => {
-          return (
-            option
-              .toLowerCase()
-              .indexOf(this.unit.toLowerCase()) >= 0
-          )
-        });
-      } else {
-        return data;
+    @Watch('validationHandler', {deep: true})
+    overrideScaleName() {
+      // Overwrite missing scale name message
+      if (this.validationHandler && this.validationHandler.getValidation(this.validationIndex!, TraitError.ScaleName).length > 0) {
+        this.validationHandler.overrideMessage(this.validationIndex!, TraitError.ScaleName, 'Missing unit of time', 400);
       }
     }
   }

--- a/src/components/trait/forms/LabelValueRow.vue
+++ b/src/components/trait/forms/LabelValueRow.vue
@@ -17,7 +17,7 @@
 
 <template>
   <div>
-    <div class="columns is-vcentered is-mobile is-gapless">
+    <div class="columns is-mobile is-gapless">
       <div class="column is-2">
         <BasicInputField
             v-bind:field-name="'Label'"
@@ -25,13 +25,14 @@
             v-bind:value="label"
             v-on:input="$emit('label-change', $event)"
             v-bind:input-id="'label' + Math.random()"
+            v-bind:server-validations="serverRowValidation ? serverRowValidation.getValidation(TraitError.CategoryLabel): undefined"
         />
       </div>
       <div class="column is-1 has-text-centered">
-        <p class="is-size-4 mb-2">=</p>
+        <p class="is-size-4 mt-2">=</p>
       </div>
       <div class="column is-9">
-        <div class="columns is-vcentered is-mobile is-gapless">
+        <div class="columns is-mobile is-gapless">
           <div class="column is-four-fifths">
             <BasicInputField
                 v-bind:field-name="'Value'"
@@ -40,10 +41,11 @@
                 v-bind:value="value"
                 v-on:input="$emit('value-change', $event)"
                 v-bind:input-id="'value' + Math.random()"
+                v-bind:server-validations="serverRowValidation ? serverRowValidation.getValidation(TraitError.CategoryValue): undefined"
             />
           </div>
           <div class="column is-one-fifth ml-2">
-            <button type="button" class="delete" v-on:click="$emit('delete')"></button>
+            <button type="button" class="delete mt-4" v-on:click="$emit('delete')"></button>
           </div>
 
         </div>
@@ -54,12 +56,17 @@
 
 <script lang="ts">
 
-import {Component, Prop, Vue} from "vue-property-decorator";
+  import {Component, Prop, Vue, Watch} from "vue-property-decorator";
 import BasicInputField from "@/components/forms/BasicInputField.vue";
 import {XIcon} from 'vue-feather-icons';
+import {FieldError} from "@/breeding-insight/model/errors/FieldError";
+import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+  import {RowError} from "@/breeding-insight/model/errors/RowError";
 
 @Component({
-  components: {BasicInputField, XIcon}
+  components: {BasicInputField, XIcon},
+  data: () => ({TraitError})
 })
 export default class LabelValueRow extends Vue {
   @Prop()
@@ -68,6 +75,8 @@ export default class LabelValueRow extends Vue {
   value!: string;
   @Prop()
   valuePlaceholder: string | undefined;
+  @Prop()
+  serverRowValidation!: RowError;
 }
 
 </script>

--- a/src/components/trait/forms/LabelValueRow.vue
+++ b/src/components/trait/forms/LabelValueRow.vue
@@ -60,7 +60,7 @@
 import BasicInputField from "@/components/forms/BasicInputField.vue";
 import {XIcon} from 'vue-feather-icons';
 import {FieldError} from "@/breeding-insight/model/errors/FieldError";
-import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+import {TraitError} from "@/breeding-insight/model/errors/TraitError";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
   import {RowError} from "@/breeding-insight/model/errors/RowError";
 

--- a/src/components/trait/forms/NumericalTraitForm.vue
+++ b/src/components/trait/forms/NumericalTraitForm.vue
@@ -83,7 +83,7 @@ export default class NumericalTraitForm extends Vue {
   @Prop()
   private validationIndex: number | undefined;
 
-  @Watch('validationHandler', {deep: true})
+  @Watch('validationHandler', {immediate: true, deep: true})
   overrideScaleName() {
     // Overwrite missing scale name message
     if (this.validationHandler && this.validationHandler.getValidation(this.validationIndex!, TraitError.ScaleName).length > 0) {

--- a/src/components/trait/forms/NumericalTraitForm.vue
+++ b/src/components/trait/forms/NumericalTraitForm.vue
@@ -62,7 +62,7 @@
   import {Component, Prop, Vue, Watch} from "vue-property-decorator";
   import BasicInputField from "@/components/forms/BasicInputField.vue";
   import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
-  import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+  import {TraitError} from "@/breeding-insight/model/errors/TraitError";
   import {DataType} from "@/breeding-insight/model/Scale";
 
 @Component({

--- a/src/components/trait/forms/NumericalTraitForm.vue
+++ b/src/components/trait/forms/NumericalTraitForm.vue
@@ -24,6 +24,7 @@
             v-bind:value="unit"
             v-on:input="$emit('unit-change', $event)"
             v-bind:field-help="'Can be any measurable unit.'"
+            v-bind:server-validations="validationHandler.getValidation(validationIndex, TraitError.ScaleName)"
         />
       </div>
       <div class="column is-half">
@@ -58,11 +59,15 @@
 
 <script lang="ts">
 
-  import {Component, Prop, Vue} from "vue-property-decorator";
+  import {Component, Prop, Vue, Watch} from "vue-property-decorator";
   import BasicInputField from "@/components/forms/BasicInputField.vue";
+  import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+  import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+  import {DataType} from "@/breeding-insight/model/Scale";
 
 @Component({
-  components: {BasicInputField}
+  components: {BasicInputField},
+  data: () => ({TraitError})
 })
 export default class NumericalTraitForm extends Vue {
   @Prop()
@@ -73,5 +78,17 @@ export default class NumericalTraitForm extends Vue {
   private validMin: number | undefined;
   @Prop()
   private validMax: number | undefined;
+  @Prop()
+  private validationHandler: ValidationError | undefined;
+  @Prop()
+  private validationIndex: number | undefined;
+
+  @Watch('validationHandler', {deep: true})
+  overrideScaleName() {
+    // Overwrite missing scale name message
+    if (this.validationHandler && this.validationHandler.getValidation(this.validationIndex!, TraitError.ScaleName).length > 0) {
+      this.validationHandler.overrideMessage(this.validationIndex!, TraitError.ScaleName, 'Missing unit', 400);
+    }
+  }
 }
 </script>

--- a/src/components/trait/forms/ValueRow.vue
+++ b/src/components/trait/forms/ValueRow.vue
@@ -42,7 +42,7 @@
   import BasicInputField from "@/components/forms/BasicInputField.vue";
   import {XIcon} from 'vue-feather-icons';
   import {RowError} from "@/breeding-insight/model/errors/RowError";
-  import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
+  import {TraitError} from "@/breeding-insight/model/errors/TraitError";
 
   @Component({
     components: {BasicInputField, XIcon},

--- a/src/components/trait/forms/ValueRow.vue
+++ b/src/components/trait/forms/ValueRow.vue
@@ -26,6 +26,7 @@
             v-bind:value="value"
             v-on:input="$emit('value-change', $event)"
             v-bind:input-id="'value' + Math.random()"
+            v-bind:server-validations="serverRowValidation ? serverRowValidation.getValidation(TraitError.CategoryValue): undefined"
         />
       </div>
       <div class="column is-one-fifth ml-2">
@@ -40,15 +41,20 @@
   import {Component, Prop, Vue} from "vue-property-decorator";
   import BasicInputField from "@/components/forms/BasicInputField.vue";
   import {XIcon} from 'vue-feather-icons';
+  import {RowError} from "@/breeding-insight/model/errors/RowError";
+  import {TraitError} from "@/breeding-insight/model/errors/TraitErrorHandler";
 
   @Component({
-    components: {BasicInputField, XIcon}
+    components: {BasicInputField, XIcon},
+    data: () => ({TraitError})
   })
   export default class ValueRow extends Vue {
     @Prop()
     value!: string;
     @Prop()
     valuePlaceholder: string | undefined;
+    @Prop()
+    serverRowValidation!: RowError;
   }
 
 </script>


### PR DESCRIPTION
PAIRED WITH TEMPLATE UPDATE. UPDATE LINK AFTER APPROVAL:

https://github.com/Breeding-Insight/requirements/pull/16

Also includes a fix to feather icons so that they line up with text properly. 

Maps the server errors to the UI inputs. Some custom parsing needed to be done for `units` because the field they go into is `scaleName`. It's not perfect, but it works for what we are doing. 

The design for the error icons changed slightly after speaking with Liz. I put them in the error text instead of in the input because it was easier for the same effect. 

![screencapture-localhost-8080-programs-d111dfa6-3acd-4906-9aa5-c8f3f4fffce9-traits-list-2020-12-14-15_27_21](https://user-images.githubusercontent.com/17887341/102131905-e6622780-3e20-11eb-9593-f226486dac9a.png)
