### PR TITLE
[BI-1175] Extend GermplasmImport.vue to perform basic file import functionality

### DIFF
--- a/src/breeding-insight/dao/ImportDAO.ts
+++ b/src/breeding-insight/dao/ImportDAO.ts
@@ -37,6 +37,16 @@ export class ImportDAO {
     return new BiResponse(data);
   }
 
+  static async getSystemMappings(importName: string | undefined) : Promise<BiResponse> {
+    const params = importName ? {'importName': importName} : undefined;
+    const { data } =  await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/import/mappings`,
+      params: params,
+      method: 'get'
+    }) as Response;
+    return new BiResponse(data);
+  }
+
   static async updateMapping(programId: string, mapping: ImportMappingConfig, options: {[key:string]:boolean}): Promise<any> {
     const mappingWithoutFile: ImportMappingConfig = new ImportMappingConfig({
       id: mapping.id,

--- a/src/breeding-insight/service/ImportService.ts
+++ b/src/breeding-insight/service/ImportService.ts
@@ -41,6 +41,12 @@ export class ImportService {
     return mappings;
   }
 
+  static async getSystemMappings(importName: string | undefined): Promise<ImportMappingConfig[]> {
+    const response: BiResponse = await ImportDAO.getSystemMappings(importName);
+    const mappings: ImportMappingConfig[] = response.result.data.map((mapping: ImportMappingConfig) => new ImportMappingConfig(mapping));
+    return mappings;
+  }
+
   static async updateMapping(programId: string, mapping: ImportMappingConfig, options: {[key:string]:boolean}): Promise<any> {
     if (!programId || programId === null) throw 'Program ID not provided';
     if (!mapping || !mapping.id) throw 'Mapping must have an id.';

--- a/src/components/trait/ConfirmImportMessageBox.vue
+++ b/src/components/trait/ConfirmImportMessageBox.vue
@@ -23,9 +23,9 @@
           <div class="level-left">
             <div class="level-item">
               <div class="has-text-dark">
-                <strong>{{numTraits}} new traits and duplicates not checked yet</strong>
-                <br/>Duplicate traits, highlighted in yellow and a <alert-triangle-icon size="1.2x" class="icon-align"/> icon, will not be imported.
-                <br/>Traits in this list can be directly edited using the "Show details" link.
+                <strong>{{numRecords}} new {{importTypeName.toLowerCase()}} records and duplicates not checked yet</strong>
+                <br/>Duplicate {{importTypeName.toLowerCase()}} records, highlighted in yellow and a <alert-triangle-icon size="1.2x" class="icon-align"/> icon, will not be imported.
+                <br/>{{toStartCase(importTypeName)}} records in this list can be directly edited using the "Show details" link.
               </div>
             </div>
           </div>
@@ -50,6 +50,7 @@
 <script lang="ts">
   import { Component, Prop, Vue } from 'vue-property-decorator'
   import {AlertTriangleIcon} from 'vue-feather-icons'
+  import {StringFormatters} from '@/breeding-insight/utils/StringFormatters'
 
   @Component({
     components: {
@@ -59,7 +60,10 @@
   export default class ConfirmImportMessageBox extends Vue {
 
     @Prop()
-    private numTraits!: number;
+    private numRecords!: number;
+
+    @Prop()
+    importTypeName! : string;
 
     confirm() {
       this.$emit('confirm');
@@ -67,6 +71,10 @@
 
     abort() {
       this.$emit('abort');
+    }
+
+    toStartCase(str : string) {
+      return StringFormatters.toStartCase(str);
     }
 
   }

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -19,6 +19,7 @@
   <div id="import-germplasm">
     <ImportTemplate v-bind:abort-msg="'No germplasm records will be added, and the import in progress will be completely removed.'"
                     v-bind:system-import-template-name="germplasmImportTemplateName"
+                    v-bind:confirm-msg="'Confirm New Germplasm Records'"
                     v-on="$listeners">
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -18,7 +18,7 @@
 <template>
   <div id="import-germplasm">
     <ImportTemplate v-bind:abort-msg="'No germplasm records will be added, and the import in progress will be completely removed.'"
-                    v-on:upload-file="upload($event)"
+                    v-bind:system-import-template-name="germplasmImportTemplateName"
                     v-on="$listeners">
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
@@ -49,9 +49,7 @@ import ImportTemplate from "@/views/import/ImportTemplate.vue";
 })
 export default class ImportGermplasm extends ProgramsBase {
 
-  upload() {
-    console.log('upload');
-  }
+  private germplasmImportTemplateName = 'GermplasmTest';
 
 }
 </script>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -22,6 +22,7 @@
                     v-bind:confirm-msg="'Confirm New Germplasm Records'"
                     v-bind:import-type-name="'Germplasm'"
                     v-on="$listeners">
+
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
                                       v-bind:template-url="'https://cornell.box.com/shared/static/kv3l900otsea9zm3iowp7e9umpcjvsck.xls'"
@@ -35,6 +36,20 @@
           database via customized matching in the upcoming step.
         </ImportInfoTemplateMessageBox>
       </template>
+
+      <template v-slot:confirmImportMessageBox="{ statistics, abort, confirm }">
+        <ConfirmImportMessageBox v-bind:num-records="getNumNewGermplasmRecords(statistics)"
+                                 v-bind:import-type-name="'Germplasm'"
+                                 v-on:abort="abort"
+                                 v-on:confirm="confirm"
+                                 class="mb-4"/>
+      </template>
+      
+      <template v-slot:importPreviewTable="previewData">
+        <!-- TODO: Replace tree-view when table is ready -->
+        <tree-view v-bind:data="previewData.previewData" v-bind:options="{maxDepth: 0}"></tree-view>
+      </template>
+
     </ImportTemplate>
   </div>
 </template>
@@ -43,15 +58,26 @@
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import ProgramsBase from "@/components/program/ProgramsBase.vue";
 import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTemplateMessageBox.vue";
+import ConfirmImportMessageBox from "@/components/trait/ConfirmImportMessageBox.vue";
 import ImportTemplate from "@/views/import/ImportTemplate.vue";
 
 @Component({
-  components: {ImportInfoTemplateMessageBox, ImportTemplate
+  components: {ImportInfoTemplateMessageBox, ConfirmImportMessageBox, ImportTemplate
   }
 })
 export default class ImportGermplasm extends ProgramsBase {
 
+  // TODO: maybe move to config instead of hardcode?
   private germplasmImportTemplateName = 'GermplasmTest';
+
+  getNumNewGermplasmRecords(statistics: any): number | undefined {
+    if (statistics.Germplasm) {
+      if (statistics.Germplasm.newObjectCount !== undefined) {
+        return statistics.Germplasm.newObjectCount;
+      }
+    }
+    return undefined;
+  }
 
 }
 </script>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -17,22 +17,23 @@
 
 <template>
   <div id="import-germplasm">
-    <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                  v-bind:template-url="'https://cornell.box.com/shared/static/kv3l900otsea9zm3iowp7e9umpcjvsck.xls'"
-                                  class="mb-5">
-      <strong>Before You Import...</strong>
-      <br/>
-      Any file containing germplasm names, breeding methods, and sources can be imported regardless of header format.
-      The system provides guidance for matching file column headers to their appropriate database location.
-      If you use the headers specified in the import template, matching will be automatic.
-      Any germplasm detail (attribute or passport information) not specified in the template can be added to the
-      database via customized matching in the upcoming step.
-    </ImportInfoTemplateMessageBox>
-    <div class="box">
-      <FileSelectMessageBox v-model="file"
-                            v-bind:fileTypes="'.csv, .xls, .xlsx'"
-      />
-    </div>
+    <ImportTemplate v-bind:abort-msg="'No germplasm records will be added, and the import in progress will be completely removed.'"
+                    v-on:upload-file="upload($event)"
+                    v-on="$listeners">
+      <template v-slot:importInfoTemplateMessageBox>
+        <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/kv3l900otsea9zm3iowp7e9umpcjvsck.xls'"
+                                      class="mb-5">
+          <strong>Before You Import...</strong>
+          <br/>
+          Any file containing germplasm names, breeding methods, and sources can be imported regardless of header format.
+          The system provides guidance for matching file column headers to their appropriate database location.
+          If you use the headers specified in the import template, matching will be automatic.
+          Any germplasm detail (attribute or passport information) not specified in the template can be added to the
+          database via customized matching in the upcoming step.
+        </ImportInfoTemplateMessageBox>
+      </template>
+    </ImportTemplate>
   </div>
 </template>
 
@@ -40,15 +41,17 @@
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import ProgramsBase from "@/components/program/ProgramsBase.vue";
 import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTemplateMessageBox.vue";
-import FileSelectMessageBox from "@/components/file-import/FileSelectMessageBox.vue";
+import ImportTemplate from "@/views/import/ImportTemplate.vue";
 
 @Component({
-  components: {ImportInfoTemplateMessageBox, FileSelectMessageBox
+  components: {ImportInfoTemplateMessageBox, ImportTemplate
   }
 })
 export default class ImportGermplasm extends ProgramsBase {
 
-  private file : File | null = null;
+  upload() {
+    console.log('upload');
+  }
 
 }
 </script>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -20,6 +20,7 @@
     <ImportTemplate v-bind:abort-msg="'No germplasm records will be added, and the import in progress will be completely removed.'"
                     v-bind:system-import-template-name="germplasmImportTemplateName"
                     v-bind:confirm-msg="'Confirm New Germplasm Records'"
+                    v-bind:import-type-name="'Germplasm'"
                     v-on="$listeners">
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -44,7 +44,7 @@
                                  v-on:confirm="confirm"
                                  class="mb-4"/>
       </template>
-      
+
       <template v-slot:importPreviewTable="previewData">
         <!-- TODO: Replace tree-view when table is ready -->
         <tree-view v-bind:data="previewData.previewData" v-bind:options="{maxDepth: 0}"></tree-view>

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -61,15 +61,12 @@
     </template>
 
     <template v-if="state === ImportState.LOADING || state === ImportState.CURATE">
-      <template v-if="tableLoaded">
-        <h1 class="title">{{toTitleCase(confirmMsg)}}</h1>
-        <ConfirmImportMessageBox v-bind:num-records="numTraits"
-                                 v-bind:import-type-name="'Germplasm'"
-                                 v-on:abort="showAbortModal = true"
-                                 v-on:confirm="importService.send(ImportEvent.CONFIRMED)"
-                                 class="mb-4"/>
-      </template>
-      <TraitsImportTable v-on:loaded="importService.send(ImportEvent.TABLE_LOADED)"/>
+      <h1 class="title">{{toTitleCase(confirmMsg)}}</h1>
+      <ConfirmImportMessageBox v-bind:num-records="numTraits"
+                               v-bind:import-type-name="'Germplasm'"
+                               v-on:abort="showAbortModal = true"
+                               v-on:confirm="importService.send(ImportEvent.CONFIRMED)"
+                               class="mb-4"/>
       <div>
         <tree-view :data="previewData" :options="{maxDepth: 0}"></tree-view>
       </div>
@@ -94,7 +91,6 @@ import { Component, Prop, Watch, Vue } from 'vue-property-decorator'
 import { mapGetters } from 'vuex'
 
 import ProgramsBase from "@/components/program/ProgramsBase.vue"
-import TraitsImportTable from "@/components/trait/TraitsImportTable.vue";
 import ImportingMessageBox from "@/components/file-import/ImportingMessageBox.vue";
 import ConfirmImportMessageBox from "@/components/trait/ConfirmImportMessageBox.vue";
 import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTemplateMessageBox.vue";
@@ -141,7 +137,6 @@ enum ImportAction {
 
 @Component({
   components: {
-    TraitsImportTable,
     ImportingMessageBox,
     ConfirmImportMessageBox,
     FileSelectMessageBox,
@@ -216,10 +211,11 @@ export default class ImportTemplate extends ProgramsBase {
                 target: ImportState.CHOOSE_FILE,
                 actions: ImportAction.ABORT
               },
-              [ImportEvent.IMPORT_SUCCESS]: ImportState.LOADING,
+              [ImportEvent.IMPORT_SUCCESS]: ImportState.CURATE,
               [ImportEvent.IMPORT_ERROR]: ImportState.IMPORT_ERROR,
             }
           },
+          //TODO: This is skipped for now
           [ImportState.LOADING]: {
             on: {
               [ImportEvent.ABORT_IMPORT]: {
@@ -432,6 +428,7 @@ export default class ImportTemplate extends ProgramsBase {
             this.previewTotalRows = previewResponse.preview.rows.length;
             this.previewData = previewResponse.preview.rows.slice(0, 100);
             this.newObjectCounts = previewResponse.preview.statistics;
+            console.log(previewResponse.preview);
           }
         }
       }

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -1,0 +1,359 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div class="template-import">
+    <WarningModal
+        v-bind:active.sync="showAbortModal"
+        v-bind:msg-title="'Abort This Import'"
+        v-on:deactivate="showAbortModal = false"
+    >
+      <section>
+        <p class="has-text-dark" :class="this.$modalTextClass">
+          {{abortMsg}}
+        </p>
+      </section>
+      <div class="columns">
+        <div class="column is-whole has-text-centered buttons">
+          <button
+              class="button is-danger"
+              v-on:click="handleAbortModal()" :id="yesAbortId"
+          >
+            <strong>Yes, abort</strong>
+          </button>
+          <button
+              class="button"
+              v-on:click="showAbortModal = false"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </WarningModal>
+
+    <template v-if="state === ImportState.CHOOSE_FILE || state === ImportState.FILE_CHOSEN">
+      <h1 class="title" v-if="showTitle">{{title}}</h1>
+      <slot name="importInfoTemplateMessageBox" />
+      <div class="box">
+        <FileSelectMessageBox v-model="file"
+                              v-bind:fileTypes="'.csv, .xls, .xlsx'"
+                              v-on:import="importService.send(ImportEvent.IMPORT_STARTED)"/>
+      </div>
+    </template>
+
+    <template v-if="state === ImportState.IMPORTING || state === ImportState.LOADING">
+      <h1 class="title">Importing...</h1>
+      <ImportingMessageBox v-bind:file="file" v-on:abort="importService.send(ImportEvent.ABORT_IMPORT)"/>
+    </template>
+
+    <template v-if="state === ImportState.LOADING || state === ImportState.CURATE">
+      <template v-if="tableLoaded">
+        <h1 class="title">Confirm New Ontology Term</h1>
+        <ConfirmImportMessageBox v-bind:num-traits="numTraits"
+                                 v-on:abort="showAbortModal = true"
+                                 v-on:confirm="importService.send(ImportEvent.CONFIRMED)"
+                                 class="mb-4"/>
+      </template>
+      <TraitsImportTable v-on:loaded="importService.send(ImportEvent.TABLE_LOADED)"/>
+    </template>
+
+    <template v-if="state === ImportState.IMPORT_ERROR">
+      <h1 class="title">Importing...</h1>
+      <TraitImportTemplateMessageBox class="mb-5"/>
+      <div class="box">
+        <FileSelectMessageBox v-model="file"
+                              v-bind:fileTypes="'.csv, .xls, .xlsx'"
+                              v-bind:errors="import_errors"
+                              v-on:import="importService.send(ImportEvent.IMPORT_STARTED)"/>
+      </div>
+    </template>
+
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Watch, Vue } from 'vue-property-decorator'
+import { mapGetters } from 'vuex'
+
+import ProgramsBase from "@/components/program/ProgramsBase.vue"
+import TraitsImportTable from "@/components/trait/TraitsImportTable.vue";
+import ImportingMessageBox from "@/components/file-import/ImportingMessageBox.vue";
+import ConfirmImportMessageBox from "@/components/trait/ConfirmImportMessageBox.vue";
+import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTemplateMessageBox.vue";
+import FileSelectMessageBox from "@/components/file-import/FileSelectMessageBox.vue"
+import WarningModal from '@/components/modals/WarningModal.vue'
+
+import {Program} from '@/breeding-insight/model/Program'
+import {TraitUploadService} from "@/breeding-insight/service/TraitUploadService";
+import {TraitService} from "@/breeding-insight/service/TraitService";
+
+import { createMachine, interpret } from '@xstate/fsm';
+import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
+import {Trait} from "@/breeding-insight/model/Trait";
+import {ProgramUpload} from "@/breeding-insight/model/ProgramUpload";
+import {AxiosResponse} from "axios";
+
+enum ImportState {
+  CHOOSE_FILE = "CHOOSE_FILE",
+  FILE_CHOSEN = "FILE_CHOSEN",
+  IMPORTING = "IMPORTING",
+  LOADING = "LOADING",
+  CURATE = "CURATE",
+  IMPORT_ERROR = "IMPORT_ERROR"
+}
+
+enum ImportEvent {
+  FILE_SELECTED = "FILE_SELECTED",
+  IMPORT_STARTED = "IMPORT_STARTED",
+  ABORT_IMPORT = "ABORT_IMPORT",
+  IMPORT_SUCCESS = "IMPORT_SUCCESS",
+  CONFIRMED = "CONFIRMED",
+  IMPORT_ERROR = "IMPORT_ERROR",
+  TABLE_LOADED = "TABLE_LOADED"
+}
+
+enum ImportAction {
+  RESET = "RESET",
+  START = "START",
+  LOADED = "LOADED",
+  CONFIRM = "CONFIRM",
+  ABORT = "ABORT",
+  STOP_LOADING = "STOP_LOADING",
+  DELETE = "DELETE"
+}
+
+@Component({
+  components: {
+    TraitsImportTable,
+    ImportingMessageBox,
+    ConfirmImportMessageBox,
+    FileSelectMessageBox,
+    ImportInfoTemplateMessageBox,
+    WarningModal
+  },
+  computed: {
+    ...mapGetters([
+      'activeProgram'
+    ])
+  }
+})
+export default class ImportTemplate extends ProgramsBase {
+
+  @Prop()
+  private title!: string;
+
+  @Prop({default: true})
+  private showTitle! : boolean;
+
+  @Prop()
+  private abortMsg!: string;
+
+  @Prop()
+  private records!: Array<any>;
+
+  @Prop()
+  private errors!: ValidationError | AxiosResponse | null;
+
+  private file : File | null = null;
+  private import_errors: ValidationError | AxiosResponse | null = null;
+  private activeProgram?: Program;
+  private tableLoaded = false;
+  private numTraits = 0;
+  private showAbortModal = false;
+
+  private yesAbortId: string = "traitsimport-yes-abort";
+
+  private ImportState = ImportState;
+  private ImportEvent = ImportEvent;
+  private ImportAction = ImportAction;
+
+  private state = ImportState.CHOOSE_FILE;
+  private importStateMachine = createMachine({
+        id: 'import',
+        initial: ImportState.CHOOSE_FILE,
+        states: {
+          [ImportState.CHOOSE_FILE]: {
+            entry: ImportAction.RESET,
+            on: {
+              [ImportEvent.FILE_SELECTED]: ImportState.FILE_CHOSEN
+            }
+          },
+          [ImportState.FILE_CHOSEN]: {
+            on: {
+              [ImportEvent.IMPORT_STARTED]: ImportState.IMPORTING
+            }
+          },
+          [ImportState.IMPORTING]: {
+            entry: ImportAction.START,
+            on: {
+              [ImportEvent.ABORT_IMPORT]: {
+                target: ImportState.CHOOSE_FILE,
+                actions: ImportAction.ABORT
+              },
+              [ImportEvent.IMPORT_SUCCESS]: ImportState.LOADING,
+              [ImportEvent.IMPORT_ERROR]: ImportState.IMPORT_ERROR,
+            }
+          },
+          [ImportState.LOADING]: {
+            on: {
+              [ImportEvent.ABORT_IMPORT]: {
+                target: ImportState.CHOOSE_FILE,
+                actions: ImportAction.STOP_LOADING
+              },
+              [ImportEvent.TABLE_LOADED]: {
+                target: ImportState.CURATE,
+                actions: ImportAction.LOADED
+              },
+            }
+          },
+          [ImportState.CURATE]: {
+            on: {
+              [ImportEvent.ABORT_IMPORT]: {
+                target: ImportState.CHOOSE_FILE,
+                actions: ImportAction.DELETE
+              },
+              [ImportEvent.CONFIRMED]: {
+                actions: ImportAction.CONFIRM
+              },
+            }
+          },
+          [ImportState.IMPORT_ERROR]: {
+            on: {
+              [ImportEvent.IMPORT_STARTED]: ImportState.IMPORTING
+            }
+          }
+        }
+      },
+      {
+        actions: {
+          [ImportAction.RESET]: (context, event) => {
+            this.reset();
+          },
+          [ImportAction.START]: (context, event) => {
+            this.upload();
+          },
+          [ImportAction.LOADED]: (context, event) => {
+            this.loaded();
+          },
+          [ImportAction.ABORT]: (context, event) => {
+            this.abort();
+          },
+          [ImportAction.STOP_LOADING]: (context, event) => {
+            this.stopLoading();
+          },
+          [ImportAction.CONFIRM]: (context, event) => {
+            this.confirm();
+          },
+          [ImportAction.DELETE]: (context, event) => {
+            this.delete();
+          }
+        }
+
+      });
+
+  private initialState = this.importStateMachine;
+  private importService = interpret(this.importStateMachine);
+
+  created() {
+    this.importService.subscribe(state => {
+      this.state = ImportState[state.value as keyof typeof ImportState];
+    });
+    this.importService.start();
+  }
+
+  @Watch('file')
+  onFileChanged(value: string, oldValue: string) {
+    if (oldValue === null && value !== null) {
+      this.importService.send(ImportEvent.FILE_SELECTED);
+    }
+  }
+
+  upload() {
+    this.$emit('upload-file', this.file!);
+    //this.$emit()
+    /*
+    TraitUploadService.uploadFile(this.activeProgram!.id!, this.file!).then((response) => {
+      this.numTraits = response.data!.length;
+      this.importService.send(ImportEvent.IMPORT_SUCCESS);
+    }).catch((error: ValidationError | AxiosResponse) => {
+      this.import_errors = error;
+      this.importService.send(ImportEvent.IMPORT_ERROR);
+    });
+     */
+  }
+
+  abort() {
+    // TODO: actually cancel request
+    this.showCancelledNotification();
+  }
+
+  stopLoading() {
+    // upload will still be there but didn't want to wait for it to load
+    this.showCancelledNotification();
+  }
+
+  delete() {
+    // TODO: call DELETE /trait-upload
+    this.showCancelledNotification();
+  }
+
+  showCancelledNotification() {
+    this.$emit('show-info-notification', 'Import cancelled');
+  }
+
+  handleAbortModal() {
+    this.showAbortModal = false;
+    this.importService.send(ImportEvent.ABORT_IMPORT);
+  }
+
+  loaded() {
+    this.tableLoaded = true;
+  }
+
+  async confirm() {
+    /*
+    const name = this.activeProgram && this.activeProgram.name ? this.activeProgram.name : 'the program';
+    try {
+      // fetch uploaded traits
+      const [ upload ] = await TraitUploadService.getTraits(this.activeProgram!.id!) as [ProgramUpload, Metadata];
+      await TraitUploadService.confirmUpload(this.activeProgram!.id!, upload!.id!);
+
+      // show all program traits
+      this.$emit('show-success-notification', `Imported ontology terms have been added to ${name}.`);
+      this.$router.push({
+        name: 'traits-list',
+        params: {
+          programId: this.activeProgram!.id!
+        },
+      });
+    } catch(err) {
+      const note = err.message ? err.message : `Error: Imported ontology terms were not added to ${name}.`;
+      this.$emit('show-error-notification', `${note}`);
+      Vue.$log.error(err);
+    }
+
+     */
+  }
+
+  reset() {
+    this.file = null;
+    this.tableLoaded = false;
+  }
+
+}
+</script>

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -435,11 +435,7 @@ export default class ImportTemplate extends ProgramsBase {
             this.previewData = previewResponse.preview.rows.slice(0, 100);
             this.newObjectCounts = previewResponse.preview.statistics;
             this.importService.send(ImportEvent.IMPORT_SUCCESS);
-          } else {
-            throw 'No import rows found';
           }
-        } else {
-          throw 'No preview response returned';
         }
       }
 

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -42,7 +42,7 @@
             Cancel
           </button>
         </div>
-      </div>              
+      </div>
     </WarningModal>
 
     <template v-if="state === ImportState.CHOOSE_FILE || state === ImportState.FILE_CHOSEN">
@@ -59,19 +59,20 @@
                                  v-on:import="importService.send(ImportEvent.IMPORT_STARTED)"/>
       </div>
     </template>
-    
+
     <template v-if="state === ImportState.IMPORTING || state === ImportState.LOADING">
       <h1 class="title">Importing...</h1>
       <ImportingMessageBox v-bind:file="file" v-on:abort="importService.send(ImportEvent.ABORT_IMPORT)"/>
     </template>
-    
+
     <template v-if="state === ImportState.LOADING || state === ImportState.CURATE">
       <template v-if="tableLoaded">
         <h1 class="title">Confirm New Ontology Term</h1>
-        <ConfirmImportMessageBox v-bind:num-traits="numTraits"
-                                    v-on:abort="showAbortModal = true" 
-                                    v-on:confirm="importService.send(ImportEvent.CONFIRMED)"
-                                    class="mb-4"/>
+        <ConfirmImportMessageBox v-bind:num-records="numTraits"
+                                 v-bind:import-type-name="'Trait'"
+                                 v-on:abort="showAbortModal = true"
+                                 v-on:confirm="importService.send(ImportEvent.CONFIRMED)"
+                                 class="mb-4"/>
       </template>
       <TraitsImportTable v-on:loaded="importService.send(ImportEvent.TABLE_LOADED)"/>
     </template>
@@ -170,7 +171,7 @@ export default class TraitsImport extends ProgramsBase {
   private showAbortModal = false;
 
   private yesAbortId: string = "traitsimport-yes-abort";
-  
+
   private ImportState = ImportState;
   private ImportEvent = ImportEvent;
   private ImportAction = ImportAction;
@@ -182,18 +183,18 @@ export default class TraitsImport extends ProgramsBase {
     states: {
       [ImportState.CHOOSE_FILE]: {
         entry: ImportAction.RESET,
-        on: { 
-          [ImportEvent.FILE_SELECTED]: ImportState.FILE_CHOSEN 
-        } 
+        on: {
+          [ImportEvent.FILE_SELECTED]: ImportState.FILE_CHOSEN
+        }
       },
-      [ImportState.FILE_CHOSEN]: { 
-        on: { 
-          [ImportEvent.IMPORT_STARTED]: ImportState.IMPORTING 
+      [ImportState.FILE_CHOSEN]: {
+        on: {
+          [ImportEvent.IMPORT_STARTED]: ImportState.IMPORTING
         }
       },
       [ImportState.IMPORTING]: {
         entry: ImportAction.START,
-        on: { 
+        on: {
           [ImportEvent.ABORT_IMPORT]: {
             target: ImportState.CHOOSE_FILE,
             actions: ImportAction.ABORT
@@ -315,7 +316,7 @@ export default class TraitsImport extends ProgramsBase {
   }
 
   async confirm() {
-    const name = this.activeProgram && this.activeProgram.name ? this.activeProgram.name : 'the program';  
+    const name = this.activeProgram && this.activeProgram.name ? this.activeProgram.name : 'the program';
     try {
       // fetch uploaded traits
       const [ upload ] = await TraitUploadService.getTraits(this.activeProgram!.id!) as [ProgramUpload, Metadata];

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -78,8 +78,13 @@
     </template>
 
     <template v-if="state === ImportState.IMPORT_ERROR">
-        <h1 class="title">Importing...</h1>
-      <TraitImportTemplateMessageBox class="mb-5"/>
+      <h1 class="title">Importing...</h1>
+      <ImportInfoTemplateMessageBox v-bind:import-type-name="'Ontology'"
+                                    v-bind:template-url="'https://cornell.box.com/shared/static/pdphm5nr8vd6wc60n2cg6bvtndmkg4vr.xls'"
+                                    class="mb-5">
+        <strong>Before You Import...</strong>
+        <br/>Prepare ontology information for import using the provided template.
+      </ImportInfoTemplateMessageBox>
         <div class="box">
           <FileSelectMessageBox v-model="file"
                                 v-bind:fileTypes="'.csv, .xls, .xlsx'"


### PR DESCRIPTION
- Execute ImportControllerIntegrationTest.sql on bidb to create test germplasm mapping
- Based off Trait Import 
  - Uses indeterminate progress bar, could switch to brapi importer progress bar
  - Importer endpoint calls embedded directly in ImportTemplate
    - If want to reuse with trait import could use events and props and mixins but interface would be messier
- Will need some error handling testing / robustness probably in future cards related to this