### PR TITLE
[BI-503] Add a loading indicator for Confirm Traits

### DIFF
--- a/src/components/trait/ConfirmImportMessageBox.vue
+++ b/src/components/trait/ConfirmImportMessageBox.vue
@@ -32,7 +32,13 @@
           <div class="level-right">
             <div class="level-item">
               <div>
-                <button class="button is-success has-text-weight-bold" v-on:click="confirm">Confirm</button>
+                <button
+                    class="button is-success has-text-weight-bold"
+                    v-on:click="confirm"
+                    v-bind:disabled="confirmImportState.saveStarted"
+                    v-bind:class="{'is-loading': confirmImportState.saveStarted}">
+                  Confirm
+                </button>
               </div>
             </div>
             <div class="level-item">
@@ -51,6 +57,7 @@
   import { Component, Prop, Vue } from 'vue-property-decorator'
   import {AlertTriangleIcon} from 'vue-feather-icons'
   import {StringFormatters} from '@/breeding-insight/utils/StringFormatters'
+  import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
 
   @Component({
     components: {
@@ -64,6 +71,9 @@
 
     @Prop()
     importTypeName! : string;
+
+    @Prop()
+    confirmImportState!: DataFormEventBusHandler;
 
     confirm() {
       this.$emit('confirm');

--- a/src/components/trait/ConfirmImportMessageBox.vue
+++ b/src/components/trait/ConfirmImportMessageBox.vue
@@ -77,6 +77,7 @@
 
     confirm() {
       this.$emit('confirm');
+      this.confirmImportState.bus.$emit(DataFormEventBusHandler.SAVE_STARTED_EVENT);
     }
 
     abort() {

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -21,6 +21,7 @@
                     v-bind:system-import-template-name="germplasmImportTemplateName"
                     v-bind:confirm-msg="'Confirm New Germplasm Records'"
                     v-bind:import-type-name="'Germplasm'"
+                    v-bind:confirm-import-state="confirmImportState"
                     v-on="$listeners">
 
       <template v-slot:importInfoTemplateMessageBox>
@@ -40,6 +41,7 @@
       <template v-slot:confirmImportMessageBox="{ statistics, abort, confirm }">
         <ConfirmImportMessageBox v-bind:num-records="getNumNewGermplasmRecords(statistics)"
                                  v-bind:import-type-name="'Germplasm'"
+                                 v-bind:confirm-import-state="confirmImportState"
                                  v-on:abort="abort"
                                  v-on:confirm="confirm"
                                  class="mb-4"/>
@@ -60,6 +62,7 @@ import ProgramsBase from "@/components/program/ProgramsBase.vue";
 import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTemplateMessageBox.vue";
 import ConfirmImportMessageBox from "@/components/trait/ConfirmImportMessageBox.vue";
 import ImportTemplate from "@/views/import/ImportTemplate.vue";
+import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
 
 @Component({
   components: {ImportInfoTemplateMessageBox, ConfirmImportMessageBox, ImportTemplate
@@ -69,6 +72,8 @@ export default class ImportGermplasm extends ProgramsBase {
 
   // TODO: maybe move to config instead of hardcode?
   private germplasmImportTemplateName = 'GermplasmTest';
+
+  private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
 
   getNumNewGermplasmRecords(statistics: any): number | undefined {
     if (statistics.Germplasm) {

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -356,7 +356,6 @@ export default class ImportTemplate extends ProgramsBase {
   }
 
   async confirm() {
-    this.confirmImportState.bus.$emit(DataFormEventBusHandler.SAVE_STARTED_EVENT);
     const name = this.activeProgram && this.activeProgram.name ? this.activeProgram.name : 'the program';
     try {
       await this.updateDataUpload(this.currentImport!.importId!, true);

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -325,7 +325,6 @@ export default class TraitsImport extends ProgramsBase {
   }
 
   async confirm() {
-    this.confirmImportState.bus.$emit(DataFormEventBusHandler.SAVE_STARTED_EVENT);
     const name = this.activeProgram && this.activeProgram.name ? this.activeProgram.name : 'the program';
     try {
       // fetch uploaded traits

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -70,6 +70,7 @@
         <h1 class="title">Confirm New Ontology Term</h1>
         <ConfirmImportMessageBox v-bind:num-records="numTraits"
                                  v-bind:import-type-name="'Trait'"
+                                 v-bind:confirm-import-state="confirmImportState"
                                  v-on:abort="showAbortModal = true"
                                  v-on:confirm="importService.send(ImportEvent.CONFIRMED)"
                                  class="mb-4"/>
@@ -118,6 +119,7 @@ import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {Trait} from "@/breeding-insight/model/Trait";
 import {ProgramUpload} from "@/breeding-insight/model/ProgramUpload";
 import {AxiosResponse} from "axios";
+import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
 
 enum ImportState {
   CHOOSE_FILE = "CHOOSE_FILE",
@@ -176,6 +178,8 @@ export default class TraitsImport extends ProgramsBase {
   private showAbortModal = false;
 
   private yesAbortId: string = "traitsimport-yes-abort";
+
+  private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
 
   private ImportState = ImportState;
   private ImportEvent = ImportEvent;
@@ -321,6 +325,7 @@ export default class TraitsImport extends ProgramsBase {
   }
 
   async confirm() {
+    this.confirmImportState.bus.$emit(DataFormEventBusHandler.SAVE_STARTED_EVENT);
     const name = this.activeProgram && this.activeProgram.name ? this.activeProgram.name : 'the program';
     try {
       // fetch uploaded traits
@@ -339,6 +344,8 @@ export default class TraitsImport extends ProgramsBase {
       const note = err.message ? err.message : `Error: Imported ontology terms were not added to ${name}.`;
       this.$emit('show-error-notification', `${note}`);
       Vue.$log.error(err);
+    } finally {
+      this.confirmImportState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT);
     }
   }
 


### PR DESCRIPTION
- For both Germplasm and Trait Import, on clicking the "Confirm" button, the button will be disabled and a loading indicator will appear.
- (Changes were applied to Germplasm Import because both Traits and Germplasm Import use the  ConfirmImportMessageBox.vue component with the aforementioned "Confirm" button)