### PR TITLE
Feature/bi 564

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "config": {
-    "devport": "8080",
+    "devport": "8082",
     "task_path": "./task"
   },
   "dependencies": {
@@ -75,7 +75,8 @@
     "shelljs": "^0.8.3",
     "typescript": "~3.5.3",
     "vue-cli-plugin-axios": "0.0.4",
-    "vue-template-compiler": "^2.6.10"
+    "vue-template-compiler": "^2.6.10",
+    "vuex-typescript": "^3.0.2"
   },
   "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/cc6dc4fb292f3b034594f2921af963bbed1f1b03"
 }

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -476,3 +476,8 @@ div.sentence-input {
   fill: none;
   stroke-width: 2;
 }
+
+.archive-tag {
+  background: lightgray;
+
+}

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -28,6 +28,7 @@ export class Trait {
   abbreviations?: Array<string>;
   synonyms?: Array<string>;
   mainAbbreviation?: string;
+  active?: boolean;
 
   constructor(id?: string,
               traitName?: string,

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -36,7 +36,8 @@ export class Trait {
               method?: Method,
               scale?: Scale,
               abbreviations?: Array<string>,
-              synonyms?: Array<string>
+              synonyms?: Array<string>,
+              active?: boolean
               ) {
     this.id = id;
     this.traitName = traitName;
@@ -57,6 +58,11 @@ export class Trait {
     }
     this.abbreviations = abbreviations;
     this.synonyms = synonyms;
+    if (active) {
+      this.active = active;
+    } else {
+      this.active = true;
+    }
   }
 
   static assign(trait: Trait): Trait {

--- a/src/components/tables/ArchiveBaseTable.vue
+++ b/src/components/tables/ArchiveBaseTable.vue
@@ -1,0 +1,169 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div>
+    <v-breakpoint v-on:mobile="emitAndUpdateIsMobile('mobile')"></v-breakpoint>
+    <v-breakpoint v-on:tablet="emitAndUpdateIsMobile('tablet')"></v-breakpoint>
+    <v-breakpoint v-on:desktop="emitAndUpdateIsMobile('desktop')"></v-breakpoint>
+    <table
+      class="table is-striped is-narrow is-hoverable is-fullwidth"
+    >
+      <thead v-if="updatedColumns.length">
+        <tr>
+          <!-- Header space for left row icon if desired -->
+          <th v-if="showRowIcon" width="40px" scope="col"/>
+          <th v-for="(column, index) in visibleColumns"
+              scope="col"
+              v-bind:key="index"
+              v-bind:style="{
+                width: column.width === undefined ? null :
+                (isNaN(column.width) ? column.width : column.width + 'px')
+              }"
+          >
+            {{ column.label }}
+          </th>
+          <!-- Add a header column to match spacing for row controls if specified -->
+          <template v-if="showExpandControls">
+            <td />
+          </template>
+        </tr>
+      </thead>
+      <tbody>
+        <template v-for="(row, index) in tableRows">
+          <!-- slot to customize each row in table -->
+          <slot name="row" v-bind:row="row" v-bind:index="index"></slot>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script lang="ts">
+
+  import {Component, Prop, Vue, Watch} from 'vue-property-decorator'
+  import {TableRow} from "@/breeding-insight/model/view_models/TableRow"
+  import TableColumn from "@/components/tables/TableColumn.vue";
+  import { VBreakpoint } from '@/components/VBreakpoint';
+
+  @Component({
+    components: { VBreakpoint
+    }
+  })
+  export default class BaseTable extends Vue {
+
+    //<slot name="table-row" v-bind:row-data="program"></slot>
+    // Knows all of the data
+    @Prop()
+    records!: Array<any>;
+    @Prop()
+    editable!: boolean;
+    @Prop()
+    archivable!: boolean;
+    @Prop({default: () => []})
+    columns!: Array<TableColumn>;
+    @Prop()
+    showExpandControls!: boolean;
+    @Prop()
+    showRowIcon!: boolean;
+
+    private initialUpdate: boolean = false;
+    private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
+    private updatedColumns: Array<TableColumn> = [...this.columns];
+    private isMobile = false;
+
+    /**
+     * Used by TableColumn component to find it's parent BaseTable
+     */
+    private isTable = true;
+
+    updated() {
+      this.initialUpdate = true;
+    }
+
+    @Watch('updatedColumns', {immediate:true})
+    updateColSpan() {
+      this.$emit('colspan', this.visibleColumns.length);
+    }
+
+    get visibleColumns() {
+      return this.updatedColumns.filter((column) => {
+          return column.isVisible || column.isVisible === undefined
+      })
+    }
+
+    @Watch('records', {immediate: true, deep:true})
+    updateTableRows(newRecords: any, oldRecords: any) {
+      let difference: Array<string> = [];
+      if (oldRecords !== null && this.initialUpdate) {
+        const newSet: Set<string> = new Set(newRecords
+          .filter( (record: any) => record.id !== undefined)
+          .map( (filteredRecord: any) => filteredRecord.id)
+        );
+        const oldSet: Set<string> = new Set(oldRecords
+          .filter( (record: any) => record.id !== undefined)
+          .map( (filteredRecord: any) => filteredRecord.id)
+        );
+        difference = [...newSet].filter( (record: any) => !oldSet.has(record));
+      }
+
+      const rowArray = new Array<TableRow<any>>();
+      for (const record of this.records){
+        const newTableRow = new TableRow<any>(this.editable, this.archivable, record);
+
+        // See if it is our new row
+        if (difference.length === 1) {
+          if (record.id === difference[0]) {
+            newTableRow.toggleNew();
+          }
+        }
+        rowArray.push(newTableRow);
+      }
+      this.tableRows = rowArray;
+    }
+
+    /**
+     * Used by TableColumn component to add itself to BaseTable
+     * @param column
+     */
+    addColumn(column: TableColumn) {
+      const repeated = this.updatedColumns.some(
+          (col) => col.newKey === column.newKey)
+
+      if (!repeated) {
+        this.updatedColumns.push(column);
+      }
+    }
+
+    emitAndUpdateIsMobile(event: string) {
+      this.$emit(event);
+      if (this.isMobile) {
+        if (event === 'tablet' || event === 'desktop') {
+          this.isMobile = false;
+          this.$emit('is-mobile', false);
+        }
+      }
+      else {
+        if (event === 'mobile') {
+          this.isMobile = true;
+          this.$emit('is-mobile', true);
+        }
+      }
+    }
+
+  }
+</script>

--- a/src/components/tables/ArchivePaginationControls.vue
+++ b/src/components/tables/ArchivePaginationControls.vue
@@ -1,0 +1,111 @@
+<template>
+  <b-pagination
+      v-if="pagination"
+      :total="pagination.totalCount"
+      :current="pagination.currentPage"
+      range-before="1"
+      range-after="1"
+      order="is-centered"
+      size="is-small"
+      :simple="false"
+      :rounded="false"
+      :per-page="pagination.pageSize"
+      aria-next-label="Next page"
+      aria-previous-label="Previous page"
+      aria-page-label="Page"
+      aria-current-label="Current page"
+      v-on:change="updatePage($event)"
+  >
+    <b-pagination-button
+        slot="previous"
+        slot-scope="props"
+        :page="props.page"
+        tag="a"
+    >
+      Previous
+    </b-pagination-button>
+
+    <template
+        slot="next"
+        slot-scope="props"
+    >
+      <b-pagination-button
+          :page="props.page"
+          tag="a"
+      >
+        Next
+      </b-pagination-button>
+
+      <div class="pagination-extras">
+        <div class="page-size-select pagination-link">
+          <div class="select is-small">
+            <label for="paginationSelect" class="is-sr-only">Results Per Page</label>
+            <select
+                id="paginationSelect"
+                :value="pagination.pageSize"
+                v-on:change="updatePageSize($event.target.value)"
+            >
+              <option value="10">
+                10
+              </option>
+              <option value="20">
+                20
+              </option>
+              <option value="50">
+                50
+              </option>
+              <option value="100">
+                100
+              </option>
+              <option value="200">
+                200
+              </option>
+            </select>
+          </div>
+          <span>per page</span>
+        </div>
+
+        <a
+            data-testid="showAll"
+            role="button"
+            class="pagination-link show-all-button"
+            v-bind:class="{ 'has-background-info': pagination.totalPages === 1}"
+            v-on:click="toggleShowAll"
+        >
+          Show All
+        </a>
+      </div>
+    </template>
+  </b-pagination>
+</template>
+
+<script lang="ts">
+  import {Component, Prop, Vue} from 'vue-property-decorator'
+  import {Pagination} from "@/breeding-insight/model/BiResponse";
+  import {TOGGLE_SHOW_ALL, UPDATE_PAGE, UPDATE_PAGE_SIZE} from "@/store/pagination/mutation-types";
+  import {mapMutations} from 'vuex';
+
+  @Component({
+    methods: {
+      ...mapMutations({
+        [UPDATE_PAGE_SIZE](commit, newSize) {
+          return commit(this.namespace + UPDATE_PAGE_SIZE, newSize);
+        },
+        [UPDATE_PAGE](commit, newPage) {
+          return commit(this.namespace + UPDATE_PAGE, newPage);
+        },
+        [TOGGLE_SHOW_ALL](commit) {
+          return commit(this.namespace + TOGGLE_SHOW_ALL);
+        }
+      })
+    }
+  })
+  export default class PaginationControls extends Vue {
+
+    @Prop()
+    private pagination!: Pagination;
+    @Prop()
+    private namespace?: string;
+
+  }
+</script>

--- a/src/components/tables/ArchiveSidePanelTable.vue
+++ b/src/components/tables/ArchiveSidePanelTable.vue
@@ -1,0 +1,246 @@
+<template>
+  <div>
+    <WarningModal
+        v-bind:active.sync="sidePanelState.closeEditModalActive"
+        v-bind:msg-title="'Close edit panel?'"
+        v-on:deactivate="sidePanelState.bus.$emit(sidePanelState.cancelCloseEditEvent)"
+    >
+      <section>
+        <p class="has-text-dark">
+          You will lose any edits you have made upon closing.
+        </p>
+      </section>
+      <div class="columns">
+        <div class="column is-whole has-text-centered buttons">
+          <button
+              class="button is-danger"
+              type="button"
+              v-on:click="sidePanelState.bus.$emit(sidePanelState.confirmCloseEditEvent)"
+          >
+            <strong>Yes, close</strong>
+          </button>
+          <button
+              class="button"
+              type="button"
+              v-on:click="sidePanelState.bus.$emit(sidePanelState.cancelCloseEditEvent)"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </WarningModal>
+
+    <div class="side-panel-table">
+      <div class="columns is-mobile">
+        <div class="column pr-0">
+          <ArchiveBaseTable
+              v-show="records.length > 0"
+              v-bind:show-expand-controls="true"
+              v-bind:editable="true"
+              v-bind="$props"
+              v-on:mobile="collapseService.send(BreakpointEvent.MOBILE)"
+              v-on:tablet="collapseService.send(BreakpointEvent.TABLET)"
+              v-on:desktop="collapseService.send(BreakpointEvent.DESKTOP)"
+              v-on="$listeners"
+          >
+
+            <!--
+              Table row slot customization
+              row:   TableRow<any>
+              index: number
+            -->
+            <template v-slot:row="{row, index}">
+              <SidePanelTableRow
+                  v-bind:key="'row' + index"
+                  v-bind:row-data="row"
+                  v-bind:state="sidePanelState"
+              >
+                <slot
+                    v-bind="row.data"
+                    name="columns"
+                />
+              </SidePanelTableRow>
+            </template>
+
+          </ArchiveBaseTable>
+        </div>
+        <div
+            class="column is-gapless pl-0"
+            v-bind:class="{'is-narrow': !sidePanelState.panelOpen,
+              'is-one-third-desktop is-half-tablet is-half-mobile': (sidePanelState.panelOpen & !sidePanelState.editActive),
+              'is-one-half-desktop is-half-tablet is-half-mobile': (sidePanelState.panelOpen & sidePanelState.editActive)}"
+        >
+          <SidePanel
+              v-bind:state="sidePanelState"
+              v-show="records.length > 0"
+              class="side-panel-scroll"
+              v-if="sidePanelState.panelOpen"
+              v-bind:background-color-class="sidePanelState.editActive ? 'has-background-primary-light' : 'has-background-info-light'"
+          >
+            <slot v-bind:table-row="sidePanelState.openedRow" name="side-panel"/>
+          </SidePanel>
+        </div>
+      </div>
+      <ArchivePaginationControls v-show="records.length > 0"
+                          v-bind="$props"
+                          v-on:paginate="closePanelAndReEmit('paginate', $event)"
+                          v-on:paginate-toggle-all="closePanelAndReEmit('paginate-toggle-all', $event)"
+                          v-on:paginate-page-size="closePanelAndReEmit('paginate-page-size', $event)"/>
+
+      <template v-if="records.length === 0">
+        <slot name="emptyMessage" />
+      </template>
+    </div>
+
+  </div>
+</template>
+
+<script lang="ts">
+  import {Component, Prop, Vue, Watch} from 'vue-property-decorator'
+  import {Pagination} from "@/breeding-insight/model/BiResponse";
+  import ArchiveBaseTable from '@/components/tables/ArchiveBaseTable.vue'
+  import SidePanel from '@/components/tables/SidePanel.vue'
+  import SidePanelTableRow from '@/components/tables/SidePanelTableRow.vue'
+  import ArchivePaginationControls from '@/components/tables/ArchivePaginationControls.vue'
+  import {createMachine, interpret} from '@xstate/fsm';
+  import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableEventBus";
+  import WarningModal from "@/components/modals/WarningModal.vue";
+
+  enum CollapseColumnsState {
+    SMALL_PANEL_OPEN = "SMALL_PANEL_OPEN",
+    SMALL_PANEL_CLOSED = "SMALL_PANEL_CLOSED",
+    NORMAL_PANEL_OPEN = "NORMAL_PANEL_OPEN",
+    NORMAL_PANEL_CLOSED = "NORMAL_PANEL_CLOSED"
+  }
+
+  enum BreakpointEvent {
+    MOBILE = "MOBILE",
+    TABLET = "TABLET",
+    DESKTOP = "DESKTOP",
+  }
+
+  enum PanelEvent {
+    OPEN = "OPEN",
+    CLOSED = "CLOSED",
+  }
+
+  enum CollapseColumnAction {
+    COLLAPSE = "COLLAPSE",
+    UNCOLLAPSE = "UNCOLLAPSE",
+  }
+
+  @Component({
+    components: {
+      ArchiveBaseTable, SidePanel, SidePanelTableRow, ArchivePaginationControls, WarningModal
+    },
+    data: () => ({})
+  })
+  export default class SidePanelTable extends Vue {
+
+    @Prop()
+    records!: Array<any>;
+    @Prop()
+    rowValidations!: Object;
+    @Prop()
+    pagination!: Pagination;
+    @Prop()
+    autoHandleClosePanelEvent!: boolean;
+    @Prop()
+    sidePanelState!: SidePanelTableEventBusHandler;
+    @Prop()
+    namespace?: string;
+
+
+    private BreakpointEvent = BreakpointEvent;
+    private state = CollapseColumnsState.NORMAL_PANEL_CLOSED;
+    private collapseStateMachine = createMachine({
+      id: 'collapse',
+      initial: CollapseColumnsState.NORMAL_PANEL_CLOSED,
+      states: {
+        [CollapseColumnsState.NORMAL_PANEL_CLOSED]: {
+          on: {
+            [BreakpointEvent.TABLET]: CollapseColumnsState.SMALL_PANEL_CLOSED,
+            [BreakpointEvent.MOBILE]: CollapseColumnsState.SMALL_PANEL_CLOSED,
+            [PanelEvent.OPEN]: CollapseColumnsState.NORMAL_PANEL_OPEN,
+          } 
+        },
+        [CollapseColumnsState.NORMAL_PANEL_OPEN]: {
+          on: {
+            [BreakpointEvent.TABLET]: CollapseColumnsState.SMALL_PANEL_OPEN,
+            [BreakpointEvent.MOBILE]: CollapseColumnsState.SMALL_PANEL_OPEN,
+            [PanelEvent.CLOSED]: CollapseColumnsState.NORMAL_PANEL_CLOSED,
+          } 
+        },
+        [CollapseColumnsState.SMALL_PANEL_CLOSED]: {
+          entry: CollapseColumnAction.UNCOLLAPSE,
+          on: { 
+            [BreakpointEvent.DESKTOP]: CollapseColumnsState.NORMAL_PANEL_CLOSED,
+            [PanelEvent.OPEN]: CollapseColumnsState.SMALL_PANEL_OPEN
+          }
+        },
+        [CollapseColumnsState.SMALL_PANEL_OPEN]: {
+          entry: CollapseColumnAction.COLLAPSE,
+          on: { 
+            [BreakpointEvent.DESKTOP]: {
+              target: CollapseColumnsState.NORMAL_PANEL_OPEN,
+              actions: [CollapseColumnAction.UNCOLLAPSE]
+            },
+            [PanelEvent.CLOSED]: CollapseColumnsState.SMALL_PANEL_CLOSED,
+          }
+        },
+      }
+    },
+    {
+      actions: {
+        [CollapseColumnAction.COLLAPSE]: (context, event) => {
+          this.collapse();
+        },
+        [CollapseColumnAction.UNCOLLAPSE]: (context, event) => {
+          this.unCollapse();
+        },
+      }
+
+    });
+
+    private initialState = this.collapseStateMachine;
+    private collapseService = interpret(this.collapseStateMachine);
+
+    @Watch('autoHandleClosePanelEvent', {immediate: true})
+    public setupClosePanelEvent(newVal: boolean) {
+      if (newVal){
+        this.sidePanelState.bus.$on(this.sidePanelState.requestClosePanelEvent, this.confirmClose);
+      } else {
+        this.sidePanelState.bus.$off(this.sidePanelState.requestClosePanelEvent, this.confirmClose);
+      }
+    }
+
+    confirmClose() {
+      this.sidePanelState.bus.$emit(this.sidePanelState.confirmCloseEditEvent);
+    }
+
+    created() {
+      this.collapseService.subscribe(state => {
+        this.state = CollapseColumnsState[state.value as keyof typeof CollapseColumnsState];
+      });
+      this.collapseService.start();
+
+      this.sidePanelState.bus.$on(this.sidePanelState.confirmOpenPanel, () => { this.collapseService.send(PanelEvent.OPEN); });
+      this.sidePanelState.bus.$on(this.sidePanelState.closePanelEvent, () => { this.collapseService.send(PanelEvent.CLOSED); });
+    }
+
+    // send events and allow caller to customize what column(s) are shown for collapsed state
+    collapse() {
+      this.sidePanelState.bus.$emit(this.sidePanelState.collapseColumnsEvent);
+    }
+
+    unCollapse() {
+      this.sidePanelState.bus.$emit(this.sidePanelState.uncollapseColumnsEvent);
+    }
+
+    closePanelAndReEmit(eventType: string, event: any) {
+      this.sidePanelState.bus.$emit(this.sidePanelState.closePanelEvent, () => {this.$emit(eventType, event)});
+    }
+
+  }
+</script>
+

--- a/src/components/trait/TraitsArchiveTable.vue
+++ b/src/components/trait/TraitsArchiveTable.vue
@@ -149,7 +149,7 @@ import WarningModal from '@/components/modals/WarningModal.vue'
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate';
 import {Trait} from '@/breeding-insight/model/Trait'
-import {mapMutations, mapGetters, mapState, mapActions} from 'vuex'
+import {mapGetters, mapState, mapActions} from 'vuex'
 import {Program} from "@/breeding-insight/model/Program";
 import NewDataForm from '@/components/forms/NewDataForm.vue'
 import BasicInputField from "@/components/forms/BasicInputField.vue";
@@ -158,7 +158,7 @@ import TraitDetailPanel from "@/components/trait/TraitDetailPanel.vue";
 import {TraitService} from "@/breeding-insight/service/TraitService";
 import EmptyTableMessage from "@/components/tables/EmtpyTableMessage.vue";
 import TableColumn from "@/components/tables/TableColumn.vue";
-import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
 import { StringFormatters } from '@/breeding-insight/utils/StringFormatters';
 import { TraitStringFormatters } from '@/breeding-insight/utils/TraitStringFormatters';
 import BaseTraitForm from "@/components/trait/forms/BaseTraitForm.vue";
@@ -168,7 +168,7 @@ import {MethodClass} from "@/breeding-insight/model/Method";
 import {DataType, Scale} from "@/breeding-insight/model/Scale";
 import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableEventBus";
 import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
-import {TOGGLE_SHOW_ALL, UPDATE_PAGE, UPDATE_PAGE_SIZE} from "@/store/pagination/mutation-types";
+import {GET_ALL_ARCHIVED_TRAITS, GET_ARCHIVED_TRAITS} from "@/store/traits/archive/action-types";
 
   @Component({
   mixins: [validationMixin],
@@ -189,14 +189,9 @@ import {TOGGLE_SHOW_ALL, UPDATE_PAGE, UPDATE_PAGE_SIZE} from "@/store/pagination
     })
   },
   methods: {
-    ...mapMutations('traits/archive/pagination',[
-        UPDATE_PAGE,
-        UPDATE_PAGE_SIZE,
-        TOGGLE_SHOW_ALL
-    ]),
     ...mapActions('traits/archive', [
-      'getAllArchivedTraits',
-      'getArchivedTraits'
+      GET_ALL_ARCHIVED_TRAITS,
+      GET_ARCHIVED_TRAITS
     ])
   },
   data: () => ({Trait, StringFormatters, TraitStringFormatters})
