### PR TITLE
[BI-701] match even/odd striped row backgrounds when selected for edit

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -128,8 +128,6 @@ main ul {
   }
 }
 
-
-
 nav.pagination {
   align-items: normal;
   justify-content: flex-start;
@@ -268,6 +266,10 @@ nav.tabs li.is-active {
   a {
     color:$link;
   }
+}
+
+.table.is-striped tbody tr:nth-child(even).is-edited {
+  background-color: $primary-light;
 }
 
 .table tr.is-selected {


### PR DESCRIPTION
Description: zebra-striping when editing Users page

Component/Version: rel-test v0.2

Browsers: Chrome, Edge, Opera, Firefox

Steps to Reproduce:

login as as an admin

navigate to Users - take note of the striping to denote different rows

choose a user whose current stripe is grey, select edit - note row stays grey

choose a user whose current stripe is white, select edit - note row turns purple

Expected result:
striping stayed in the same pattern   modified 1/8/20 per discussion w/Liz & Tim
the row being edited should be purple whether original stripe is grey or white

Actual Result:
striping goes off pattern
the row remains grey if the original row color is grey - added 1/8/20
the row turns purple if the original row color is white- added 1/21/20