### PR TITLE
[BI-846] - Hiding create/edit buttons for traits for member role

### DIFF
--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -69,11 +69,11 @@
       <p class="has-text-weight-bold mt-3 mb-0">Description of collection method</p>
       <p>{{data.method.description}}</p>
 
-      <ProgressBar v-if="loadingEditable" v-bind:label="'Checking trait editability status'"
+      <ProgressBar v-if="loadingEditable && $ability.can('update', 'Trait')" v-bind:label="'Checking trait editability status'"
                    v-bind:estimated-time-text="'May take a few seconds'"
       />
 
-      <article v-if="!editable && !loadingEditable" class="message is-info">
+      <article v-if="!editable && !loadingEditable && $ability.can('update', 'Trait')" class="message is-info">
         <div class="message-body">
           <div class="media">
             <figure class="media-left">
@@ -96,7 +96,7 @@
             size="is-small"
             style="background: lightgray"
             class="archive-tag"
-            v-if="!data.active">
+            v-if="archivable && !data.active">
           Archived
         </b-button>
       </template>
@@ -115,7 +115,7 @@
         </div>
         <div class="column is-narrow">
           <a
-            v-if="data.active"
+            v-if="archivable && data.active"
             v-on:click="$emit('archive', data)"
             v-on:keypress.enter.space="$emit('archive', data)"
             tabindex="0"

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -48,6 +48,7 @@
     <div class="columns has-text-right mb-0">
       <div class="column">
         <button
+            v-if="$ability.can('create', 'Trait')"
             data-testid="newDataForm"
             v-show="!newTraitActive & traits.length > 0"
             class="button is-primary has-text-weight-bold"
@@ -133,12 +134,12 @@
           v-bind:data="traitSidePanelState.openedRow"
           v-bind:observation-level-options="observationLevelOptions"
           v-bind:edit-active="traitSidePanelState.editActive"
-          v-bind:editable="currentTraitEditable"
+          v-bind:editable="$ability.can('update', 'Trait') && currentTraitEditable"
           v-bind:loading-editable="loadingTraitEditable"
           v-bind:edit-form-state="traitSidePanelState.dataFormState"
           v-bind:client-validations="traitValidations"
           v-bind:validation-handler="editValidationHandler"
-          v-bind:archivable="true"
+          v-bind:archivable="$ability.can('archive', 'Trait')"
           v-on:activate-edit="activateEdit($event)"
           v-on:deactivate-edit="traitSidePanelState.bus.$emit(traitSidePanelState.closePanelEvent)"
           v-on:trait-change="editTrait = Trait.assign({...$event})"
@@ -154,11 +155,14 @@
             v-bind:button-view-toggle="!newTraitActive"
             v-bind:button-text="'New Trait'"
             v-on:newClick="activateNewTraitForm"
+            v-bind:create-enabled="$ability.can('create', 'Trait')"
         >
           <p class="has-text-weight-bold">
             No traits are currently defined for this program.
           </p>
-          Create new traits by clicking "New Trait" or navigating to "Import Traits".
+          <p v-if="$ability.can('create', 'Trait')">
+            Create new traits by clicking "New Trait" or navigating to "Import Traits".
+          </p>
         </EmptyTableMessage>
       </template>
     </SidePanelTable>
@@ -265,7 +269,9 @@ export default class TraitTable extends Vue {
     });
 
     this.traitSidePanelState.bus.$on(this.traitSidePanelState.selectRowEvent, (row: any) => {
-      this.editable(row);
+      if(this.$ability.can('update', 'Trait')) {
+        this.editable(row);
+      }
     })
   }
 

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -34,6 +34,8 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('update', 'Location');
     can('archive', 'Location');
     can('create', 'Trait');
+    can('update', 'Trait');
+    can('archive', 'Trait');
   },
   admin(user, { can }) {
     can('create', 'ProgramUser');


### PR DESCRIPTION
Added abilities of `create` and `update` of `Trait` to the `breeder` role, and then enforced them by hiding or showing create, edit, and archive buttons (breeder can see the buttons, member cannot).