@@ -228,7 +223,7 @@ export default class TraitsArchiveTable extends Vue {
   private deactivateActive: boolean = false;
 
   mounted() {
-    this.getArchivedTraits();
+    this[GET_ARCHIVED_TRAITS]();
     this.getObservationLevels();
 
     // Events
@@ -245,15 +240,18 @@ export default class TraitsArchiveTable extends Vue {
   }
   @Watch('paginationController.pageSize')
   onPageSizeChange() {
-    this.getArchivedTraits();
+    let force: boolean = true;
+    this.getArchivedTraits(force);
   }
   @Watch('paginationController.currentPage')
   onPageChange() {
-      this.getArchivedTraits();
+    let force: boolean = false;
+    this.getArchivedTraits(force);
   }
   @Watch('paginationController.showAll')
   onShowAllChange() {
-      this.getArchivedTraits();
+    let force: boolean = false;
+    this.getArchivedTraits(force);
   }
 
   activateEdit(editTrait: Trait) {

--- a/src/components/trait/TraitsArchiveTable.vue
+++ b/src/components/trait/TraitsArchiveTable.vue
@@ -1,0 +1,359 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <section id="traitTableLabel">
+    <WarningModal
+      v-bind:active.sync="deactivateActive"
+      v-bind:msg-title="'Remove trait from Program name?'"
+      v-on:deactivate="deactivateActive = false"
+    >
+      <section>
+        <p class="has-text-dark">
+          Program-related data referencing this trait will not be affected by this change.
+        </p>
+      </section>
+      <div class="columns">
+        <div class="column is-whole has-text-centered buttons">
+          <button v-on:click="modalDeleteHandler()" class="button is-danger"><strong>Yes, remove</strong></button>
+          <button v-on:click="deactivateActive = false" class="button">Cancel</button>
+        </div>
+      </div>              
+    </WarningModal>
+
+    <div class="columns has-text-right mb-0">
+      <div class="column">
+        <button
+            data-testid="newDataForm"
+            v-show="!newTraitActive & traits.length > 0"
+            class="button is-primary has-text-weight-bold"
+            v-on:click="activateNewTraitForm"
+        >
+        <span class="icon is-small">
+          <PlusCircleIcon
+              size="1.5x"
+              aria-hidden="true"
+          />
+        </span>
+          <span>
+          New Trait
+        </span>
+        </button>
+      </div>
+    </div>
+
+    <NewDataForm
+        v-if="newTraitActive"
+        v-bind:new-record.sync="newTrait"
+        v-bind:data-form-state="newTraitFormState"
+        v-on:submit="saveTrait"
+        v-on:cancel="cancelNewTrait"
+        v-on:show-error-notification="$emit('show-error-notification', $event)"
+    >
+      <template v-slot="validations">
+        <BaseTraitForm
+            v-on:trait-change="newTrait = $event"
+            v-bind:trait="newTrait"
+            v-bind:scale-options="scaleClassOptions"
+            v-bind:method-options="methodClassOptions"
+            v-bind:program-observation-levels="observationLevelOptions"
+            v-bind:validation-handler="validationHandler"
+        ></BaseTraitForm>
+      </template>
+    </NewDataForm>
+
+    <ArchiveSidePanelTable
+      :records="paginatedArchivedTraits"
+      :pagination="archivePagination"
+      :namespace="namespace"
+      :auto-handle-close-panel-event="false"
+      :side-panel-state="traitSidePanelState"
+      @:show-error-notification="$emit('show-error-notification', $event)"
+    >
+
+      <!-- 
+        Table row column slot specification
+        data: T
+      -->
+      <template #columns="data">
+        <TableColumn name="name" :label="'Name'">
+          {{ data.traitName }}
+        </TableColumn>
+        <TableColumn name="level" :label="'Level'" :visible="!traitSidePanelState.collapseColumns">
+          {{ data.programObservationLevel.name }}
+        </TableColumn>
+        <TableColumn name="method" :label="'Method'" :visible="!traitSidePanelState.collapseColumns">
+          {{ StringFormatters.toStartCase(data.method.methodClass) }}
+        </TableColumn>
+        <TableColumn name="scale" :label="'Scale'" :visible="!traitSidePanelState.collapseColumns">
+          {{ TraitStringFormatters.getScaleTypeString(data.scale) }}
+        </TableColumn>        
+      </template>
+
+      <!-- 
+        Side panel data slot specification
+        data: T
+      -->
+      <template #side-panel="{tableRow}">
+        <TraitDetailPanel
+          :data="traitSidePanelState.openedRow"
+          :observation-level-options="observationLevelOptions"
+          :edit-active="traitSidePanelState.editActive"
+          :editable="true"
+          :edit-form-state="traitSidePanelState.dataFormState"
+          @:activate-edit="activateEdit($event)"
+          @:deactivate-edit="traitSidePanelState.bus.$emit(traitSidePanelState.closePanelEvent)"
+          @:trait-change="editTrait = Trait.assign({...$event})"
+          @:submit="updateTrait"
+        />
+      </template>
+
+      <template v-slot:emptyMessage>
+        <EmptyTableMessage
+            :button-view-toggle="!newTraitActive"
+            :button-text="'New Trait'"
+            @:newClick="activateNewTraitForm"
+        >
+          <p class="has-text-weight-bold">
+            No traits are currently archived for this program.
+          </p>
+          Archive a trait by first navigating to "Trait List" then clicking "Show Details" and finally "Archive".
+        </EmptyTableMessage>
+      </template>
+    </ArchiveSidePanelTable>
+  </section>
+</template>
+
+<script lang="ts">
+import {Component, Vue, Watch} from 'vue-property-decorator'
+import WarningModal from '@/components/modals/WarningModal.vue'
+import {PlusCircleIcon} from 'vue-feather-icons'
+import {validationMixin} from 'vuelidate';
+import {Trait} from '@/breeding-insight/model/Trait'
+import {mapMutations, mapGetters, mapState, mapActions} from 'vuex'
+import {Program} from "@/breeding-insight/model/Program";
+import NewDataForm from '@/components/forms/NewDataForm.vue'
+import BasicInputField from "@/components/forms/BasicInputField.vue";
+import ArchiveSidePanelTable from "@/components/tables/ArchiveSidePanelTable.vue";
+import TraitDetailPanel from "@/components/trait/TraitDetailPanel.vue";
+import {TraitService} from "@/breeding-insight/service/TraitService";
+import EmptyTableMessage from "@/components/tables/EmtpyTableMessage.vue";
+import TableColumn from "@/components/tables/TableColumn.vue";
+import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
+import { StringFormatters } from '@/breeding-insight/utils/StringFormatters';
+import { TraitStringFormatters } from '@/breeding-insight/utils/TraitStringFormatters';
+import BaseTraitForm from "@/components/trait/forms/BaseTraitForm.vue";
+import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+import {ProgramService} from "@/breeding-insight/service/ProgramService";
+import {MethodClass} from "@/breeding-insight/model/Method";
+import {DataType, Scale} from "@/breeding-insight/model/Scale";
+import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableEventBus";
+import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
+import {TOGGLE_SHOW_ALL, UPDATE_PAGE, UPDATE_PAGE_SIZE} from "@/store/pagination/mutation-types";
+
+  @Component({
+  mixins: [validationMixin],
+  components: {
+    BaseTraitForm, NewDataForm, BasicInputField, ArchiveSidePanelTable, EmptyTableMessage, TableColumn,
+                WarningModal, TraitDetailPanel,
+                PlusCircleIcon },
+  computed: {
+    ...mapGetters([
+      'activeProgram'
+    ]),
+    ...mapGetters('traits/archive',[
+        'archivePagination'
+    ]),
+    ...mapState('traits/archive', {
+      paginatedArchivedTraits: state => state.paginatedTraits,
+      paginationController: state => state.pagination
+    })
+  },
+  methods: {
+    ...mapMutations('traits/archive/pagination',[
+        UPDATE_PAGE,
+        UPDATE_PAGE_SIZE,
+        TOGGLE_SHOW_ALL
+    ]),
+    ...mapActions('traits/archive', [
+      'getAllArchivedTraits',
+      'getArchivedTraits'
+    ])
+  },
+  data: () => ({Trait, StringFormatters, TraitStringFormatters})
+})
+export default class TraitsArchiveTable extends Vue {
+
+  private activeProgram?: Program;
+  private traits: Trait[] = [];
+  private methodClassOptions: string[] = Object.values(MethodClass);
+  private observationLevelOptions?: string[];
+  private scaleClassOptions: string[] = Object.values(DataType);
+  private editTrait?: Trait;
+  private originalTrait?: Trait;
+  private newTrait: Trait = new Trait();
+  private namespace: string = 'traits/archive/pagination/';
+
+  // New trait form
+  private newTraitActive: boolean = false;
+  private validationHandler: ValidationError = new ValidationError();
+  private newTraitFormState: DataFormEventBusHandler = new DataFormEventBusHandler();
+
+  // Side panel table
+  private traitSidePanelState: SidePanelTableEventBusHandler = new SidePanelTableEventBusHandler();
+
+  // Edit form
+  private editValidationHandler: ValidationError = new ValidationError();
+
+  // Archive trait
+  private deactivateActive: boolean = false;
+
+  mounted() {
+    this.getArchivedTraits();
+    this.getObservationLevels();
+
+    // Events
+    this.traitSidePanelState.bus.$on(this.traitSidePanelState.requestClosePanelEvent, (showWarningEvent: Function, confirmCloseEvent: Function) => {
+      if (this.editTrait && !this.editTrait.equals(this.originalTrait)) {
+        showWarningEvent();
+      } else {
+        confirmCloseEvent();
+      }
+    });
+    this.traitSidePanelState.bus.$on(this.traitSidePanelState.confirmCloseEditEvent, () => {
+      this.clearSelectedRow();
+    });
+  }
+  @Watch('paginationController.pageSize')
+  onPageSizeChange() {
+    this.getArchivedTraits();
+  }
+  @Watch('paginationController.currentPage')
+  onPageChange() {
+      this.getArchivedTraits();
+  }
+  @Watch('paginationController.showAll')
+  onShowAllChange() {
+      this.getArchivedTraits();
+  }
+
+  activateEdit(editTrait: Trait) {
+    this.traitSidePanelState.bus.$emit(this.traitSidePanelState.activateEditEvent);
+    this.originalTrait = Trait.assign({...editTrait} as Trait);
+    this.editTrait = Trait.assign({...editTrait} as Trait);
+  }
+
+  activateNewTraitForm() {
+    this.traitSidePanelState.bus.$emit(this.traitSidePanelState.closePanelEvent, () => { this.newTraitActive = true; });
+  }
+
+  clearSelectedRow() {
+    this.editTrait = undefined;
+    this.originalTrait = undefined;
+  }
+
+  async saveTrait() {
+    try {
+      this.validationHandler = new ValidationError();
+      await TraitService.createTraits(this.activeProgram!.id!, [this.newTrait]);
+      this.$emit('show-success-notification', 'Trait creation successful.');
+      this.getTraits();
+      await this.getObservationLevels();
+      this.newTrait = new Trait();
+      this.newTraitActive = false;
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        this.validationHandler = error;
+
+        // Set up overrides for error messages
+        let deletions: string[] = [];
+        //TODO: Move this into the class perhaps
+        if (!this.newTrait.scale!.dataType) {
+          // Remove scale name error
+          deletions.push('scale.scaleName');
+        } else if (Scale.dataTypeEquals(this.newTrait.scale!.dataType!, DataType.Numerical)) {
+          // Rename scale name to unit
+          this.validationHandler.overrideMessage(0, 'scale.scaleName', 'Missing unit', 400);
+        } else if (Scale.dataTypeEquals(this.newTrait.scale!.dataType!, DataType.Duration)) {
+          // Rename scale name to unit of time
+          this.validationHandler.overrideMessage(0, 'scale.scaleName', 'Missing unit of time', 400);
+        }
+
+        this.$emit('show-error-notification', `Error creating trait. ${this.validationHandler.condenseErrorsSingleRow(deletions)}`);
+      } else {
+        this.$emit('show-error-notification', 'Error creating trait.');
+      }
+    } finally {
+      this.newTraitFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT);
+    }
+  }
+
+  async updateTrait() {
+    try {
+      this.editValidationHandler = new ValidationError();
+      const [data] = await TraitService.updateTraits(this.activeProgram!.id!, [this.editTrait!]) as [Trait[], Metadata];
+
+      // Temporary: Only update the given trait.
+      // TODO: Select all traits and find the edited trait within results to keep row open
+      if (data.length > 0){
+        const traitInd = this.traits.findIndex(trait => trait.id === data[0].id);
+        const traitCopy = [...this.traits];
+        if (traitInd >= 0) {
+          traitCopy[traitInd] = {...data[0]} as Trait;
+        }
+        this.traits = traitCopy;
+      }
+
+      this.traitSidePanelState.bus.$emit(this.traitSidePanelState.successEditEvent, data[0]);
+      this.clearSelectedRow();
+      await this.getObservationLevels();
+      this.$emit('show-success-notification', 'Trait edit successful.');
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        this.editValidationHandler = error;
+        this.$emit('show-error-notification', `Error updating trait. ${this.editValidationHandler.condenseErrorsSingleRow()}`);
+      } else {
+        this.$emit('show-error-notification', 'Error updating trait.');
+      }
+    } finally {
+      this.traitSidePanelState.dataFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT);
+    }
+  }
+
+  cancelNewTrait() {
+    this.newTrait = new Trait();
+    this.validationHandler = new ValidationError();
+    this.newTraitActive = false;
+  }
+
+  async getObservationLevels() {
+    try {
+      const response = await ProgramService.getObservationLevels(this.activeProgram!.id!);
+      if (response) {
+        const [observationLevels, metadata] = response;
+        this.observationLevelOptions = observationLevels.map(value => value.name!);
+        return;
+      }
+    } catch (error) {
+      this.$emit('show-error-notification', 'Unable to retrieve observation levels');
+    }
+    this.$emit('show-error-notification', 'Unable to retrieve observation levels');
+  }
+
+}
+
+</script>

