### PR TITLE
[BI-1039] Switch label and value in scale categories

### DIFF
--- a/src/breeding-insight/model/errors/ValidationError.ts
+++ b/src/breeding-insight/model/errors/ValidationError.ts
@@ -75,4 +75,14 @@ export class ValidationError {
     }
     return errorSentence;
   }
+
+  clearValidation(rowIndex: number, errorName: string) {
+    if (this.rows && this.rows[rowIndex]) {
+      for (const [errorIndex, field] of this.rows[rowIndex].errors!.entries()) {
+        if (field.field === errorName) {
+          delete this.rows[rowIndex].errors![errorIndex];
+        }
+      }
+    }
+  }
 }

--- a/src/components/trait/TraitImportTemplateMessageBox.vue
+++ b/src/components/trait/TraitImportTemplateMessageBox.vue
@@ -32,7 +32,7 @@
             <div class="level-item">
               <div class="has-text-dark has-text-centered is-size-7">
                 <!-- temporary link until the backend card is done -->
-                <a href="https://cornell.box.com/shared/static/g6vmpktevwolwkyatwxbdbzpkbwv77ov.xls"
+                <a href="https://cornell.box.com/shared/static/8sp0qvccpjotosiv8576tczeg09nnvao.xls"
                   class="button is-outlined is-primary" :id="downloadTraitTemplateId">Download the Trait Import Template</a>
                 <br/>Template version placeholder
               </div>

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -260,7 +260,8 @@ export default class BaseTraitForm extends Vue {
 
     if (Scale.dataTypeEquals(value, DataType.Nominal) && Scale.dataTypeEquals(this.lastCategoryType, DataType.Ordinal)) {
       this.trait.scale = Scale.assign(this.scaleHistory[DataType.Ordinal.toLowerCase()]);
-      // TODO: Clear the scale category validations if there are any, the switch is confusing
+      // Clear the scale category validations if there are any, the switch is confusing
+      this.validationHandler.clearValidation(0, 'scale.categories');
 
       // Clear the values, use labels as the new values if they exist
       if (this.trait.scale.categories) {
@@ -274,7 +275,8 @@ export default class BaseTraitForm extends Vue {
       this.trait!.scale!.scaleName = value;
     } else if (Scale.dataTypeEquals(value, DataType.Ordinal) && Scale.dataTypeEquals(this.lastCategoryType, DataType.Nominal)) {
       this.trait.scale = Scale.assign(this.scaleHistory[DataType.Nominal.toLowerCase()]);
-      // TODO: Clear the scale category validations if there are any, the switch is confusing
+      // Clear the scale category validations if there are any, the switch is confusing
+      this.validationHandler.clearValidation(0, 'scale.categories');
 
       // Add 1-based index values to categories
       if (this.trait.scale.categories) {

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -260,31 +260,36 @@ export default class BaseTraitForm extends Vue {
 
     if (Scale.dataTypeEquals(value, DataType.Nominal) && Scale.dataTypeEquals(this.lastCategoryType, DataType.Ordinal)) {
       this.trait.scale = Scale.assign(this.scaleHistory[DataType.Ordinal.toLowerCase()]);
-      // Clear the labels
+      // TODO: Clear the scale category validations if there are any, the switch is confusing
+
+      // Clear the values, use labels as the new values if they exist
       if (this.trait.scale.categories) {
-        this.trait.scale.categories.forEach(category => category.label = undefined);
+        this.trait.scale.categories.forEach(category => {
+          category.value = category.label;
+          category.label = undefined;
+        });
       }
 
       this.trait.scale.dataType = value;
       this.trait!.scale!.scaleName = value;
     } else if (Scale.dataTypeEquals(value, DataType.Ordinal) && Scale.dataTypeEquals(this.lastCategoryType, DataType.Nominal)) {
       this.trait.scale = Scale.assign(this.scaleHistory[DataType.Nominal.toLowerCase()]);
-      // Add 1-based index labels to categories
+      // TODO: Clear the scale category validations if there are any, the switch is confusing
+
+      // Add 1-based index values to categories
       if (this.trait.scale.categories) {
         this.trait.scale.categories.forEach((category, index, categories) => {
-          // Use prior labels if they exist
+          // Use prior values if they exist
           const historicalCats: Category[] = this.scaleHistory[DataType.Ordinal.toLowerCase()] ? this.scaleHistory[DataType.Ordinal.toLowerCase()].categories as Category[] : [] as Category[];
-          if (historicalCats[index] && historicalCats[index].label) {
-            category.label = historicalCats[index].label;
+          // Assign the value in the label place for the switch back to ordinal
+          category.label = category.value;
+          if (historicalCats[index] && historicalCats[index].value) {
+              category.value = historicalCats[index].value;
           } else {
-            const autoLabel: string = index + 1 + '';
-            if(categories.find(anyCategory => anyCategory.label === autoLabel)) {
-              category.label = autoLabel + '_dup';
-            } else {
-              category.label = autoLabel;
-            }
+            const autoValue: string = index + 1 + '';
+            category.value = autoValue;
           }
-        })
+        });
       }
       this.trait.scale.dataType = value;
       this.trait!.scale!.scaleName = value;

--- a/src/components/trait/forms/CategoryTraitForm.vue
+++ b/src/components/trait/forms/CategoryTraitForm.vue
@@ -158,9 +158,9 @@ export default class CategoryTraitForm extends Vue {
   prepopulateCategories() {
     for (const i of Array(5).keys()) {
       if (this.type === DataType.Ordinal) {
-        this.data.push(new Category((i + 1).toString(), ''));
+        this.data.push(new Category('', (i + 1).toString()));
       } else {
-        this.data.push(new Category(undefined, ''));
+        this.data.push(new Category('', undefined));
       }
     }
   }

--- a/src/components/trait/forms/LabelValueRow.vue
+++ b/src/components/trait/forms/LabelValueRow.vue
@@ -20,12 +20,12 @@
     <div class="columns is-mobile is-gapless">
       <div class="column is-2">
         <BasicInputField
-            v-bind:field-name="'Label'"
+            v-bind:field-name="'Value'"
             v-bind:show-label="false"
-            v-bind:value="label"
-            v-on:input="$emit('label-change', $event)"
-            v-bind:input-id="'label' + Math.random()"
-            v-bind:server-validations="serverRowValidation ? serverRowValidation.getValidation(TraitError.CategoryLabel): undefined"
+            v-bind:value="value"
+            v-on:input="$emit('value-change', $event)"
+            v-bind:input-id="'value' + Math.random()"
+            v-bind:server-validations="serverRowValidation ? serverRowValidation.getValidation(TraitError.CategoryValue): undefined"
         />
       </div>
       <div class="column is-1 has-text-centered">
@@ -35,13 +35,13 @@
         <div class="columns is-mobile is-gapless">
           <div class="column is-four-fifths">
             <BasicInputField
-                v-bind:field-name="'Value'"
+                v-bind:field-name="'Label'"
                 v-bind:show-label="false"
                 v-bind:placeholder="valuePlaceholder"
-                v-bind:value="value"
-                v-on:input="$emit('value-change', $event)"
-                v-bind:input-id="'value' + Math.random()"
-                v-bind:server-validations="serverRowValidation ? serverRowValidation.getValidation(TraitError.CategoryValue): undefined"
+                v-bind:value="label"
+                v-on:input="$emit('label-change', $event)"
+                v-bind:input-id="'label' + Math.random()"
+                v-bind:server-validations="serverRowValidation ? serverRowValidation.getValidation(TraitError.CategoryLabel): undefined"
             />
           </div>
           <div class="column is-one-fifth ml-2">


### PR DESCRIPTION
Changes the scale categories README description to say `<value of the category> = <label of the category>` instead of `<label of the category> = <meaning of the category>`.

Changes to the UI:
- Switch the label and value around. The UI will look the same, values are just assigned differently to the scale model.
- Changes for switching between nominal and ordinal:
  - When switching from ordinal to nominal, the category value is set equal to the previous category label. 
  - When switching from nominal to ordinal, the category label is set equal to the category value.
    - These changes were made to mimic the previous behavior on the UI. 
  - Cleared the server validations for categories in the front end when switching between nominal and ordinal
    - The validations were confusing because the errors seemed to move fields because of the orientation of the fields. 

Changes to BreedBase:
- Changes brapi v1 categories to be formatted as "value=label" instead of "label=value" to follow the switching on our side. 
- If a label isn't passed, the label is set as the value, instead of being set as an incrementing label. 
  - This fixes nominal categories automatically generating labels.

Changes to bi-api:
- There are no changes to the backend

Changes to Field Book:
- Field Book now uses the `value` in the brapi category, instead of the `label`

This PR is related to some FieldBook work being done, https://github.com/PhenoApps/Field-Book/issues/294.
Here is the Field Book PR: https://github.com/PhenoApps/Field-Book/pull/320

Chaney is going to do most of that work, although I have a PR for a quick fix to match the brapi v1 implementation in FieldBook.

Things you'll have to do:
- Update your trait files to be label = value
- Run the migration script below to fix your brapi v2 categories in breedbase
- Fix your nominal traits if you have any and if you want to.

You will have to migrate any existing categorical traits in BreedBase because `label` and `value` are switched currently. Here is a query to do that:

```
DO
$do$
declare
    category_row record;
begin
	for category_row in 
		select label.cvtermprop_id as label_id, label.value as label_value, value.cvtermprop_id as value_id, value.value as value_value 
		from cvterm 
		join cvtermprop as label on cvterm.cvterm_id = label.cvterm_id and label.type_id = 79072
		join cvtermprop as value on cvterm.cvterm_id = value.cvterm_id and label.rank = value.rank and value.type_id = 79073
		where 
		cv_id = 79
	loop
		RAISE NOTICE 'label_id: %, label: %, value_id: %, value: %', category_row.label_id, category_row.label_value, category_row.value_id, category_row.value_value;
		update cvtermprop set value = category_row.value_value where cvtermprop.cvtermprop_id = category_row.label_id;
		update cvtermprop set value = category_row.label_value where cvtermprop.cvtermprop_id = category_row.value_id;
		--select category_row.value_id, category_row.value_value from category_row;
	end loop;
end;
$do$;
```