### PR TITLE
[BI-563] Archive Individual Trait

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "config": {
-    "devport": "8080",
+    "devport": "8082",
     "task_path": "./task"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "config": {
-    "devport": "8082",
+    "devport": "8080",
     "task_path": "./task"
   },
   "dependencies": {

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -480,3 +480,8 @@ div.sentence-input {
   fill: none;
   stroke-width: 2;
 }
+
+.archive-tag {
+  background: lightgray;
+
+}

--- a/src/breeding-insight/dao/TraitDAO.ts
+++ b/src/breeding-insight/dao/TraitDAO.ts
@@ -55,4 +55,14 @@ export class TraitDAO {
     }) as Response;
     return new BiResponse(data);
   }
+
+  static async archiveTrait(programId: string, trait: Trait): Promise<BiResponse> {
+    const { data } =  await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/traits/${trait.id}/archive`,
+      params: {'active': trait.active},
+      method: 'put'
+    }) as Response;
+    return new BiResponse(data);
+  }
+
 }

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -28,6 +28,7 @@ export class Trait {
   abbreviations?: Array<string>;
   synonyms?: Array<string>;
   mainAbbreviation?: string;
+  active?: boolean;
 
   constructor(id?: string,
               traitName?: string,
@@ -35,7 +36,8 @@ export class Trait {
               method?: Method,
               scale?: Scale,
               abbreviations?: Array<string>,
-              synonyms?: Array<string>
+              synonyms?: Array<string>,
+              active?: boolean
               ) {
     this.id = id;
     this.traitName = traitName;
@@ -56,6 +58,11 @@ export class Trait {
     }
     this.abbreviations = abbreviations;
     this.synonyms = synonyms;
+    if (active) {
+      this.active = active;
+    } else {
+      this.active = true;
+    }
   }
 
   static assign(trait: Trait): Trait {

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -58,7 +58,7 @@ export class Trait {
     }
     this.abbreviations = abbreviations;
     this.synonyms = synonyms;
-    if (active) {
+    if (active !== undefined) {
       this.active = active;
     } else {
       this.active = true;
@@ -67,7 +67,7 @@ export class Trait {
 
   static assign(trait: Trait): Trait {
     return new Trait(trait.id, trait.traitName, trait.programObservationLevel, trait.method,
-      trait.scale, trait.abbreviations, trait.synonyms);
+      trait.scale, trait.abbreviations, trait.synonyms, trait.active);
   }
 
   checkStringListEquals(list: string[] | undefined, otherList: string[] | undefined): boolean {

--- a/src/breeding-insight/service/TraitService.ts
+++ b/src/breeding-insight/service/TraitService.ts
@@ -40,7 +40,7 @@ export class TraitService {
   static async updateTraits(programId: string, traits: Trait[]): Promise<[Trait[], Metadata]> {
     if (programId && traits) {
       // Check that they all have a trait id
-      if (traits.filter(trait => trait.id).length === 0) {
+      if (traits.filter(trait => trait.id).length !== traits.length) {
         throw 'Unable to update trait';
       }
 

--- a/src/breeding-insight/service/TraitService.ts
+++ b/src/breeding-insight/service/TraitService.ts
@@ -37,22 +37,40 @@ export class TraitService {
       else throw 'Unable to create trait';
     }
 
-  static async updateTraits(programId: string, traits: Trait[]): Promise<[Trait[], Metadata]> {
-    if (programId && traits) {
-      // Check that they all have a trait id
-      if (traits.filter(trait => trait.id).length !== traits.length) {
-        throw 'Unable to update trait';
-      }
+    static async updateTraits(programId: string, traits: Trait[]): Promise<[Trait[], Metadata]> {
+      if (programId && traits) {
+        // Check that they all have a trait id
+        if (traits.filter(trait => trait.id).length !== traits.length) {
+          throw 'Unable to update trait';
+        }
 
-      try {
-        const { result: { data }, metadata } = await TraitDAO.updateTraits(programId, traits);
-        return [data, metadata];
-      } catch (error) {
-        throw TraitUploadService.parseError(error);
+        try {
+          const { result: { data }, metadata } = await TraitDAO.updateTraits(programId, traits);
+          return [data, metadata];
+        } catch (error) {
+          throw TraitUploadService.parseError(error);
+        }
       }
+      else throw 'Unable to update trait';
     }
-    else throw 'Unable to update trait';
-  }
+
+    static async archiveTrait(programId: string, trait: Trait): Promise<Trait> {
+
+      if (programId && trait) {
+        // Check that they all have a trait id
+        if (!trait.id){
+          throw 'Unable to update trait';
+        }
+
+        try {
+          const { result, metadata } = await TraitDAO.archiveTrait(programId, trait);
+          return Trait.assign(result);
+        } catch (error) {
+          throw TraitUploadService.parseError(error);
+        }
+      }
+      else throw 'Unable to update trait';
+    }
 
     static getAll(programId: string, paginationQuery?: PaginationQuery, full?: boolean): Promise<[Trait[], Metadata]> {
         return new Promise<[Trait[], Metadata]>(((resolve, reject) => {
@@ -64,10 +82,10 @@ export class TraitService {
       if (full === undefined) {
         full = false;
       }
-            
+
       if (programId) {
           TraitDAO.getAll(programId, paginationQuery, full).then((biResponse) => {
-              
+
           let traits: Trait[] = [];
 
           if (biResponse.result.data) {

--- a/src/components/tables/SidePanel.vue
+++ b/src/components/tables/SidePanel.vue
@@ -35,6 +35,7 @@
     components: {}
   })
   export default class SidePanel extends Vue {
+
     @Prop()
     backgroundColorClass!: string;
     @Prop()

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -70,6 +70,16 @@
       <p class="has-text-weight-bold mt-3 mb-0">Description of collection method</p>
       <p>{{data.method.description}}</p>
 
+      <template v-if="!archivable">
+        <p class="has-text-weight-bold mt-3 mb-0">Included in Favorites</p>
+        <b-button
+            type="is-light"
+            style="background: lightgray"
+            v-if="!archivable">
+          Archived
+        </b-button>
+      </template>
+
       <!-- maybe break out controls for reuse eventually -->
       <div class="columns is-mobile is-centered pt-6">
         <div class="column is-narrow">

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -76,7 +76,7 @@
             size="is-small"
             style="background: lightgray"
             class="archive-tag"
-            v-if="!data.active && archivable">
+            v-if="!data.active">
           Archived
         </b-button>
       </template>
@@ -95,7 +95,7 @@
         </div>
         <div class="column is-narrow">
           <a
-            v-if="archivable && data.active"
+            v-if="data.active"
             v-on:click="$emit('archive', data)"
             v-on:keypress.enter.space="$emit('archive', data)"
             tabindex="0"

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -76,7 +76,7 @@
             size="is-small"
             style="background: lightgray"
             class="archive-tag"
-            v-if="!data.active">
+            v-if="!data.active && archivable">
           Archived
         </b-button>
       </template>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -73,9 +73,10 @@
       <template v-if="!archivable">
         <p class="has-text-weight-bold mt-3 mb-0">Included in Favorites</p>
         <b-button
-            type="is-light"
+            size="is-small"
             style="background: lightgray"
-            v-if="!archivable">
+            class="archive-tag"
+            v-if="!data.active">
           Archived
         </b-button>
       </template>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -91,6 +91,14 @@
             >
             Archive
           </a>
+          <a
+              v-else
+              v-on:click="$emit('restore')"
+              v-on:keypress.enter.space="$emit('restore')"
+              tabindex="0"
+          >
+            Restore/Unarchive
+          </a>
         </div>
       </div>
     </template>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -70,7 +70,7 @@
       <p class="has-text-weight-bold mt-3 mb-0">Description of collection method</p>
       <p>{{data.method.description}}</p>
 
-      <template v-if="!archivable">
+      <template v-if="archivable && !data.active">
         <p class="has-text-weight-bold mt-3 mb-0">Included in Favorites</p>
         <b-button
             size="is-small"
@@ -95,18 +95,18 @@
         </div>
         <div class="column is-narrow">
           <a
-            v-if="archivable"
+            v-if="archivable && data.active"
             v-on:click="$emit('archive', data)"
-            v-on:keypress.enter.space="$emit('archive')"
+            v-on:keypress.enter.space="$emit('archive', data)"
             tabindex="0"
             >
             Archive
           </a>
           <a
-              v-else
-              v-on:click="$emit('restore')"
-              v-on:keypress.enter.space="$emit('restore')"
-              tabindex="0"
+            v-if="archivable && !data.active"
+            v-on:click="$emit('restore', data)"
+            v-on:keypress.enter.space="$emit('restore', data)"
+            tabindex="0"
           >
             Restore/Unarchive
           </a>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -70,7 +70,7 @@
       <p class="has-text-weight-bold mt-3 mb-0">Description of collection method</p>
       <p>{{data.method.description}}</p>
 
-      <template v-if="archivable && !data.active">
+      <template v-if="!data.active">
         <p class="has-text-weight-bold mt-3 mb-0">Included in Favorites</p>
         <b-button
             size="is-small"

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -96,7 +96,7 @@
         <div class="column is-narrow">
           <a
             v-if="archivable"
-            v-on:click="$emit('archive')"
+            v-on:click="$emit('archive', data)"
             v-on:keypress.enter.space="$emit('archive')"
             tabindex="0"
             >

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -29,7 +29,7 @@
       </section>
       <div class="columns">
         <div class="column is-whole has-text-centered buttons">
-          <button v-on:click="modalDeleteHandler()" class="button is-danger"><strong>Yes, remove</strong></button>
+          <button v-on:click="modalDeleteHandler" class="button is-danger"><strong>Yes, remove</strong></button>
           <button v-on:click="deactivateActive = false" class="button">Cancel</button>
         </div>
       </div>              
@@ -77,6 +77,7 @@
     </NewDataForm>
 
     <SidePanelTable
+      ref="sidePanelTable"
       v-bind:records="traits"
       v-bind:pagination="traitsPagination"
       v-bind:auto-handle-close-panel-event="false"
@@ -118,6 +119,7 @@
           v-bind:editable="true"
           v-bind:edit-form-state="traitSidePanelState.dataFormState"
           v-bind:validation-handler="editValidationHandler"
+          v-bind:archivable="true"
           v-on:activate-edit="activateEdit($event)"
           v-on:deactivate-edit="traitSidePanelState.bus.$emit(traitSidePanelState.closePanelEvent)"
           v-on:trait-change="editTrait = Trait.assign({...$event})"
@@ -206,7 +208,7 @@ export default class TraitTable extends Vue {
   private editValidationHandler: ValidationError = new ValidationError();
 
   // Archive trait
-  private deactivateWarningTitle: string;
+  private deactivateWarningTitle = 'Remove trait from this program?';
   private deactivateActive: boolean = false;
 
   // TODO: Move these into an event bus in the future
@@ -214,6 +216,7 @@ export default class TraitTable extends Vue {
   private paginationController: PaginationController = new PaginationController();
 
   mounted() {
+    this.deactivateWarningTitle = `Remove trait from ${this.activeProgram.name}?`;
     this.getTraits();
     this.getObservationLevels();
 
@@ -249,8 +252,12 @@ export default class TraitTable extends Vue {
   }
 
   activateArchive(){
-    this.deactivateWarningTitle = `Remove trait from ${this.activeProgram.name}?`;
     this.deactivateActive = true;
+  }
+
+  modalDeleteHandler(){
+    this.deactivateActive = false;
+    this.traitSidePanelState.bus.$emit(this.traitSidePanelState.closePanelEvent);
   }
 
   activateEdit(editTrait: Trait) {

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -259,6 +259,7 @@ export default class TraitTable extends Vue {
     this.deactivateActive = false;
     this.traitSidePanelState.bus.$emit(this.traitSidePanelState.closePanelEvent);
     this.paginationController.updatePage(1);
+    this.$emit('show-success-notification', 'Trait successfully archived');
   }
 
   activateEdit(editTrait: Trait) {

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -282,7 +282,7 @@ export default class TraitTable extends Vue {
     try {
       const traitClone = JSON.parse(JSON.stringify(this.focusTrait));
       traitClone.active = !traitClone.active;
-      await TraitService.updateTraits(this.activeProgram.id, [ traitClone ]);
+      await TraitService.updateTraits(this.activeProgram!.id!, [ traitClone ]);
       this.deactivateActive = false;
       this.traitSidePanelState.bus.$emit(this.traitSidePanelState.closePanelEvent);
       this.paginationController.updatePage(1);

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -258,6 +258,7 @@ export default class TraitTable extends Vue {
   modalDeleteHandler(){
     this.deactivateActive = false;
     this.traitSidePanelState.bus.$emit(this.traitSidePanelState.closePanelEvent);
+    this.paginationController.updatePage(1);
   }
 
   activateEdit(editTrait: Trait) {

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -19,7 +19,7 @@
   <section id="traitTableLabel">
     <WarningModal
       v-bind:active.sync="deactivateActive"
-      v-bind:msg-title="'Remove trait from Program name?'"
+      v-bind:msg-title="deactivateWarningTitle"
       v-on:deactivate="deactivateActive = false"
     >
       <section>
@@ -122,7 +122,7 @@
           v-on:deactivate-edit="traitSidePanelState.bus.$emit(traitSidePanelState.closePanelEvent)"
           v-on:trait-change="editTrait = Trait.assign({...$event})"
           v-on:submit="updateTrait"
-          v-on:archive="deactivateActive = true"
+          v-on:archive="activateArchive"
         />
       </template>
 
@@ -206,6 +206,7 @@ export default class TraitTable extends Vue {
   private editValidationHandler: ValidationError = new ValidationError();
 
   // Archive trait
+  private deactivateWarningTitle: string;
   private deactivateActive: boolean = false;
 
   // TODO: Move these into an event bus in the future
@@ -245,6 +246,11 @@ export default class TraitTable extends Vue {
       this.$emit('show-error-notification', 'Error while trying to load traits');
       throw error;
     });
+  }
+
+  activateArchive(){
+    this.deactivateWarningTitle = `Remove trait from ${this.activeProgram.name}?`;
+    this.deactivateActive = true;
   }
 
   activateEdit(editTrait: Trait) {

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -270,9 +270,9 @@ export default class TraitTable extends Vue {
 
   activateArchive(focusTrait: Trait){
     if (focusTrait.active) {
-      this.deactivateWarningTitle = `Remove "${focusTrait.traitName}" from ${this.activeProgram.name}?`;
+      this.deactivateWarningTitle = `Remove "${focusTrait.traitName}" from ${this.activeProgram!.name!}?`;
     } else {
-      this.deactivateWarningTitle = `Restore "${focusTrait.traitName}" to ${this.activeProgram.name}?`;
+      this.deactivateWarningTitle = `Restore "${focusTrait.traitName}" to ${this.activeProgram!.name!}?`;
     }
     this.focusTrait = focusTrait;
     this.deactivateActive = true;

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -282,13 +282,18 @@ export default class TraitTable extends Vue {
     try {
       const traitClone = JSON.parse(JSON.stringify(this.focusTrait));
       traitClone.active = !traitClone.active;
-      await TraitService.updateTraits(this.activeProgram!.id!, [ traitClone ]);
+      const updatedTrait: Trait = await TraitService.archiveTrait(this.activeProgram!.id!, traitClone);
+
+      // Replace traits in queried traits
+      const traitIndex = this.traits.findIndex(trait => trait.id === updatedTrait.id);
+      if (traitIndex !== -1) { this.traits.splice(traitIndex, 1, updatedTrait); }
+
       this.deactivateActive = false;
       this.traitSidePanelState.bus.$emit(this.traitSidePanelState.closePanelEvent);
-      this.paginationController.updatePage(1);
       this.$emit('show-success-notification', `"${traitClone.traitName}" successfully ${ traitClone.active ? 'restored' : 'archived'}`);
     } catch(err) {
-      this.$emit('show-error-notification', `"${this.focusTrait.traitName}" could not be ${ this.focusTrait.active ? 'restored' : 'archived'}`);
+      this.$log.error(err);
+      this.$emit('show-error-notification', `"${this.focusTrait.traitName}" could not be ${ this.focusTrait.active ? 'archived' : 'restored'}`);
     }
   }
 

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -94,6 +94,13 @@
       -->
       <template v-slot:columns="data">
         <TableColumn name="name" v-bind:label="'Name'">
+          <b-button
+              size="is-small"
+              style="background: lightgray"
+              class="archive-tag"
+              v-if="!data.active">
+            Archived
+          </b-button>
           {{ data.traitName }}
         </TableColumn>
         <TableColumn name="level" v-bind:label="'Level'" v-bind:visible="!traitSidePanelState.collapseColumns">

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -289,6 +289,7 @@ export default class TraitTable extends Vue {
       if (traitIndex !== -1) { this.traits.splice(traitIndex, 1, updatedTrait); }
 
       this.deactivateActive = false;
+      this.paginationController.updatePage(1);
       this.traitSidePanelState.bus.$emit(this.traitSidePanelState.closePanelEvent);
       this.$emit('show-success-notification', `"${traitClone.traitName}" successfully ${ traitClone.active ? 'restored' : 'archived'}`);
     } catch(err) {

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -29,8 +29,18 @@
       </section>
       <div class="columns">
         <div class="column is-whole has-text-centered buttons">
-          <button v-on:click="modalDeleteHandler" class="button is-danger"><strong>Yes, remove</strong></button>
-          <button v-on:click="deactivateActive = false" class="button">Cancel</button>
+          <button
+            class="button is-danger"
+            v-on:click="modalDeleteHandler"
+          >
+            <strong>Yes, {{ focusTrait.active ? 'remove' : 'restore' }}</strong>
+          </button>
+          <button
+            class="button"
+            v-on:click="deactivateActive = false"
+          >
+            Cancel
+          </button>
         </div>
       </div>              
     </WarningModal>
@@ -96,7 +106,6 @@
         <TableColumn name="name" v-bind:label="'Name'">
           <b-button
               size="is-small"
-              style="background: lightgray"
               class="archive-tag"
               v-if="!data.active && data.active !== undefined">
             Archived
@@ -132,6 +141,7 @@
           v-on:trait-change="editTrait = Trait.assign({...$event})"
           v-on:submit="updateTrait"
           v-on:archive="activateArchive($event)"
+          v-on:restore="activateArchive($event)"
         />
       </template>
 
@@ -215,7 +225,7 @@ export default class TraitTable extends Vue {
   private editValidationHandler: ValidationError = new ValidationError();
 
   // Archive trait
-  private focusTrait: Trait;
+  private focusTrait: Trait = new Trait();
   private deactivateWarningTitle = 'Remove trait from this program?';
   private deactivateActive: boolean = false;
 
@@ -224,7 +234,6 @@ export default class TraitTable extends Vue {
   private paginationController: PaginationController = new PaginationController();
 
   mounted() {
-    this.deactivateWarningTitle = `Remove trait from ${this.activeProgram.name}?`;
     this.getTraits();
     this.getObservationLevels();
 
@@ -259,7 +268,12 @@ export default class TraitTable extends Vue {
     });
   }
 
-  activateArchive(focusTrait){
+  activateArchive(focusTrait: Trait){
+    if (focusTrait.active) {
+      this.deactivateWarningTitle = `Remove "${focusTrait.traitName}" from ${this.activeProgram.name}?`;
+    } else {
+      this.deactivateWarningTitle = `Restore "${focusTrait.traitName}" to ${this.activeProgram.name}?`;
+    }
     this.focusTrait = focusTrait;
     this.deactivateActive = true;
   }
@@ -268,13 +282,13 @@ export default class TraitTable extends Vue {
     try {
       const traitClone = JSON.parse(JSON.stringify(this.focusTrait));
       traitClone.active = !traitClone.active;
-      await TraitService.updateTraits(this.activeProgram, [ traitClone ]);
+      await TraitService.updateTraits(this.activeProgram.id, [ traitClone ]);
       this.deactivateActive = false;
       this.traitSidePanelState.bus.$emit(this.traitSidePanelState.closePanelEvent);
       this.paginationController.updatePage(1);
-      this.$emit('show-success-notification', 'Trait successfully archived');
+      this.$emit('show-success-notification', `"${traitClone.traitName}" successfully ${ traitClone.active ? 'restored' : 'archived'}`);
     } catch(err) {
-      this.$emit('show-error-notification', 'Trait could not be archived');
+      this.$emit('show-error-notification', `"${this.focusTrait.traitName}" could not be ${ this.focusTrait.active ? 'restored' : 'archived'}`);
     }
   }
 

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -33,7 +33,7 @@
             class="button is-danger"
             v-on:click="modalDeleteHandler"
           >
-            <strong>Yes, {{ focusTrait.active ? 'remove' : 'restore' }}</strong>
+            <strong>Yes, {{ focusTrait.active ? 'archive' : 'restore' }}</strong>
           </button>
           <button
             class="button"
@@ -226,7 +226,7 @@ export default class TraitTable extends Vue {
 
   // Archive trait
   private focusTrait: Trait = new Trait();
-  private deactivateWarningTitle = 'Remove trait from this program?';
+  private deactivateWarningTitle = 'Archive trait in this program?';
   private deactivateActive: boolean = false;
 
   // TODO: Move these into an event bus in the future
@@ -270,7 +270,7 @@ export default class TraitTable extends Vue {
 
   activateArchive(focusTrait: Trait){
     if (focusTrait.active) {
-      this.deactivateWarningTitle = `Remove "${focusTrait.traitName}" from ${this.activeProgram!.name!}?`;
+      this.deactivateWarningTitle = `Archive "${focusTrait.traitName}" in ${this.activeProgram!.name!}?`;
     } else {
       this.deactivateWarningTitle = `Restore "${focusTrait.traitName}" to ${this.activeProgram!.name!}?`;
     }

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -122,6 +122,7 @@
           v-on:deactivate-edit="traitSidePanelState.bus.$emit(traitSidePanelState.closePanelEvent)"
           v-on:trait-change="editTrait = Trait.assign({...$event})"
           v-on:submit="updateTrait"
+          v-on:archive="deactivateActive = true"
         />
       </template>
 


### PR DESCRIPTION
The Trait model was updated to include the "active" property and set it to true by default.

The Archiving features in the UI can be activated/deactivated by toggle the state of the archivable prop in TraitsListTable.
Archivable should be set to false until the "active" property is included in trait data from bi-api.

Given: The user has navigated to the "Trait Management" screen
And: the user has selected a trait to view
When: the user clicks "Archive" on the detail pane
Then: ensure that a confirmation dialog appears

Given: The user has clicked “Archive”
When: they confirm archiving the trait
Then: ensure that the trait detail pane is closed
And: ensure that the row shows an indicator that the trait is archived
And: ensure that a success notification is displayed at the top of the screen

Given: The user has clicked “Archive”
When: they decline archiving the trait
Then: ensure that the archive confirmation dialog closes
And: ensure that the trait is not archived

Given: The user has navigated to the "Trait Management" screen
When: the user has selected an archived trait to view
Then: ensure that the ‘Archived’ tag is displayed at the bottom of the detail pane

Given: that there is more than one page of traits in the trait list
When: the user archives a trait that is not on the first page
Then: ensure that the page in view is reset to the first page