--- a/src/components/trait/TraitsArchiveTable.vue
+++ b/src/components/trait/TraitsArchiveTable.vue
@@ -91,6 +91,11 @@
       -->
       <template #columns="data">
         <TableColumn name="name" :label="'Name'">
+          <b-button
+              size="is-small"
+              class="archive-tag">
+            Archived
+          </b-button>
           {{ data.traitName }}
         </TableColumn>
         <TableColumn name="level" :label="'Level'" :visible="!traitSidePanelState.collapseColumns">

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -20,6 +20,7 @@ import Vuex, { StoreOptions } from 'vuex';
 import { RootState } from './types';
 import { mutations } from './mutations';
 import {actions} from './actions';
+import {traits} from '@/store/traits/index';
 
 Vue.use(Vuex);
 
@@ -34,6 +35,9 @@ const store: StoreOptions<RootState> = {
     user: undefined,
     program: undefined,
     firstVisit: undefined
+  },
+  modules: {
+    traits
   },
   mutations,
   actions,

--- a/src/store/pagination/getters.ts
+++ b/src/store/pagination/getters.ts
@@ -1,0 +1,78 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {GetterTree} from 'vuex';
+import {RootState} from "@/store/types";
+import {PaginationControllerState} from "@/store/pagination/types";
+import {Pagination} from "@/breeding-insight/model/BiResponse";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {Trait} from "@/breeding-insight/model/Trait";
+
+export const getters: GetterTree<PaginationControllerState, RootState> = {
+    getMatchesCurrentRequest(state: PaginationControllerState): (pagination: Pagination) => boolean {
+      return (pagination: Pagination): boolean => {
+        if (state.currentCall) {
+            if (state.showAll){
+                return pagination.currentPage == 1 && pagination.totalPages == 1;
+            } else {
+                return state.currentCall.page === pagination.currentPage &&
+                    state.currentCall.pageSize === pagination.pageSize;
+            }
+        }
+        return false;
+      };
+    },
+    getPaginationSelections(state: PaginationControllerState): (currentPage: number, pageSize: number, showAll: boolean) => PaginationQuery {
+        return (currentPage: number, pageSize: number, showAll: boolean): PaginationQuery => {
+            if (showAll) {
+                return new PaginationQuery(0, 0, true);
+            } else {
+                return new PaginationQuery(
+                    currentPage, pageSize, false);
+            }
+        }
+    },
+    mockPagination(state: PaginationControllerState, getters: GetterTree<PaginationControllerState, RootState>, rootGetters: any): (records: Trait[], page: number, pageSize: number, showAll: boolean) => [any[], Pagination] {
+        return (records: Trait[], page: number, pageSize: number, showAll: boolean): [any[], Pagination] => {
+            if (showAll){
+                const newPagination: Pagination = new Pagination({
+                    totalCount: records.length,
+                    pageSize: records.length,
+                    totalPages: 1,
+                    currentPage: 1
+                });
+                return [records, newPagination];
+            } else if (records.length === 0){
+                const newPagination: Pagination = new Pagination({
+                    totalCount: 0,
+                    pageSize: pageSize,
+                    totalPages: 1,
+                    currentPage: page
+                });
+                return [[], newPagination];
+            } else {
+                const newPagination: Pagination = new Pagination({
+                    totalCount: records.length,
+                    pageSize: pageSize,
+                    totalPages: records.length / pageSize,
+                    currentPage: page
+                });
+                return [records.slice((page * pageSize - pageSize), (page * pageSize > records.length ? records.length : page * pageSize)), newPagination];
+            }
+        }
+    }
+};

