### PR TITLE
[BI-640] - Disable modification of user role for self

### DIFF
--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -224,7 +224,7 @@
               v-bind:selected-id="editData.roleId"
               v-bind:field-name="'Role'"
               v-bind:empty-value-name="'No Role'"
-              :isDisabled="isCurrentUser(editData.id)"
+              v-bind:is-disabled="isCurrentUser(editData.id)"
             />
           </div>
         </div>
@@ -462,7 +462,7 @@ export default class AdminUsersTable extends Vue {
   }
 
   isCurrentUser(userId: string) {
-    if (this.activeUser!.id == userId){
+    if (this.activeUser!.id === userId){
       return true;
     } else {
       return false;

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -391,7 +391,7 @@ export default class AdminUsersTable extends Vue {
 
     //if active user is same as modified user, don't update roles
     let promiseHandler;
-    let noRoles = this.isCurrentUser(user.id);
+    let noRoles = this.isCurrentUser(user.id!);
     if (noRoles) {
       promiseHandler = new PromiseHandler([updateUserPromise]);
     } else {

--- a/src/components/forms/BasicSelectField.vue
+++ b/src/components/forms/BasicSelectField.vue
@@ -28,7 +28,7 @@
           v-bind:id="fieldName.replace(' ', '-')"
           v-on:change="$emit('input', $event.target.value)"
           class="select is-fullwidth"
-          :disabled="isDisabled"
+          v-bind:disabled="isDisabled"
       >
         <option disabled v-bind:selected="displayDefault()" value="">Select a {{fieldName.toLowerCase()}}</option>
         <template v-if="emptyValueName">

--- a/src/components/forms/BasicSelectField.vue
+++ b/src/components/forms/BasicSelectField.vue
@@ -28,6 +28,7 @@
           v-bind:id="fieldName.replace(' ', '-')"
           v-on:change="$emit('input', $event.target.value)"
           class="select is-fullwidth"
+          :disabled="isDisabled"
       >
         <option disabled v-bind:selected="displayDefault()" value="">Select a {{fieldName.toLowerCase()}}</option>
         <template v-if="emptyValueName">
@@ -73,6 +74,8 @@
     emptyValueName!: string;
     @Prop()
     showLabel!: boolean;
+    @Prop()
+    isDisabled!: boolean;
 
 
     displayDefault() {


### PR DESCRIPTION
The current messages when a sys admin modifies their own role and no other fields are confusing. To simplify this, the field for modifying a user's role will be disabled when the user is the same as the sys admin.

**Changes:**
When user matches active user:
- In edit for System Users table, disabled Role field
- Only submitted change via promises for user info and not for user roles
- Use more specific user info success message 'User info (name/email/program) successfully updated'

Modified banner message logic for one promise succeeding and not the other to only fire when there are two promises

Linked to PR [taf/BI-640](https://github.com/Breeding-Insight/taf/pull/15)