### PR TITLE
Feature/bi625

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,7 +5,7 @@ VUE_APP_OPENID_LOGOUT_URL=https://sandbox.orcid.org/userStatus.json?logUserOut=t
 VUE_APP_SANDBOX=public
 
 # Only edit this one
-VUE_APP_BI_API_ROOT=http://localhost:8081
+VUE_APP_BI_API_ROOT=http://localhost
 
 # The level of logging for our logger
 VUE_APP_LOG_LEVEL=error

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN ["mkdir", "/home/host/biweb"]
 WORKDIR /home/${CONT_USERNAME}/biweb
 
 # Install the app dependencies and configuration
+COPY --chown=host:host ["./src", "/home/host/biweb/src/"]
+COPY --chown=host:host ["./task", "/home/host/biweb/task/"]
+COPY --chown=host:host ["./tests", "/home/host/biweb/test/"]
+COPY --chown=host:host ["./public", "/home/host/biweb/public/"]
 COPY --chown=host:host ["babel.config.js", ".browserslistrc", "cypress.json", ".eslintrc.js", ".npmrc", "tsconfig.json", "vue.config.js", ".env.development","./"]
 COPY --chown=host:host ["package.json", "/home/host/biweb/package.json"]
 COPY --chown=host:host ["package-lock.json", "/home/host/biweb/package-lock.json"]


### PR DESCRIPTION
The domain for bi-api-root was from localhost:8081 to localhost since biapi will not have a port exposed on teh host.

Fixed a bug in the docker-copmse.yml files so that the source code and tests are now copied into biweb when in production mode.