--- a/src/store/pagination/index.ts
+++ b/src/store/pagination/index.ts
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Module} from 'vuex';
+import {getters} from '@/store/pagination/getters';
+import {mutations} from '@/store/pagination/mutations';
+import {PaginationControllerState} from '@/store/pagination/types';
+import {RootState} from '@/store/types';
+
+export const state: PaginationControllerState = {
+    currentPage: 1,
+    pageSize: 50,
+    showAll: false,
+    currentCall: undefined
+};
+
+const namespaced: boolean = true
+
+export const pagination: Module<PaginationControllerState, RootState> = {
+    namespaced,
+    state,
+    getters,
+    mutations
+};

--- a/src/store/pagination/mutation-types.ts
+++ b/src/store/pagination/mutation-types.ts
@@ -1,0 +1,21 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const TOGGLE_SHOW_ALL = 'toggleShowAll';
+export const UPDATE_PAGE_SIZE = 'updatePageSize';
+export const UPDATE_PAGE = 'updatePage';
+export const SET_CURRENT_CALL = 'setCurrentCall';

--- a/src/store/pagination/mutations.ts
+++ b/src/store/pagination/mutations.ts
@@ -1,0 +1,41 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MutationTree } from 'vuex';
+import {PaginationControllerState} from "@/store/pagination/types";
+import {TOGGLE_SHOW_ALL,
+        UPDATE_PAGE_SIZE,
+        UPDATE_PAGE,
+        SET_CURRENT_CALL} from "@/store/pagination/mutation-types";
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+
+export const mutations: MutationTree<PaginationControllerState> = {
+    [TOGGLE_SHOW_ALL](state: PaginationControllerState) {
+        state.showAll = !state.showAll;
+    },
+    [UPDATE_PAGE_SIZE](state: PaginationControllerState, pageSize: number) {
+        state.pageSize = pageSize;
+        state.showAll = false;
+    },
+    [UPDATE_PAGE](state: PaginationControllerState, page: number) {
+        state.currentPage = page;
+        state.showAll = false;
+    },
+    [SET_CURRENT_CALL](state: PaginationControllerState, paginationQuery: PaginationQuery) {
+        state.currentCall = paginationQuery;
+    }
+};

