### PR TITLE
[BI-698] Import Traits not available until refreshing page after adding self to program

### DIFF
--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -192,6 +192,9 @@
   import { User } from '@/breeding-insight/model/User';
   import {UserService} from "@/breeding-insight/service/UserService";
   import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
+  import store from "@/store";
+  import {LOGIN} from "@/store/mutation-types";
+  import {defineAbilityFor} from "@/config/ability";
 
 @Component({
   components: { NewDataForm, BasicInputField, BasicSelectField, TableColumn,
@@ -314,6 +317,8 @@ export default class ProgramUsersTable extends Vue {
         this.$emit('show-success-notification', 'Success! ' + this.newUser.name + ' added.');
       }
 
+      if(this.newUser.email === this.activeUser.email) this.updateActiveUser();
+
       this.getSystemUsers();
       this.newUser = new ProgramUser();
       this.newUserActive = false;
@@ -323,6 +328,13 @@ export default class ProgramUsersTable extends Vue {
       this.getSystemUsers();
     }).finally(() => this.newUserFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT))
 
+  }
+
+  async updateActiveUser() {
+    const user = await UserService.getUserInfo();
+    store.commit(LOGIN, user);
+    const { rules } = defineAbilityFor(store.state.user, store.state.program);
+    Vue.prototype.$ability.update(rules);
   }
 
   //TODO: Reconsider when user search feature is added

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -317,7 +317,7 @@ export default class ProgramUsersTable extends Vue {
         this.$emit('show-success-notification', 'Success! ' + this.newUser.name + ' added.');
       }
 
-      if(this.newUser.email === this.activeUser.email) this.updateActiveUser();
+      if(this.newUser.email === this.activeUser!.email) this.updateActiveUser();
 
       this.getSystemUsers();
       this.newUser = new ProgramUser();

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -283,9 +283,17 @@ export default class ProgramUsersTable extends Vue {
 
   updateUser(updatedUser: ProgramUser) {
 
-    ProgramUserService.update(updatedUser).then(() => {
+    ProgramUserService.update(updatedUser).then((newProgramUser) => {
       this.getUsers();
       this.$emit('show-success-notification', 'Success! ' + updatedUser.name + ' updated.');
+      if(newProgramUser.email === this.activeUser!.email) return UserService.getUserInfo();
+        else return;
+    }).then((user) => {
+      if (user) {
+        store.commit(LOGIN, user);
+        const { rules } = defineAbilityFor(store.state.user, store.state.program);
+        Vue.prototype.$ability.update(rules);
+      }
     }).catch((error) => {
       this.$emit('show-error-notification', error['errorMessage']);
     }).finally(() => this.editUserFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT));

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -283,12 +283,12 @@ export default class ProgramUsersTable extends Vue {
 
   updateUser(updatedUser: ProgramUser) {
 
-    ProgramUserService.update(updatedUser).then((newProgramUser) => {
+    ProgramUserService.update(updatedUser).then((user: any) : any => {
       this.getUsers();
       this.$emit('show-success-notification', 'Success! ' + updatedUser.name + ' updated.');
-      if(newProgramUser.email === this.activeUser!.email) return UserService.getUserInfo();
+      if(user.email === this.activeUser!.email) return UserService.getUserInfo();
         else return;
-    }).then((user) => {
+    }).then((user: any) => {
       if (user) {
         store.commit(LOGIN, user);
         const { rules } = defineAbilityFor(store.state.user, store.state.program);


### PR DESCRIPTION
If the active user is being added to a program then the active user roles are updated as part of the success handler.

Description: Import Traits not available until refreshing page after adding self to program
Component/Version: v0.2
Steps to Reproduce

login as admin

add self to a program

select traits in left navigation bar

Expected result:
Import Traits visible as a selection 

Actual Result:
Import traits not visible until the page is refreshed