### PR TITLE
[BI-1014] - Banner Class Modifications

### DIFF
--- a/src/components/notifications/ErrorNotification.vue
+++ b/src/components/notifications/ErrorNotification.vue
@@ -22,7 +22,7 @@
       <div class="column is-flex-grow-0">
           <AlertCircleIcon size="1.5x"></AlertCircleIcon>
       </div>
-      <div class="column">
+      <div class="column" :class="bannerTextClass">
         {{msg}}
       </div>
     </div>
@@ -39,6 +39,8 @@ import { AlertCircleIcon } from 'vue-feather-icons'
 export default class ErrorNotification extends Vue {
   public active: boolean = false;
   public msg : string = '';
+
+  private bannerTextClass: string = "banner-text";
 }
 
 </script>

--- a/src/components/notifications/InfoNotification.vue
+++ b/src/components/notifications/InfoNotification.vue
@@ -23,7 +23,7 @@
             <div class="level-item">
                 <InfoIcon size="1.5x"></InfoIcon>
             </div>
-            <div class="level-item">
+            <div class="level-item" :class="bannerTextClass">
                 {{msg}}
             </div>
         </div>
@@ -41,6 +41,8 @@ import { InfoIcon } from 'vue-feather-icons'
 export default class InfoNotification extends Vue {
   public active: boolean = false;
   public msg : string = '';
+
+  private bannerTextClass: string = "banner-text";
 }
 
 </script>

--- a/src/components/notifications/SuccessNotification.vue
+++ b/src/components/notifications/SuccessNotification.vue
@@ -23,7 +23,7 @@
         <div class="level-item">
           <CheckCircleIcon size="1.5x"></CheckCircleIcon>
         </div>
-        <div class="level-item">
+        <div class="level-item" :class="bannerTextClass">
           {{msg}}
         </div>
       </div>
@@ -41,6 +41,8 @@ import { CheckCircleIcon } from 'vue-feather-icons'
 export default class SuccessNotification extends Vue {
   public active: boolean = false;
   public msg : string = '';
+
+  private bannerTextClass: string = "banner-text";
 }
 
 </script>

--- a/src/components/notifications/WarningNotification.vue
+++ b/src/components/notifications/WarningNotification.vue
@@ -23,7 +23,7 @@
         <div class="level-item">
           <AlertTriangleIcon size="1.5x"></AlertTriangleIcon>
         </div>
-        <div class="level-item">
+        <div class="level-item" :class="bannerTextClass">
           {{msg}}
         </div>
       </div>
@@ -41,6 +41,8 @@
   export default class WarningNotification extends Vue {
     public active: boolean = false;
     public msg : string = '';
+
+    private bannerTextClass: string = "banner-text";
   }
 
 </script>


### PR DESCRIPTION
To make TAF selectors more robust against changing layouts, adding a “banner-text” value for the HTML class attribute that will be associated with the message in a banner for the following banner components:

- ErrorNotification.vue
- WarningNotification.vue
- SuccessNotification.vue
- InfoNotification.vue

This issue is linked to [taf/BI-1014](https://github.com/Breeding-Insight/taf/pull/5)