### PR TITLE
[BI-1025] - Id added for imported file name

### DIFF
--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -63,7 +63,7 @@
           <div class="level-left">
             <div v-if="file" class="level-item">
               <div
-                v-bind:class="{'has-text-dark': allErrors.length <= 0, 'has-text-danger': allErrors.length > 0}"
+                v-bind:class="{'has-text-dark': allErrors.length <= 0, 'has-text-danger': allErrors.length > 0}" :id="importFileNameId"
             >
                 {{file.name}}                  
               </div>
@@ -113,6 +113,7 @@
     private errors!: ValidationError | string | null;
 
     private importButtonId: string = "fileselectmessagebox-import-button";
+    private importFileNameId: string = "fileselectmessagebox-import-filename";
 
     mounted() {
       this.file = this.value;


### PR DESCRIPTION
The TAF tests checking for the display of uploaded filename are currently failing.

- Added an id to the div with the filename in FileSelectMessageBox.vue

Associated with PR [taf/1025](https://github.com/Breeding-Insight/taf/pull/6)