### PR TITLE
[BI-997 BI-1061]-2 Update Trait Import (clean redo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v0.4.0+148",
+  "version": "v0.4.0+150",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -85,5 +85,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.6.10"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/9ff2c4552e00260234e42099f9ce7df1ff3b50c9"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/df5d79f07fa717c123ca895aa9877bc6aee4eca8"
 }

--- a/src/breeding-insight/service/TraitUploadService.ts
+++ b/src/breeding-insight/service/TraitUploadService.ts
@@ -28,7 +28,7 @@ export class TraitUploadService {
 
   static errorContactingServer: string = "Unknown error when contacting server. Please try again.";
   static errorUnknown: string = "Unable to determine reason for failure upload. Please check file and try again.";
-  static forbiddenUploadingFile: string = "You do not have permission to upload traits";
+  static forbiddenUploadingFile: string = "You do not have permission to upload ontology terms";
 
   static async deleteTraits(programId: string): Promise<void|Error> {
     try {
@@ -114,7 +114,7 @@ export class TraitUploadService {
       await TraitUploadDAO.confirmUpload(programId, traitUploadId);
       return;
     } catch (error) {
-      throw 'Error saving traits';
+      throw 'Error saving ontology terms';
     }
   }
 

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -37,16 +37,21 @@
       -->
       <template v-slot:columns="data">
         <TableColumn name="name" v-bind:label="'Name'">
-          {{ data.traitName }}
+          {{ data.observationVariableName }}
         </TableColumn>
-        <TableColumn name="level" v-bind:label="'Level'" v-bind:visible="!collapseColumns">
-          {{ data.programObservationLevel.name }}
+        <TableColumn name="trait" v-bind:label="'Trait'" v-bind:visible="!collapseColumns">
+          {{ StringFormatters.toStartCase(data.traitDescription) }}
         </TableColumn>
         <TableColumn name="method" v-bind:label="'Method'" v-bind:visible="!collapseColumns">
-          {{ StringFormatters.toStartCase(data.method.methodClass) }}
+          {{ data.method.description + " " + StringFormatters.toStartCase(data.method.methodClass) }}
         </TableColumn>
-        <TableColumn name="scale" v-bind:label="'Scale'" v-bind:visible="!collapseColumns">
+        <TableColumn name="scaleClass" v-bind:label="'Scale Class'" v-bind:visible="!collapseColumns">
           {{ TraitStringFormatters.getScaleTypeString(data.scale) }}
+        </TableColumn>
+        <TableColumn name="unit" v-bind:label="'Unit'" v-bind:visible="!traitSidePanelState.collapseColumns">
+          <template v-if="data.scale.dataType==='NUMERICAL'">
+            {{ data.scale.scaleName }}
+          </template>
         </TableColumn>
       </template>
 

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -48,7 +48,7 @@
     <template v-if="state === ImportState.CHOOSE_FILE || state === ImportState.FILE_CHOSEN">
       <h1 class="title" v-if="showTitle">Import Ontology</h1>
       <ImportInfoTemplateMessageBox v-bind:import-type-name="'Ontology'"
-                                    v-bind:template-url="'https://cornell.box.com/shared/static/8sp0qvccpjotosiv8576tczeg09nnvao.xls'"
+                                    v-bind:template-url="'https://cornell.box.com/shared/static/u9vuob3vvu2cgwyoe26b2722u41b8f6o.xls'"
                                     class="mb-5">
         <strong>Before You Import...</strong>
         <br/>Prepare ontology information for import using the provided template.

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -24,7 +24,7 @@
     >
       <section>
         <p class="has-text-dark" :class="this.$modalTextClass">
-          No traits will be added, and the import in progress will be completely removed.
+          No ontology terms will be added, and the import in progress will be completely removed.
         </p>
       </section>
       <div class="columns">
@@ -322,7 +322,7 @@ export default class TraitsImport extends ProgramsBase {
       await TraitUploadService.confirmUpload(this.activeProgram!.id!, upload!.id!);
 
       // show all program traits
-      this.$emit('show-success-notification', `Imported traits have been added to ${name}.`);
+      this.$emit('show-success-notification', `Imported ontology terms have been added to ${name}.`);
       this.$router.push({
         name: 'traits-list',
         params: {
@@ -330,7 +330,7 @@ export default class TraitsImport extends ProgramsBase {
         },
       });
     } catch(err) {
-      const note = err.message ? err.message : `Error: Imported traits were not added to ${name}.`;
+      const note = err.message ? err.message : `Error: Imported ontology terms were not added to ${name}.`;
       this.$emit('show-error-notification', `${note}`);
       Vue.$log.error(err);
     }

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -46,8 +46,8 @@
     </WarningModal>
 
     <template v-if="state === ImportState.CHOOSE_FILE || state === ImportState.FILE_CHOSEN">
-      <h1 class="title" v-if="showTitle">Import Traits</h1>
-      <ImportInfoTemplateMessageBox v-bind:import-type-name="'Trait'"
+      <h1 class="title" v-if="showTitle">Import Ontology</h1>
+      <ImportInfoTemplateMessageBox v-bind:import-type-name="'Ontology'"
                                     v-bind:template-url="'https://cornell.box.com/shared/static/8sp0qvccpjotosiv8576tczeg09nnvao.xls'"
                                     class="mb-5">
         <strong>Before You Import...</strong>
@@ -67,7 +67,7 @@
     
     <template v-if="state === ImportState.LOADING || state === ImportState.CURATE">
       <template v-if="tableLoaded">
-        <h1 class="title">Curate and Confirm New Traits</h1>
+        <h1 class="title">Confirm New Ontology Term</h1>
         <ConfirmImportMessageBox v-bind:num-traits="numTraits"
                                     v-on:abort="showAbortModal = true" 
                                     v-on:confirm="importService.send(ImportEvent.CONFIRMED)"

--- a/tests/unit/components/tables/SidePanelTable.spec.ts
+++ b/tests/unit/components/tables/SidePanelTable.spec.ts
@@ -42,7 +42,7 @@ function setup() {
   const scale = new Scale('Test Scale', 'Number', undefined, 3, 0, 999);
   const level = new ProgramObservationLevel('Plant');
   const range = [...Array(200).keys()];
-  traits = range.map((i:number) => new Trait(i.toString(), `Trait${i}`, undefined, level, undefined, undefined, undefined, method, scale));
+  traits = range.map((i:number) => new Trait(i.toString(), `Trait${i}`, `Trait${i}`, level, undefined, undefined, undefined, method, scale));
 
   const response = DaoUtils.formatBiResponse(traits);
 


### PR DESCRIPTION
Ontology Changes 
- Replace "Trait" with "Ontology" in Trait Import
- Alter table columns in Trait Import according to specifications
- Changed "traits" to "ontology terms" in modal message and banner messages

Linked to PR [taf/BI-997](https://github.com/Breeding-Insight/taf/pull/21) 
Redo of PR [bi-web/BI-997](https://github.com/Breeding-Insight/bi-web/pull/116)