### PR TITLE
[BI-972] - Testing Automation Framework (TAF) Button ID selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v0.4.0+96",
+  "version": "v0.4.0+100",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -83,5 +83,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.6.10"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/190274d33315f7e293a5bcf24514124d2b4b5287"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/931576e872358d4b28573613ab86a9370288fc75"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v0.4.0+94",
+  "version": "v0.4.0+96",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -83,5 +83,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.6.10"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/3bba5c03d93c15a110fa4176a6324ab462292809"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/190274d33315f7e293a5bcf24514124d2b4b5287"
 }

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -79,7 +79,7 @@
           <div class="level-right">
             <div class="level-item">
               <div>
-                <a v-if="file" class="button is-primary has-text-weight-bold" v-on:click="$emit('import')">Import</a>
+                <a v-if="file" class="button is-primary has-text-weight-bold" :id="importButtonId" v-on:click="$emit('import')">Import</a>
               </div>
             </div>
           </div>
@@ -111,6 +111,8 @@
 
     @Prop()
     private errors!: ValidationError | string | null;
+
+    private importButtonId: string = "import-button";
 
     mounted() {
       this.file = this.value;

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -112,7 +112,7 @@
     @Prop()
     private errors!: ValidationError | string | null;
 
-    private importButtonId: string = "import-button";
+    private importButtonId: string = "fileselectmessagebox-import-button";
 
     mounted() {
       this.file = this.value;

--- a/src/components/file-import/FileSelector.vue
+++ b/src/components/file-import/FileSelector.vue
@@ -57,8 +57,8 @@
     @Prop()
     private value!: File;
 
-    private chooseFileId: string = "choose-file";
-    private chooseDiffFileId: string = "choose-different-file";
+    private chooseFileId: string = "fileselector-choose-file";
+    private chooseDiffFileId: string = "fileselector-choose-different-file";
 
     @Prop()
     private fileTypes!: string[];

--- a/src/components/file-import/FileSelector.vue
+++ b/src/components/file-import/FileSelector.vue
@@ -17,7 +17,7 @@
 
 <template>
   <label class="file-select">
-    <div v-if="value" class="button is-outlined is-primary">
+    <div v-if="value" :id="chooseDiffFileId" class="button is-outlined is-primary">
       <span class="icon is-small">
         <UploadIcon
           size="1.5x"
@@ -28,7 +28,7 @@
         Choose a different file...
       </span>
     </div>
-    <div v-else class="button is-primary">
+    <div v-else :id="chooseFileId" class="button is-primary">
       <span class="icon is-small">
         <UploadIcon
           size="1.5x"
@@ -57,6 +57,9 @@
     @Prop()
     private value!: File;
 
+    private chooseFileId: string = "choose-file";
+    private chooseDiffFileId: string = "choose-different-file";
+
     @Prop()
     private fileTypes!: string[];
 
@@ -67,6 +70,8 @@
     get fileTypesString(): string {
       return this.fileTypes.toString();
     }
+
+    //
 
   }
 </script>

--- a/src/components/layouts/BaseSideBarLayout.vue
+++ b/src/components/layouts/BaseSideBarLayout.vue
@@ -90,7 +90,7 @@
                 <p class="mb-0">Logged in as <strong>{{username}}</strong></p>
               </div>
               <div class="level-item">
-                <button class="button is-outlined is-primary" @click="$emit('logout')">Log out</button>
+                <button class="button is-outlined is-primary" :id="logoutId" @click="$emit('logout')">Log out</button>
               </div>
             </div>
           </div>
@@ -117,6 +117,8 @@ import VersionInfo from '@/components/layouts/VersionInfo.vue';
   export default class SideBarMaster extends Vue {
     sideMenuShownMobile: boolean = true;
     SandboxMode = SandboxMode;
+
+    private logoutId: string = "basesidebarlayout-logout-button";
 
     @Prop()
     username!: string;

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -76,12 +76,12 @@
           </p>
           <ul class="menu-list">
             <li>
-              <router-link to="/admin/user-management">
+              <router-link to="/admin/user-management" :id="usersMenuId">
                 Users
               </router-link>
             </li>
             <li>
-              <router-link to="/admin/program-management">
+              <router-link to="/admin/program-management" :id="programsMenuId">
                 Programs
               </router-link>
               <ul class="menu-list">
@@ -105,7 +105,7 @@
         <template v-if="activeProgram">
           <ul class="menu-list">
             <li>
-              <router-link v-bind:to="{name: 'program-home', params: {programId: activeProgram.id}}">
+              <router-link v-bind:to="{name: 'program-home', params: {programId: activeProgram.id}}" :id="homeMenuId">
                 Home
               </router-link>
             </li>
@@ -120,6 +120,7 @@
             <li>
               <router-link
                 v-bind:to="{name: 'import'}"
+                :id="importFileMenuId"
               >
                 Import File
               </router-link>
@@ -128,6 +129,7 @@
               <router-link
                 v-bind:to="{name: 'traits', params: {programId: activeProgram.id}}"
                 v-bind:class="{ 'is-active': traitsActive }"
+                :id="traitsMenuId"
               >
                 Traits
                 <MoreVerticalIcon
@@ -176,6 +178,7 @@
               <router-link
                 v-bind:to="{name: 'program-management', params: {programId: activeProgram.id}}"
                 v-bind:class="{ 'is-active': programManagementActive }"
+                :id="programManagementMenuId"
               >
                 Program Management
                 <MoreVerticalIcon
@@ -201,7 +204,7 @@
               </ul>
             </li>
             <li>
-              <router-link v-bind:to="{name: 'brapi-info', params: {programId: activeProgram.id}}">
+              <router-link v-bind:to="{name: 'brapi-info', params: {programId: activeProgram.id}}" :id="brAPIMenuId">
                 BrAPI
               </router-link>
             </li>
@@ -247,7 +250,16 @@
     private programs: Program[] = [];
     private programSelectActive: boolean = false;
 
-    @Prop()
+    private usersMenuId: string = "usersidebarlayout-users-menu";
+    private programsMenuId: string = "usersidebarlayout-programs-menu";
+
+    private homeMenuId: string = "usersidebarlayout-home-menu";
+    private importFileMenuId: string = "usersidebarlayout-import-file-menu";
+    private traitsMenuId: string = "usersidebarlayout-traits-menu";
+    private programManagementMenuId: string = "usersidebarlayout-program-management-menu";
+    private brAPIMenuId: string = "usersidebarlayout-brapi-menu";
+
+  @Prop()
     username!: string;
     created() {
       EventBus.bus.$on(EventBus.programChange, this.getPrograms);

--- a/src/components/trait/TraitImportTemplateMessageBox.vue
+++ b/src/components/trait/TraitImportTemplateMessageBox.vue
@@ -33,7 +33,7 @@
               <div class="has-text-dark has-text-centered is-size-7">
                 <!-- temporary link until the backend card is done -->
                 <a href="https://cornell.box.com/shared/static/snf69ydrzmmr27qfqby0pcr0mw34qulr.xls"
-                  class="button is-outlined is-primary">Download the Trait Import Template</a>
+                  class="button is-outlined is-primary" :id="downloadTraitTemplateId">Download the Trait Import Template</a>
                 <br/>Template version placeholder
               </div>
             </div>
@@ -52,6 +52,8 @@
     }
   })
   export default class TraitImportTemplateMessageBox extends Vue {
+
+    private downloadTraitTemplateId: string = "download-trait-template";
 
   }
 </script>

