### PR TITLE
[BI-680] Fixing invalid versionInfo URL for bi-web

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,7 +5,7 @@ VUE_APP_OPENID_LOGOUT_URL=https://sandbox.orcid.org/userStatus.json?logUserOut=t
 VUE_APP_SANDBOX=public
 
 # Only edit this one
-VUE_APP_BI_API_ROOT=http://localhost:8081
+VUE_APP_BI_API_ROOT=http://localhost
 
 # The level of logging for our logger
 VUE_APP_LOG_LEVEL=error

--- a/vue.config.js
+++ b/vue.config.js
@@ -18,7 +18,7 @@
 const fs = require('fs')
 const packageJson = fs.readFileSync('./package.json')
 const version = JSON.parse(packageJson).version || 0
-const versionInfo = JSON.parse(packageJson).versionTag || 0
+const versionInfo = JSON.parse(packageJson).versionInfo || "https://github.com/Breeding-Insight/bi-web"
 
 process.env.VUE_APP_VERSION = version;
 process.env.VUE_APP_VERSION_INFO = versionInfo;


### PR DESCRIPTION
bi-web was referencing an incorrect field in package.json.  The field needed to be `versionInfo` instead of `versionTag`