### PR TITLE
[BI-994] Ontology UI - Review Existing Terms

### DIFF
--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -179,7 +179,7 @@
               <router-link
                 v-bind:to="{name: 'traits', params: {programId: activeProgram.id}}"
                 v-bind:class="{ 'is-active': traitsActive }"
-                :id="traitsMenuId"
+                :id="ontologyMenuId"
               >
                 Ontology
                 <MoreVerticalIcon
@@ -307,7 +307,7 @@
 
     private homeMenuId: string = "usersidebarlayout-home-menu";
     private importFileMenuId: string = "usersidebarlayout-import-file-menu";
-    private traitsMenuId: string = "usersidebarlayout-traits-menu";
+    private ontologyMenuId: string = "usersidebarlayout-ontology-menu";
     private programManagementMenuId: string = "usersidebarlayout-program-management-menu";
     private brAPIMenuId: string = "usersidebarlayout-brapi-menu";
 

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -181,7 +181,7 @@
                 v-bind:class="{ 'is-active': traitsActive }"
                 :id="traitsMenuId"
               >
-                Traits
+                Ontology
                 <MoreVerticalIcon
                   v-if="!traitsActive"
                   class="is-pulled-right"
@@ -194,7 +194,7 @@
               <ul v-show="traitsActive">
                 <li>
                   <router-link v-bind:to="{name: 'traits-list', params: {programId: activeProgram.id}}">
-                    Trait List
+                    Ontology List
                   </router-link>
                 </li>
                 <li>
@@ -206,12 +206,12 @@
                   v-if="$ability.can('create', 'Trait')"
                 >
                   <router-link v-bind:to="{name: 'traits-import', params: {programId: activeProgram.id}}">
-                    Import Traits
+                    Import Ontology
                   </router-link>
                 </li>
                 <li>
                   <router-link v-bind:to="{name: 'traits-archived', params: {programId: activeProgram.id}}">
-                    Archived Traits
+                    Archived Ontology
                   </router-link>
                 </li>
               </ul>

--- a/src/components/trait/TraitListsTable.vue
+++ b/src/components/trait/TraitListsTable.vue
@@ -45,7 +45,7 @@
       </div>              
     </WarningModal>
 
-    <div class="columns has-text-right mb-0">
+    <div class="columns has-text-right mb-0 buttons">
       <div class="column">
         <button
             v-if="$ability.can('create', 'Trait')"
@@ -61,7 +61,23 @@
           />
         </span>
           <span>
-          New Trait
+          New Term
+        </span>
+        </button>
+        <button
+            v-if="$ability.can('create', 'Trait')"
+            v-show="!newTraitActive & traits.length > 0"
+            class="button is-primary has-text-weight-bold"
+            v-on:click="$router.push({name: 'traits-import', params: {programId: activeProgram.id}})"
+        >
+        <span class="icon is-small">
+          <PlusCircleIcon
+              size="1.5x"
+              aria-hidden="true"
+          />
+        </span>
+        <span>
+          Import Batch File
         </span>
         </button>
       </div>
@@ -116,17 +132,22 @@
               v-if="!data.active && data.active !== undefined">
             Archived
           </b-button>
-          {{ data.traitName }}
+          {{ data.observationVariableName }}
         </TableColumn>
-        <TableColumn name="level" v-bind:label="'Level'" v-bind:visible="!traitSidePanelState.collapseColumns">
-          {{ data.programObservationLevel.name }}
+        <TableColumn name="trait" v-bind:label="'Trait'" v-bind:visible="!collapseColumns">
+          {{ StringFormatters.toStartCase(data.traitDescription) }}
         </TableColumn>
         <TableColumn name="method" v-bind:label="'Method'" v-bind:visible="!traitSidePanelState.collapseColumns">
-          {{ StringFormatters.toStartCase(data.method.methodClass) }}
+          {{ data.method.description + " " + StringFormatters.toStartCase(data.method.methodClass) }}
         </TableColumn>
-        <TableColumn name="scale" v-bind:label="'Scale'" v-bind:visible="!traitSidePanelState.collapseColumns">
+        <TableColumn name="scaleClass" v-bind:label="'Scale Class'" v-bind:visible="!traitSidePanelState.collapseColumns">
           {{ TraitStringFormatters.getScaleTypeString(data.scale) }}
-        </TableColumn>        
+        </TableColumn>
+        <TableColumn name="unit" v-bind:label="'Unit'" v-bind:visible="!traitSidePanelState.collapseColumns">
+          <template v-if="data.scale.dataType==='NUMERICAL'">
+            {{ data.scale.scaleName }}
+          </template>
+        </TableColumn>
       </template>
 
       <!-- 
@@ -158,15 +179,15 @@
       <template v-slot:emptyMessage>
         <EmptyTableMessage
             v-bind:button-view-toggle="!newTraitActive"
-            v-bind:button-text="'New Trait'"
+            v-bind:button-text="'New Term'"
             v-on:newClick="activateNewTraitForm"
             v-bind:create-enabled="$ability.can('create', 'Trait')"
         >
           <p class="has-text-weight-bold">
-            No traits are currently defined for this program.
+            No ontology terms are currently defined for this program.
           </p>
           <p v-if="$ability.can('create', 'Trait')">
-            Create new traits by clicking "New Trait" or navigating to "Import Traits".
+            Create new ontology terms by clicking "New Term" or navigating to "Import Ontology".
           </p>
         </EmptyTableMessage>
       </template>

--- a/src/views/trait/TraitsList.vue
+++ b/src/views/trait/TraitsList.vue
@@ -17,7 +17,7 @@
 
 <template>
   <div class="traits-list">
-    <h1 class="title">All Traits</h1>
+    <h1 class="title">Ontology</h1>
     <TraitListsTable
     v-on:show-success-notification="$emit('show-success-notification', $event)"
     v-on:show-error-notification="$emit('show-error-notification', $event)"


### PR DESCRIPTION
Modified sidebar menu to use Ontology instead of Traits
Changed existing traits list to an ontology list and changed table and associated buttons to match desired UI

Linked to PR [taf/BI-994](https://github.com/Breeding-Insight/taf/pull/26)