### PR TITLE
Fix/BI-794 ISSUE: New/Edit Trait - ordinal scale name for new traits persists in db after changing scale name to nominal

### DIFF
--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -234,42 +234,36 @@ export default class BaseTraitForm extends Vue {
   setScaleClass(value: string) {
     // Save history of current scale class
     if (this.trait.scale!.dataType) {
-      // Nominal and ordinal save histories
-      if (Scale.dataTypeEquals(this.trait.scale!.dataType, DataType.Nominal) ||
-        Scale.dataTypeEquals(this.trait.scale!.dataType, DataType.Ordinal))
-      {
-        this.scaleHistory[DataType.Ordinal.toLowerCase()] = Scale.assign({...this.trait.scale!} as Scale);
-      } else {
-        this.scaleHistory[this.trait.scale!.dataType.toLowerCase()] = Scale.assign({...this.trait.scale!} as Scale);
+      this.scaleHistory[this.trait.scale!.dataType.toLowerCase()] = Scale.assign({...this.trait.scale!} as Scale);
+      if (Scale.dataTypeEquals(this.trait.scale.dataType, DataType.Nominal) || Scale.dataTypeEquals(this.trait.scale.dataType, DataType.Ordinal)) {
+        this.scaleHistory.lastCategoryType = this.trait.scale.dataType;
       }
     }
 
-    // Look in history for existing scale
-    if ((Scale.dataTypeEquals(value, DataType.Nominal) || Scale.dataTypeEquals(value, DataType.Ordinal)) &&
-      this.scaleHistory[DataType.Ordinal.toLowerCase()])
-    {
+    if (Scale.dataTypeEquals(value, DataType.Nominal) && Scale.dataTypeEquals(this.scaleHistory.lastCategoryType, DataType.Ordinal)) {
       this.trait.scale = this.scaleHistory[DataType.Ordinal.toLowerCase()];
-
-      if (Scale.dataTypeEquals(value, DataType.Nominal)) {
-        // Clear the labels
-        if (this.trait.scale.categories) {
-          this.trait.scale.categories.forEach(category => category.label = undefined);
-        }
-        // Set the data type and scale name
-        this.trait.scale.dataType = DataType.Nominal;
-        this.trait.scale.scaleName = DataType.Nominal;
-      } else {
-        if (this.trait.scale.categories) {
-          this.trait.scale.categories.forEach((category, index) => category.label = index + 1 + '');
-        }
-        // Set the data type and scale name
-        this.trait.scale.dataType = DataType.Ordinal;
-        this.trait.scale.scaleName = DataType.Ordinal;
+      // Clear the labels
+      if (this.trait.scale.categories) {
+        this.trait.scale.categories.forEach(category => category.label = undefined);
       }
+
+      this.trait.scale.dataType = value;
+      this.trait!.scale!.scaleName = value;
+
+    } else if (Scale.dataTypeEquals(value, DataType.Ordinal) && Scale.dataTypeEquals(this.scaleHistory.lastCategoryType, DataType.Nominal)) {
+      // Add 1-based index labels to categories
+      if (this.trait.scale.categories) {
+        this.trait.scale.categories.forEach((category, index) => category.label = index + 1 + '');
+      }
+
+      this.trait.scale.dataType = value;
+      this.trait!.scale!.scaleName = value;
+
     } else if (this.scaleHistory[value.toLowerCase()]) {
       this.trait.scale = this.scaleHistory[value.toLowerCase()];
       this.trait.scale.dataType = value;
       this.trait!.scale!.scaleName = value;
+
     } else {
       // No history
       this.trait.scale = new Scale();
@@ -278,6 +272,7 @@ export default class BaseTraitForm extends Vue {
       // Allow for units in the numerical and duration traits
       if (Scale.dataTypeEquals(value, DataType.Numerical) || Scale.dataTypeEquals(value, DataType.Duration)) {
         this.trait!.scale!.scaleName = undefined;
+
       } else {
         this.trait!.scale!.scaleName = value;
       }

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -253,12 +253,17 @@ export default class BaseTraitForm extends Vue {
       this.trait.scale = Scale.assign(this.scaleHistory[DataType.Nominal.toLowerCase()]);
       // Add 1-based index labels to categories
       if (this.trait.scale.categories) {
-        this.trait.scale.categories.forEach((category, index) => {
+        this.trait.scale.categories.forEach((category, index, categories) => {
           // Use prior labels if they exist
           if (this.scaleHistory[DataType.Ordinal.toLowerCase()] && this.scaleHistory[DataType.Ordinal.toLowerCase()].categories[index]) {
             category.label = this.scaleHistory[DataType.Ordinal.toLowerCase()].categories[index].label;
           } else {
-            category.label = index + 1 + '';
+            let autoLabel: string = index + 1 + '';
+            if(categories.find(anyCategory => anyCategory.label === autoLabel)) {
+              category.label = autoLabel + '_dup';
+            } else {
+              category.label = autoLabel;
+            }
           }
         })
       }

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -255,14 +255,16 @@ export default class BaseTraitForm extends Vue {
         if (this.trait.scale.categories) {
           this.trait.scale.categories.forEach(category => category.label = undefined);
         }
-        // Set the data type
+        // Set the data type and scale name
         this.trait.scale.dataType = DataType.Nominal;
+        this.trait.scale.scaleName = DataType.Nominal;
       } else {
         if (this.trait.scale.categories) {
           this.trait.scale.categories.forEach((category, index) => category.label = index.toString());
         }
-        // Set the data type
+        // Set the data type and scale name
         this.trait.scale.dataType = DataType.Ordinal;
+        this.trait.scale.scaleName = DataType.Ordinal;
       }
     } else if (this.scaleHistory[value.toLowerCase()]) {
       this.trait.scale = this.scaleHistory[value.toLowerCase()];

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -241,7 +241,7 @@ export default class BaseTraitForm extends Vue {
     }
 
     if (Scale.dataTypeEquals(value, DataType.Nominal) && Scale.dataTypeEquals(this.scaleHistory.lastCategoryType, DataType.Ordinal)) {
-      this.trait.scale = this.scaleHistory[DataType.Ordinal.toLowerCase()];
+      this.trait.scale = Scale.assign(this.scaleHistory[DataType.Ordinal.toLowerCase()]);
       // Clear the labels
       if (this.trait.scale.categories) {
         this.trait.scale.categories.forEach(category => category.label = undefined);
@@ -249,13 +249,19 @@ export default class BaseTraitForm extends Vue {
 
       this.trait.scale.dataType = value;
       this.trait!.scale!.scaleName = value;
-
     } else if (Scale.dataTypeEquals(value, DataType.Ordinal) && Scale.dataTypeEquals(this.scaleHistory.lastCategoryType, DataType.Nominal)) {
+      this.trait.scale = Scale.assign(this.scaleHistory[DataType.Nominal.toLowerCase()]);
       // Add 1-based index labels to categories
       if (this.trait.scale.categories) {
-        this.trait.scale.categories.forEach((category, index) => category.label = index + 1 + '');
+        this.trait.scale.categories.forEach((category, index) => {
+          // Use prior labels if they exist
+          if (this.scaleHistory[DataType.Ordinal.toLowerCase()] && this.scaleHistory[DataType.Ordinal.toLowerCase()].categories[index]) {
+            category.label = this.scaleHistory[DataType.Ordinal.toLowerCase()].categories[index].label;
+          } else {
+            category.label = index + 1 + '';
+          }
+        })
       }
-
       this.trait.scale.dataType = value;
       this.trait!.scale!.scaleName = value;
 

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -260,7 +260,7 @@ export default class BaseTraitForm extends Vue {
         this.trait.scale.scaleName = DataType.Nominal;
       } else {
         if (this.trait.scale.categories) {
-          this.trait.scale.categories.forEach((category, index) => category.label = index.toString());
+          this.trait.scale.categories.forEach((category, index) => category.label = index + 1 + '');
         }
         // Set the data type and scale name
         this.trait.scale.dataType = DataType.Ordinal;


### PR DESCRIPTION
The fixes used in this PR for the method of setting the scale class when using the new-trait form also satisfies
BI-796 ISSUE: Trait Create/Edit - Labels for Ordinal inconsistent 
BI-797 ISSUE: Trait Create/Edit - Labels for Ordinal not remembered when switching between scale classes
https://breedinginsight.atlassian.net/browse/BI-796
https://breedinginsight.atlassian.net/browse/BI-797