--- a/src/store/pagination/types.ts
+++ b/src/store/pagination/types.ts
@@ -1,0 +1,8 @@
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+
+export interface PaginationControllerState {
+    currentPage: number,
+    pageSize: number,
+    showAll: boolean,
+    currentCall?: PaginationQuery
+}

--- a/src/store/traits/action-types.ts
+++ b/src/store/traits/action-types.ts
@@ -1,0 +1,18 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const GET_ALL_TRAITS = 'getAllTraits';

--- a/src/store/traits/actions.ts
+++ b/src/store/traits/actions.ts
@@ -23,9 +23,10 @@ import {TraitService} from "@/breeding-insight/service/TraitService";
 import {Trait} from "@/breeding-insight/model/Trait";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {LOAD_TRAITS} from "@/store/traits/mutation-types";
+import {GET_ALL_TRAITS} from "@/store/traits/action-types";
 
 export const actions: ActionTree<TraitState, RootState> = {
-    async getAllTraits({commit, getters, rootGetters}): Promise<void> {
+    async [GET_ALL_TRAITS]({commit, getters, rootGetters}): Promise<void> {
         try {
             let traits: Trait[] = getters.all;
             let metadata: Metadata;

--- a/src/store/traits/actions.ts
+++ b/src/store/traits/actions.ts
@@ -1,0 +1,50 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TraitState} from "@/store/traits/types";
+import {RootState} from "@/store/types";
+import {ActionTree} from 'vuex';
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {TraitService} from "@/breeding-insight/service/TraitService";
+import {Trait} from "@/breeding-insight/model/Trait";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
+import {LOAD_TRAITS} from "@/store/traits/mutation-types";
+
+export const actions: ActionTree<TraitState, RootState> = {
+    async getAllTraits({commit, getters, rootGetters}): Promise<void> {
+        try {
+            let traits: Trait[] = getters.all;
+            let metadata: Metadata;
+
+            if (traits.length === 0) {
+                let paginationQuery: PaginationQuery = rootGetters['traits/pagination/getPaginationSelections'](
+                    0, 0, true
+                );
+
+                [traits, metadata] = await TraitService.getAll(
+                    rootGetters.activeProgram!.id!,
+                    paginationQuery,
+                    true
+                );
+            }
+
+            commit(LOAD_TRAITS, traits);
+        } catch(error) {
+            throw error;
+        }
+    }
+};

--- a/src/store/traits/archive/action-types.ts
+++ b/src/store/traits/archive/action-types.ts
@@ -1,0 +1,19 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const GET_ALL_ARCHIVED_TRAITS = 'getAllArchivedTraits';
+export const GET_ARCHIVED_TRAITS = 'getArchivedTraits';

--- a/src/store/traits/archive/actions.ts
+++ b/src/store/traits/archive/actions.ts
@@ -21,21 +21,23 @@ import {ActionTree} from 'vuex';
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {LOAD_PAGINATED_TRAITS, LOAD_PAGINATION, LOAD_TRAITS} from "@/store/traits/archive/mutation-types";
 import {SET_CURRENT_CALL} from "@/store/pagination/mutation-types";
+import {GET_ALL_ARCHIVED_TRAITS, GET_ARCHIVED_TRAITS} from "@/store/traits/archive/action-types";
+import {GET_ALL_TRAITS} from "@/store/traits/action-types";
 
 export const actions: ActionTree<ArchiveState, RootState> = {
-    async getAllArchivedTraits({commit, dispatch, rootGetters}, refresh: boolean): Promise<void> {
+    async [GET_ALL_ARCHIVED_TRAITS]({commit, dispatch, rootGetters}, refresh: boolean): Promise<void> {
 
         if (rootGetters['traits/all'].length === 0 || refresh) {
-            await dispatch('traits/getAllTraits', null, {root: true});
+            await dispatch(`traits/${GET_ALL_TRAITS}`, null, {root: true});
         }
 
-        let traits = rootGetters['traits/all'];//.filter(trait => trait.method.methodClass === 'Observation');
-        //let traits = rootGetters['traits/all'].filter(trait => trait.method.methodClass === 'Observation');
+        let traits = rootGetters['traits/all'];
+        //let traits = rootGetters['traits/all'].filter(trait => trait.active === false);
         commit(LOAD_TRAITS, traits);
     },
-    async getArchivedTraits({dispatch, getters, state, commit}, refresh: boolean): Promise<void> {
+    async [GET_ARCHIVED_TRAITS]({dispatch, getters, state, commit}, refresh: boolean): Promise<void> {
         if (state.archivedTraits!.length === 0 || refresh) {
-            await dispatch('getAllArchivedTraits', refresh);
+            await dispatch(GET_ALL_ARCHIVED_TRAITS, refresh);
         }
 
         let paginationQuery: PaginationQuery = getters['pagination/getPaginationSelections'](

--- a/src/store/traits/archive/actions.ts
+++ b/src/store/traits/archive/actions.ts
@@ -23,9 +23,9 @@ import {LOAD_PAGINATED_TRAITS, LOAD_PAGINATION, LOAD_TRAITS} from "@/store/trait
 import {SET_CURRENT_CALL} from "@/store/pagination/mutation-types";
 
 export const actions: ActionTree<ArchiveState, RootState> = {
-    async getAllArchivedTraits({commit, dispatch, rootGetters}): Promise<void> {
+    async getAllArchivedTraits({commit, dispatch, rootGetters}, refresh: boolean): Promise<void> {
 
-        if (rootGetters['traits/all'].length === 0) {
+        if (rootGetters['traits/all'].length === 0 || refresh) {
             await dispatch('traits/getAllTraits', null, {root: true});
         }
 
@@ -33,9 +33,9 @@ export const actions: ActionTree<ArchiveState, RootState> = {
         //let traits = rootGetters['traits/all'].filter(trait => trait.method.methodClass === 'Observation');
         commit(LOAD_TRAITS, traits);
     },
-    async getArchivedTraits({dispatch, getters, state, commit}): Promise<void> {
-        if (state.archivedTraits.length === 0) {
-            await dispatch('getAllArchivedTraits');
+    async getArchivedTraits({dispatch, getters, state, commit}, refresh: boolean): Promise<void> {
+        if (state.archivedTraits!.length === 0 || refresh) {
+            await dispatch('getAllArchivedTraits', refresh);
         }
 
         let paginationQuery: PaginationQuery = getters['pagination/getPaginationSelections'](

--- a/src/store/traits/archive/actions.ts
+++ b/src/store/traits/archive/actions.ts
@@ -1,0 +1,58 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ArchiveState} from "@/store/traits/archive/types";
+import {RootState} from "@/store/types";
+import {ActionTree} from 'vuex';
+import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {LOAD_PAGINATED_TRAITS, LOAD_PAGINATION, LOAD_TRAITS} from "@/store/traits/archive/mutation-types";
+import {SET_CURRENT_CALL} from "@/store/pagination/mutation-types";
+
+export const actions: ActionTree<ArchiveState, RootState> = {
+    async getAllArchivedTraits({commit, dispatch, rootGetters}): Promise<void> {
+
+        if (rootGetters['traits/all'].length === 0) {
+            await dispatch('traits/getAllTraits', null, {root: true});
+        }
+
+        let traits = rootGetters['traits/all'];//.filter(trait => trait.method.methodClass === 'Observation');
+        //let traits = rootGetters['traits/all'].filter(trait => trait.method.methodClass === 'Observation');
+        commit(LOAD_TRAITS, traits);
+    },
+    async getArchivedTraits({dispatch, getters, state, commit}): Promise<void> {
+        if (state.archivedTraits.length === 0) {
+            await dispatch('getAllArchivedTraits');
+        }
+
+        let paginationQuery: PaginationQuery = getters['pagination/getPaginationSelections'](
+            state.pagination.currentPage,
+            state.pagination.pageSize,
+            state.pagination.showAll
+        );
+        commit(`pagination/${SET_CURRENT_CALL}`, paginationQuery);
+
+        const [traits, pagination] = getters['pagination/mockPagination'](
+            state.archivedTraits,
+            state.pagination.currentPage,
+            state.pagination.pageSize,
+            state.pagination.showAll
+        );
+
+        commit(LOAD_PAGINATED_TRAITS, traits);
+        commit(LOAD_PAGINATION, pagination);
+    }
+};

--- a/src/store/traits/archive/getters.ts
+++ b/src/store/traits/archive/getters.ts
@@ -1,0 +1,34 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {GetterTree} from 'vuex';
+import {ArchiveState} from "@/store/traits/archive/types";
+import {RootState} from "@/store/types";
+import {Trait} from "@/breeding-insight/model/Trait";
+import {Pagination} from "@/breeding-insight/model/BiResponse";
+
+export const getters: GetterTree<ArchiveState, RootState> = {
+    all(state): Trait[] | undefined {
+        return state.archivedTraits;
+    },
+    archivedTraits(state, getters, rootState): Trait[] | undefined {
+        return rootState.traits.traits.filter(trait => trait.method.methodClass === 'Observation');
+    },
+    archivePagination(state): Pagination {
+        return state.archivePagination;
+    }
+};

--- a/src/store/traits/archive/index.ts
+++ b/src/store/traits/archive/index.ts
@@ -1,0 +1,45 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Module} from 'vuex';
+import {getters} from '@/store/traits/archive/getters';
+import {actions} from '@/store/traits/archive/actions';
+import {mutations} from '@/store/traits/archive/mutations';
+import {ArchiveState} from '@/store/traits/archive/types';
+import {RootState} from '@/store/types';
+import {pagination} from '@/store/pagination/index';
+import {Pagination} from "@/breeding-insight/model/BiResponse";
+
+export const state: ArchiveState = {
+    archivedTraits: [],
+    paginatedTraits: [],
+    archivePagination: new Pagination()
+};
+
+const namespaced: boolean = true
+
+export const archive: Module<ArchiveState, RootState> = {
+    namespaced,
+    state,
+    getters,
+    actions,
+    mutations,
+    modules: {
+        pagination
+    }
+};
+

--- a/src/store/traits/archive/mutation-types.ts
+++ b/src/store/traits/archive/mutation-types.ts
@@ -1,0 +1,20 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const LOAD_TRAITS = 'loadTraits';
+export const LOAD_PAGINATED_TRAITS = 'loadPaginatedTraits';
+export const LOAD_PAGINATION = 'loadArchivePagination';

--- a/src/store/traits/archive/mutations.ts
+++ b/src/store/traits/archive/mutations.ts
@@ -1,0 +1,36 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ArchiveState} from "@/store/traits/archive/types";
+import {MutationTree} from 'vuex';
+import {Trait} from "@/breeding-insight/model/Trait";
+import {LOAD_PAGINATED_TRAITS, LOAD_PAGINATION, LOAD_TRAITS} from "@/store/traits/archive/mutation-types";
+import {Pagination} from "@/breeding-insight/model/BiResponse";
+
+export const mutations: MutationTree<ArchiveState> = {
+    [LOAD_TRAITS](state: ArchiveState, traits: Trait[]) {
+        state.archivedTraits = traits;
+        //state.archivedTraits = traits.filter(trait => trait.method.methodClass === 'Observation');
+        //state.archivedTraits = traits.filter(trait => trait.active === false);
+    },
+    [LOAD_PAGINATED_TRAITS](state: ArchiveState, traits: Trait[]) {
+        state.paginatedTraits = traits;
+    },
+    [LOAD_PAGINATION](state: ArchiveState, pagination: Pagination) {
+        state.archivePagination = pagination;
+    }
+};

--- a/src/store/traits/archive/types.ts
+++ b/src/store/traits/archive/types.ts
@@ -1,0 +1,10 @@
+import {Trait} from "@/breeding-insight/model/Trait";
+import {PaginationControllerState} from "@/store/pagination/types";
+import {Pagination} from "@/breeding-insight/model/BiResponse";
+
+export interface ArchiveState {
+    archivedTraits?: Trait[];
+    paginatedTraits?: Trait[];
+    archivePagination?: Pagination;
+    pagination: PaginationControllerState;
+}

--- a/src/store/traits/getters.ts
+++ b/src/store/traits/getters.ts
@@ -1,0 +1,27 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {GetterTree} from 'vuex';
+import {TraitState} from "@/store/traits/types";
+import {RootState} from "@/store/types";
+import {Trait} from "@/breeding-insight/model/Trait";
+
+export const getters: GetterTree<TraitState, RootState> = {
+    all(state): Trait[] | undefined {
+      return state.traits;
+    }
+};

--- a/src/store/traits/index.ts
+++ b/src/store/traits/index.ts
@@ -1,0 +1,44 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Module} from 'vuex';
+import {getters} from '@/store/traits/getters';
+import {actions} from '@/store/traits/actions';
+import {mutations} from '@/store/traits/mutations';
+import {TraitState} from '@/store/traits/types';
+import {RootState} from '@/store/types';
+import {archive} from '@/store/traits/archive/index';
+import {pagination} from "@/store/pagination";
+
+export const state: TraitState = {
+    traits: []
+};
+
+const namespaced: boolean = true
+
+export const traits: Module<TraitState, RootState> = {
+    namespaced,
+    state,
+    getters,
+    actions,
+    mutations,
+    modules: {
+      archive,
+      pagination
+    }
+};
+

--- a/src/store/traits/mutation-types.ts
+++ b/src/store/traits/mutation-types.ts
@@ -1,0 +1,18 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const LOAD_TRAITS = 'loadTraits';

--- a/src/store/traits/mutations.ts
+++ b/src/store/traits/mutations.ts
@@ -1,0 +1,27 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TraitState} from "@/store/traits/types";
+import { MutationTree } from 'vuex';
+import {LOAD_TRAITS} from "@/store/traits/mutation-types";
+import {Trait} from "@/breeding-insight/model/Trait";
+
+export const mutations: MutationTree<TraitState> = {
+    [LOAD_TRAITS](state: TraitState, traits: Trait[]) {
+        state.traits = traits;
+    }
+};

--- a/src/store/traits/types.ts
+++ b/src/store/traits/types.ts
@@ -1,0 +1,9 @@
+import {Trait} from "@/breeding-insight/model/Trait";
+import {ArchiveState} from "@/store/traits/archive/types";
+import {PaginationControllerState} from "@/store/pagination/types";
+
+export interface TraitState {
+    traits?: Trait[];
+    archive: ArchiveState;
+    pagination: PaginationControllerState;
+}

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -17,6 +17,7 @@
 
 import {User} from "@/breeding-insight/model/User";
 import {Program} from "@/breeding-insight/model/Program";
+import {TraitState} from "@/store/traits/types";
 
 export interface RootState {
   loggedIn: boolean;
@@ -27,4 +28,5 @@ export interface RootState {
   loginServerError: boolean;
   requestedPath?: string;
   firstVisit?: boolean;
+  traits: TraitState;
 }

--- a/src/views/trait/TraitsArchived.vue
+++ b/src/views/trait/TraitsArchived.vue
@@ -18,15 +18,22 @@
 <template>
   <div class="traits-archived">
     <h1 class="title">Archived Traits</h1>
+    <TraitsArchiveTable
+        @show-success-notification="$emit('show-success-notification', $event)"
+        @show-error-notification="$emit('show-error-notification', $event)"
+    >
+    </TraitsArchiveTable>
   </div>
 </template>
 
 <script lang="ts">
-  import { Component, Prop, Vue } from 'vue-property-decorator'
+  import { Component } from 'vue-property-decorator'
+  import TraitsArchiveTable from '@/components/trait/TraitsArchiveTable.vue'
   import ProgramsBase from "@/components/program/ProgramsBase.vue";
 
   @Component({
     components: {
+      TraitsArchiveTable
     }
   })
   export default class TraitsArchived extends ProgramsBase {


### PR DESCRIPTION
### Archived Traits Table

Hey! Please take a look at how Vuex can be used and make any comments. The purpose of this PR is to make it easy to make comments and discuss specifics of how vuex could be used for biweb. This is not intended to be a final review before merging.

#### Required State Data
All traits in a program are pulled from the backend and stored locally. Filtering the existing all-traits collection for archived traits will not suffice because all-traits data stored is only one page of the collection, and the archived traits can be distributed over all pages.
An additional GET archived-traits endpoint could eliminate the need to store an entire collection on the frontend, but that doesn't exist, now.

The pagination and pagination controls state for the archive table must be independent of that of all other tables.

#### Vuex
Vuex modules for traits, archive, and pagination were added to the store with the hierarchy: 
```
root --> traits --> archive --> pagination
             \
              \--> pagination
```
The all-traits collection is stored in the `traits` module; the archived-traits and paginated-archived-traits are stored in the `archive` module; and the pagination state and control data is stored in the respective `pagination` module, although only the archive controls are currently set up.

You can explore the state tree using the state tab on the chrome debugging tool Vue extension.  Also, you will see a history of mutations committed as well as a list of getters and mutations in each module.

#### Vuex-specific Component Changes
`@/components/trait/TraitsArchiveTable.vue` was necessarily created for the new table but also the SidePanelTable and child components were copied over into `@/components/tables/ArchiveSidePanelTable.vue`, `@/components/tables/ArchiveBaseTable.vue`, and `@/components/tables/ArchivePaginationControls.vue`. These last three files are temporary to hold the changes made to these child components in order to use Vuex for state management for the archive table.

The props and methods originally used for the all-traits table was ported into vuex module state, getters, mutations, and actions which are then added to an archive component using the vuex helper functions `mapState`, `mapGetters`, `mapMutations`, and `mapActions`.  State and getters are mapped to component computed values; mutations and actions are mapped to component methods.

For input forms like the page size selector box two-way data binding is not allowed since the store operates in strict mode. `v-model` is simply replaced with `v-bind` and the existing `v-on:change`.

The pagination event listeners don't need to bubble up from the ArchivePaginationControls to the TraitsArchiveTable component level so those have been removed from the top level.

#### Work in Progress
This branch is only supposed to illustrate how Vuex could be used to manage state on the front end as the UI gains in complexity in order to make any discussions and decision specific and meaningful. I only went as far as getting the pagination controls working, but Vuex would also need to manage the all-traits data and pagination as well as sidebar panel state information for the table to function property. For example, editing traits at the all-traits table will not affect the archived traits.

Also, the archived traits right now only return all traits since the filtering has been commented out since the new backend features supporting the active prop haven't been merged in yet.