--- a/src/components/trait/TraitImportTemplateMessageBox.vue
+++ b/src/components/trait/TraitImportTemplateMessageBox.vue
@@ -53,7 +53,7 @@
   })
   export default class TraitImportTemplateMessageBox extends Vue {
 
-    private downloadTraitTemplateId: string = "download-trait-template";
+    private downloadTraitTemplateId: string = "traitimporttemplatemessagebox-download-trait-template";
 
   }
 </script>

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -160,7 +160,7 @@ export default class TraitsImport extends ProgramsBase {
   private numTraits = 0;
   private showAbortModal = false;
 
-  private yesAbortId: string = "yes-abort";
+  private yesAbortId: string = "traitsimport-yes-abort";
   
   private ImportState = ImportState;
   private ImportEvent = ImportEvent;

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -31,7 +31,7 @@
         <div class="column is-whole has-text-centered buttons">
           <button
             class="button is-danger"
-            v-on:click="handleAbortModal()"
+            v-on:click="handleAbortModal()" :id="yesAbortId"
           >
             <strong>Yes, abort</strong>
           </button>
@@ -159,6 +159,8 @@ export default class TraitsImport extends ProgramsBase {
   private tableLoaded = false;
   private numTraits = 0;
   private showAbortModal = false;
+
+  private yesAbortId: string = "yes-abort";
   
   private ImportState = ImportState;
   private ImportEvent = ImportEvent;


### PR DESCRIPTION
Adding IDs to buttons to make TAF testing more robust (as opposed to using xpaths for selectors).

- Download the Trait Import Template
- Choose a file…
- Choose a different file…
- Import
- Yes, abort
- Log out
- Home
- Import File
- Program Management
- Traits
- BrAPI
- Users
- Programs

Convention: lowercase, separated by dashes, prefaced with component name, ie: “fileselector-choose-file”

Linked to https://github.com/Breeding-Insight/taf/pull/3 which modifies associated TAF tests
