### PR TITLE
[BI-1087] "Show All" link on tables not focusable via tabbing

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -156,7 +156,7 @@ nav.pagination {
         margin-left: 4px;
       }
     }
-    & a.show-all-button {
+    & button.show-all-button {
       order: 2;
     }
   }

--- a/src/components/tables/PaginationControls.vue
+++ b/src/components/tables/PaginationControls.vue
@@ -20,7 +20,7 @@
         slot="previous"
         slot-scope="props"
         :page="props.page"
-        tag="a"
+        tag="button"
     >
       Previous
     </b-pagination-button>
@@ -31,7 +31,7 @@
     >
       <b-pagination-button
           :page="props.page"
-          tag="a"
+          tag="button"
       >
         Next
       </b-pagination-button>
@@ -65,15 +65,14 @@
           <span>per page</span>
         </div>
 
-        <a
+        <button
             data-testid="showAll"
-            role="button"
             class="pagination-link show-all-button"
             v-bind:class="{ 'has-background-info': pagination.totalPages === 1}"
             v-on:click="$emit('paginate-toggle-all')"
         >
           Show All
-        </a>
+        </button>
       </div>
     </template>
   </b-pagination>

--- a/src/components/tables/PaginationControls.vue
+++ b/src/components/tables/PaginationControls.vue
@@ -67,6 +67,7 @@
 
         <button
             data-testid="showAll"
+            role="button"
             class="pagination-link show-all-button"
             v-bind:class="{ 'has-background-info': pagination.totalPages === 1}"
             v-on:click="$emit('paginate-toggle-all')"

