### PR TITLE
[BI-1079] Parse 400 errors for trait import errors

### DIFF
--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -94,6 +94,7 @@
   import FileSelector from "@/components/file-import/FileSelector.vue";
   import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
   import { AlertTriangleIcon } from 'vue-feather-icons';
+  import {AxiosResponse} from "axios";
 
   @Component({
     components: {
@@ -110,7 +111,7 @@
     private displayAllErrors: boolean = false;
 
     @Prop()
-    private errors!: ValidationError | string | null;
+    private errors!: ValidationError | AxiosResponse | null;
 
     private importButtonId: string = "fileselectmessagebox-import-button";
     private importFileNameId: string = "fileselectmessagebox-import-filename";
@@ -149,7 +150,13 @@
         }
         return errors;
       } else if (this.errors != null) {
-        return [this.errors!] as string[];
+        // Parse 400 responses and display the message if its not empty
+        if (this.errors.status && this.errors.status === 400 &&
+            this.errors.data && this.errors.data.message && this.errors.data.message !== '') {
+          return [this.errors.data.message] as string[];
+        }else {
+          return [this.errors!] as string[];
+        }
       } else {
         return [];
       }

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -151,15 +151,18 @@
         return errors;
       } else if (this.errors != null) {
         // Parse 400 responses and display the message if its not empty
-        if (this.errors.status && this.errors.status === 400 &&
-            this.errors.data && this.errors.data.message && this.errors.data.message !== '') {
-          return [this.errors.data.message] as string[];
-        }else {
-          return [this.errors!] as string[];
+        const apiResponse = this.errors as AxiosResponse;
+        if (apiResponse.status && apiResponse.status === 400 &&
+            apiResponse.data && apiResponse.data.message && apiResponse.data.message !== '') {
+          return [apiResponse.data.message] as string[];
         }
-      } else {
-        return [];
       }
+
+      // A catch all for anything we haven't explicitly caught
+      if (this.errors) {
+        return ["An unknown error has occurred"] as string[];
+      }
+      return [];
     }
   }
 </script>

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -106,6 +106,7 @@ import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {Trait} from "@/breeding-insight/model/Trait";
 import {ProgramUpload} from "@/breeding-insight/model/ProgramUpload";
+import {AxiosResponse} from "axios";
 
 enum ImportState {
   CHOOSE_FILE = "CHOOSE_FILE",
@@ -154,7 +155,7 @@ enum ImportAction {
 export default class TraitsImport extends ProgramsBase {
 
   private file : File | null = null;
-  private import_errors: ValidationError | string | null = null;
+  private import_errors: ValidationError | AxiosResponse | null = null;
   private activeProgram?: Program;
   private tableLoaded = false;
   private numTraits = 0;
@@ -271,7 +272,7 @@ export default class TraitsImport extends ProgramsBase {
     TraitUploadService.uploadFile(this.activeProgram!.id!, this.file!).then((response) => {
       this.numTraits = response.data!.length;
       this.importService.send(ImportEvent.IMPORT_SUCCESS);
-    }).catch((error: ValidationError | string) => {
+    }).catch((error: ValidationError | AxiosResponse) => {
       this.import_errors = error;
       this.importService.send(ImportEvent.IMPORT_ERROR);
     });


### PR DESCRIPTION
Parses 400 errors on the front end to display a cleaner error message. Only 400 errors are parsed. If the error is not a 400 error, and not a `ValidationError`, a generic "An unknown error has occurred" message is shown. 

![duplicate_columns](https://user-images.githubusercontent.com/17887341/129624792-a307575b-2a02-42c2-9787-0c9834d20df8.png)
![missing_columns](https://user-images.githubusercontent.com/17887341/129624797-b1c7fdc0-4e3d-4731-a4ed-2a739ae72874.png)
![screencapture-192-168-1-113-8080-programs-9fbf27ad-b60d-4c13-8d2e-39e55784007d-traits-import-2021-08-16-16_19_50](https://user-images.githubusercontent.com/17887341/129624800-df9b9b52-daac-4550-a886-99aaec884fa5.png)
