### PR TITLE
[BI-986] - Change scale valid value min/max text

### DIFF
--- a/src/components/trait/forms/NumericalTraitForm.vue
+++ b/src/components/trait/forms/NumericalTraitForm.vue
@@ -43,7 +43,7 @@
             v-bind:field-name="'Minimum Valid Value'"
             v-bind:value="validMin"
             v-on:input="$emit('min-change', $event)"
-            v-bind:field-help="'Numbers only. Decimals ok.'"
+            v-bind:field-help="'Numbers only. Decimals not supported.'"
             v-bind:validations="clientValidations && clientValidations.scale.validValueMin ? clientValidations.scale.validValueMin : undefined"
             v-bind:server-validations="validationHandler.getValidation(validationIndex, TraitError.MaximumValue)"
         />
@@ -53,7 +53,7 @@
             v-bind:field-name="'Maximum Valid Value'"
             v-bind:value="validMax"
             v-on:input="$emit('max-change', $event)"
-            v-bind:field-help="'Numbers only. Decimals ok.'"
+            v-bind:field-help="'Numbers only. Decimals not supported.'"
             v-bind:validations="clientValidations && clientValidations.scale.validValueMax ? clientValidations.scale.validValueMax : undefined"
             v-bind:server-validations="validationHandler.getValidation(validationIndex, TraitError.MaximumValue)"
         />


### PR DESCRIPTION
On our UI we had the help text for scale valid value min/max as `Numbers only. Decimals ok.`. BrAPI doesn't not support decimals places in these fields, neither does our backend. The import template correctly states that only integers are supported. 

See bi-api change: 

https://github.com/Breeding-Insight/bi-api/pull/94