--- a/tests/unit/components/tables/ExpandableRowTable.spec.ts
+++ b/tests/unit/components/tables/ExpandableRowTable.spec.ts
@@ -191,7 +191,7 @@ describe('Pagination works with expandable table', () => {
     let editForm = wrapper.findComponent(EditDataRowForm);
     expect(editForm.exists()).toBeFalsy();
 
-    const showAllBtn = wrapper.find('a[data-testid="showAll"]');
+    const showAllBtn = wrapper.find('button[data-testid="showAll"]');
     await showAllBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -206,7 +206,7 @@ describe('Pagination works with expandable table', () => {
   it('Show all selection works when expandable open', async () => {
     await openEditForm(wrapper);
 
-    const showAllBtn = wrapper.find('a[data-testid="showAll"]');
+    const showAllBtn = wrapper.find('button[data-testid="showAll"]');
     await showAllBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -226,7 +226,7 @@ describe('Pagination works with expandable table', () => {
     await numSelect.find('option[value="50"]').setSelected();
     await wrapper.vm.$nextTick();
 
-    const nextPageBtn = wrapper.find('a[aria-label="Next page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Next page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -239,7 +239,7 @@ describe('Pagination works with expandable table', () => {
   it('Next page button works when expandable open', async () => {
     await openEditForm(wrapper);
 
-    const nextPageBtn = wrapper.find('a[aria-label="Next page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Next page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -254,7 +254,7 @@ describe('Pagination works with expandable table', () => {
   it('Previous page button works when expandable open', async () => {
     await openEditForm(wrapper);
 
-    const nextPageBtn = wrapper.find('a[aria-label="Previous page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Previous page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -270,7 +270,7 @@ describe('Pagination works with expandable table', () => {
     let editForm = wrapper.findComponent(EditDataRowForm);
     expect(editForm.exists()).toBeFalsy();
 
-    const nextPageBtn = wrapper.find('a[aria-label="Previous page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Previous page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 

--- a/tests/unit/components/tables/ExpandableTable.spec.ts
+++ b/tests/unit/components/tables/ExpandableTable.spec.ts
@@ -234,7 +234,7 @@ describe('Pagination works with expandable table', () => {
     let editForm = wrapper.findComponent(EditDataRowForm);
     expect(editForm.exists()).toBeFalsy();
 
-    const showAllBtn = wrapper.find('a[data-testid="showAll"]');
+    const showAllBtn = wrapper.find('button[data-testid="showAll"]');
     await showAllBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -250,7 +250,7 @@ describe('Pagination works with expandable table', () => {
   it('Show all selection works when expandable open', async () => {
     await openEditForm(wrapper);
 
-    const showAllBtn = wrapper.find('a[data-testid="showAll"]');
+    const showAllBtn = wrapper.find('button[data-testid="showAll"]');
     await showAllBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -271,7 +271,7 @@ describe('Pagination works with expandable table', () => {
     await numSelect.find('option[value="50"]').setSelected();
     await wrapper.vm.$nextTick();
 
-    const nextPageBtn = wrapper.find('a[aria-label="Next page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Next page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -285,7 +285,7 @@ describe('Pagination works with expandable table', () => {
   it('Next page button works when expandable open', async () => {
     await openEditForm(wrapper);
 
-    const nextPageBtn = wrapper.find('a[aria-label="Next page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Next page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -301,7 +301,7 @@ describe('Pagination works with expandable table', () => {
   it('Previous page button works when expandable open', async () => {
     await openEditForm(wrapper);
 
-    const nextPageBtn = wrapper.find('a[aria-label="Previous page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Previous page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -318,7 +318,7 @@ describe('Pagination works with expandable table', () => {
     let editForm = wrapper.findComponent(EditDataRowForm);
     expect(editForm.exists()).toBeFalsy();
 
-    const nextPageBtn = wrapper.find('a[aria-label="Previous page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Previous page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 

--- a/tests/unit/components/tables/SidePanelTable.spec.ts
+++ b/tests/unit/components/tables/SidePanelTable.spec.ts
@@ -138,7 +138,7 @@ describe('Pagination works with side table', () => {
     let editForm = wrapper.findComponent(SidePanel);
     expect(editForm.exists()).toBeFalsy();
 
-    const showAllBtn = wrapper.find('a[data-testid="showAll"]');
+    const showAllBtn = wrapper.find('button[data-testid="showAll"]');
     await showAllBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -153,7 +153,7 @@ describe('Pagination works with side table', () => {
   it('Show all selection works when details open', async () => {
     await openEditForm(wrapper);
 
-    const showAllBtn = wrapper.find('a[data-testid="showAll"]');
+    const showAllBtn = wrapper.find('button[data-testid="showAll"]');
     await showAllBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -173,7 +173,7 @@ describe('Pagination works with side table', () => {
     await numSelect.find('option[value="50"]').setSelected();
     await wrapper.vm.$nextTick();
 
-    const nextPageBtn = wrapper.find('a[aria-label="Next page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Next page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -186,7 +186,7 @@ describe('Pagination works with side table', () => {
   it('Next page button works when details open', async () => {
     await openEditForm(wrapper);
 
-    const nextPageBtn = wrapper.find('a[aria-label="Next page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Next page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -201,7 +201,7 @@ describe('Pagination works with side table', () => {
   it('Previous page button works when details open', async () => {
     await openEditForm(wrapper);
 
-    const nextPageBtn = wrapper.find('a[aria-label="Previous page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Previous page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 
@@ -217,7 +217,7 @@ describe('Pagination works with side table', () => {
     let editForm = wrapper.findComponent(SidePanel);
     expect(editForm.exists()).toBeFalsy();
 
-    const nextPageBtn = wrapper.find('a[aria-label="Previous page"');
+    const nextPageBtn = wrapper.find('button[aria-label="Previous page"');
     await nextPageBtn.trigger('click');
     await wrapper.vm.$nextTick();
 


### PR DESCRIPTION
By default HTML <a> elements with NO href attribute are not focusable. As the “Show All” button presently is such an element, it can’t be accessed by tabbing. 

- Make “Show All” accessible to tabbing by changing element to `<button>` (which is focusable). 
- For sake of consistency, change Next and Previous `<a>` elements to `<button>`.
- Updated unit tests to look for `<button>` instead of `<a>`