### PR TITLE
[BI-623] Update UI OntologyTables implementation to handle sort events

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -614,8 +614,8 @@ div.new-term p.help {
   cursor: pointer;
 }
 
-.activesort {
-  text-decoration: underline;
+th.activesort.sortcolumn {
+  border-bottom: 2px solid;
 }
 
 .ascending, .descending {

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -611,7 +611,7 @@ div.new-term p.help {
   cursor: pointer;
 }
 
-th.activesort.sortcolumn {
+th.activesort.sortcolumn, th.sortcolumn:hover {
   border-bottom: 2px solid;
 }
 

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -21,9 +21,6 @@
 @import url('https://fonts.googleapis.com/css?family=Fira+Sans:400,600,700');
 @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600');
 
-// Import Font Awesome
-@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css');
-
 // Override Bulma default colors
 $red: #E20057;
 $yellow: #FFCC21;

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -21,6 +21,9 @@
 @import url('https://fonts.googleapis.com/css?family=Fira+Sans:400,600,700');
 @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600');
 
+// Import Font Awesome
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css');
+
 // Override Bulma default colors
 $red: #E20057;
 $yellow: #FFCC21;
@@ -605,4 +608,20 @@ div.new-term div.taginput-container.is-focusable {
 div.new-term p.help {
   padding: 0;
   margin: 0;
+}
+
+.sortcolumn, .activesort {
+  cursor: pointer;
+}
+
+.activesort {
+  text-decoration: underline;
+}
+
+.ascending, .descending {
+  transition: transform 0.3s ease;
+}
+
+.descending {
+  transform: rotate(180deg);
 }

--- a/src/breeding-insight/dao/ProgramDAO.ts
+++ b/src/breeding-insight/dao/ProgramDAO.ts
@@ -19,6 +19,7 @@ import {Program} from "@/breeding-insight/model/Program";
 import {BiResponse, Response} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {ProgramSort} from "@/breeding-insight/model/Sort";
 
 
 export class ProgramDAO {
@@ -59,17 +60,24 @@ export class ProgramDAO {
     return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/archive/${id}`, method: 'delete'});
   }
 
-  static getAll(paginationQuery: PaginationQuery): Promise<BiResponse> {
+  static getAll(paginationQuery: PaginationQuery, {field, order}: ProgramSort): Promise<BiResponse> {
 
     return new Promise<BiResponse>(((resolve, reject) => {
-
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`, method: 'get'})
-        .then((response: any) => {
-          const biResponse = new BiResponse(response.data);
-          resolve(biResponse);
-        }).catch((error) => {
-          reject(error);
-        })
+      const config = {
+        url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs`,
+        method: 'get',
+        params: {
+          sortField: field,
+          sortOrder: order
+        }
+      }
+      api.call(config)
+          .then((response: any) => {
+            const biResponse = new BiResponse(response.data);
+            resolve(biResponse);
+          }).catch((error) => {
+        reject(error);
+      })
 
     }))
   }

--- a/src/breeding-insight/dao/ProgramLocationDAO.ts
+++ b/src/breeding-insight/dao/ProgramLocationDAO.ts
@@ -19,6 +19,7 @@ import {ProgramLocation} from "@/breeding-insight/model/ProgramLocation";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {LocationSort} from "@/breeding-insight/model/Sort";
 
 export class ProgramLocationDAO {
 
@@ -58,11 +59,18 @@ export class ProgramLocationDAO {
     return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations/${locationId}`, method: 'delete'});
   }
 
-  static getAll(programId: string, paginationQuery: PaginationQuery): Promise<BiResponse> {
+  static getAll(programId: string, paginationQuery: PaginationQuery, {field, order}: LocationSort): Promise<BiResponse> {
 
     return new Promise<BiResponse>(((resolve, reject) => {
-
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations`, method: 'get' })
+      const config: any = {
+        url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/locations`,
+        method: 'get',
+        params: {
+          sortField: field,
+          sortOrder: order
+        }
+      };
+      api.call(config)
         .then((response: any) => {
           const biResponse = new BiResponse(response.data);
           resolve(biResponse);

--- a/src/breeding-insight/dao/ProgramUserDAO.ts
+++ b/src/breeding-insight/dao/ProgramUserDAO.ts
@@ -19,7 +19,7 @@ import {ProgramUser} from "@/breeding-insight/model/ProgramUser";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
-import {SortField} from "@/breeding-insight/model/SortField";
+import {UserSort} from "@/breeding-insight/model/Sort";
 
 export class ProgramUserDAO {
 
@@ -71,24 +71,25 @@ export class ProgramUserDAO {
     return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users/${userId}`, method: 'delete'});
   }
 
-  static getAll(programId: string, paginationQuery: PaginationQuery, sortField: SortField | undefined): Promise<BiResponse> {
-
+  static getAll(programId: string, {page, pageSize}: PaginationQuery, {field, order}: UserSort): Promise<BiResponse> {
     return new Promise<BiResponse>(((resolve, reject) => {
-
-      let params = {
-        sortField: sortField ? sortField.sortField : undefined,
-        sortOrder: sortField ? sortField.sortOrder : undefined,
-        page: paginationQuery.page,
-        pageSize: paginationQuery.pageSize
-      };
-
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users`, method: 'get', params: params })
-        .then((response: any) => {
-          const biResponse = new BiResponse(response.data);
-          resolve(biResponse);
-        }).catch((error) => {
-          reject(error);
-        })
+      const config = {
+        url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/users`,
+        method: 'get',
+        params: {
+          sortField: field,
+          sortOrder: order,
+          page,
+          pageSize
+        }
+      }
+      api.call(config)
+          .then((response: any) => {
+            const biResponse = new BiResponse(response.data);
+            resolve(biResponse);
+          }).catch((error) => {
+        reject(error);
+      })
 
     }))
   }

--- a/src/breeding-insight/dao/TraitDAO.ts
+++ b/src/breeding-insight/dao/TraitDAO.ts
@@ -20,9 +20,10 @@ import {BiResponse, Response} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {TraitFilter, TraitSelector} from "@/breeding-insight/model/TraitSelector";
-import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
+import {OntologySort, SortOrder} from "@/breeding-insight/model/Sort";
 
 export class TraitDAO {
+    private activeOntologySortOrder!: SortOrder;
 
     static getAll(programId: string, paginationQuery: PaginationQuery, full: boolean): Promise<BiResponse> {
         const config: any = {};
@@ -38,13 +39,21 @@ export class TraitDAO {
                 }).catch((error) => {
                 reject(error);
             })
-
         }))
     }
 
-    static getFilteredTraits(programId: string, paginationQuery: PaginationQuery, full: boolean, sortField: TraitSortField, sortOrder: SortOrder, filters?: TraitFilter[]): Promise<BiResponse> {
-        const config: any = {};
-        config.params = {full, sortField, sortOrder};
+    static getFilteredTraits(programId: string,
+                             paginationQuery: PaginationQuery,
+                             full: boolean,
+                             sort: OntologySort,
+                             filters?: TraitFilter[]): Promise<BiResponse> {
+        const config: any = {
+            params: {
+                full,
+                sortField: sort.field,
+                sortOrder: sort.flag ? SortOrder.Ascending : SortOrder.Descending
+            }
+        };
 
         if (filters) {
             //

--- a/src/breeding-insight/dao/TraitDAO.ts
+++ b/src/breeding-insight/dao/TraitDAO.ts
@@ -42,7 +42,7 @@ export class TraitDAO {
         }))
     }
 
-    static getFilteredTraits(programId: string, paginationQuery: PaginationQuery, full: boolean, filters?: TraitFilter[], sortField: TraitSortField, sortOrder: SortOrder): Promise<BiResponse> {
+    static getFilteredTraits(programId: string, paginationQuery: PaginationQuery, full: boolean, sortField: TraitSortField, sortOrder: SortOrder, filters?: TraitFilter[]): Promise<BiResponse> {
         const config: any = {};
         config.params = {full, sortField, sortOrder};
 

--- a/src/breeding-insight/dao/TraitDAO.ts
+++ b/src/breeding-insight/dao/TraitDAO.ts
@@ -20,6 +20,7 @@ import {BiResponse, Response} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {TraitFilter, TraitSelector} from "@/breeding-insight/model/TraitSelector";
+import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
 
 export class TraitDAO {
 
@@ -41,9 +42,9 @@ export class TraitDAO {
         }))
     }
 
-    static getFilteredTraits(programId: string, paginationQuery: PaginationQuery, full: boolean, filters?: TraitFilter[]): Promise<BiResponse> {
+    static getFilteredTraits(programId: string, paginationQuery: PaginationQuery, full: boolean, filters?: TraitFilter[], sortField: TraitSortField, sortOrder: SortOrder): Promise<BiResponse> {
         const config: any = {};
-        config.params = {full};
+        config.params = {full, sortField, sortOrder};
 
         if (filters) {
             //

--- a/src/breeding-insight/dao/TraitDAO.ts
+++ b/src/breeding-insight/dao/TraitDAO.ts
@@ -51,7 +51,7 @@ export class TraitDAO {
             params: {
                 full,
                 sortField: sort.field,
-                sortOrder: sort.flag ? SortOrder.Ascending : SortOrder.Descending
+                sortOrder: sort.order
             }
         };
 

--- a/src/breeding-insight/dao/TraitUploadDAO.ts
+++ b/src/breeding-insight/dao/TraitUploadDAO.ts
@@ -18,6 +18,7 @@
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {OntologySort, SortOrder} from "@/breeding-insight/model/Sort";
 
 export class TraitUploadDAO {
 
@@ -46,17 +47,26 @@ export class TraitUploadDAO {
     });
   }
 
-  static getTraitUpload(programId: string, paginationQuery: PaginationQuery): Promise<BiResponse> {
+  static getTraitUpload(programId: string,
+                        paginationQuery: PaginationQuery,
+                        sort: OntologySort): Promise<BiResponse> {
 
     return new Promise<BiResponse>(((resolve, reject) => {
-
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/trait-upload`, method: 'get' })
-        .then((response: any) => {
-          const biResponse = new BiResponse(response.data);
-          resolve(biResponse);
-        }).catch((error) => {
-          reject(error);
-        })
+      const config: any = {
+        url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/trait-upload`,
+        method: 'get',
+        params: {
+          sortField: sort.field,
+          sortOrder: sort.flag ? SortOrder.Ascending : SortOrder.Descending
+        }
+      };
+      api.call(config)
+          .then((response: any) => {
+            const biResponse = new BiResponse(response.data);
+            resolve(biResponse);
+          }).catch((error) => {
+        reject(error);
+      })
 
     }))
   }

--- a/src/breeding-insight/dao/TraitUploadDAO.ts
+++ b/src/breeding-insight/dao/TraitUploadDAO.ts
@@ -57,7 +57,7 @@ export class TraitUploadDAO {
         method: 'get',
         params: {
           sortField: sort.field,
-          sortOrder: sort.flag ? SortOrder.Ascending : SortOrder.Descending
+          sortOrder: sort.order
         }
       };
       api.call(config)

--- a/src/breeding-insight/dao/UserDAO.ts
+++ b/src/breeding-insight/dao/UserDAO.ts
@@ -20,6 +20,7 @@ import * as api from "@/util/api";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import {Role} from "@/breeding-insight/model/Role";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {UserSort} from "@/breeding-insight/model/Sort";
 
 export class UserDAO {
 
@@ -73,17 +74,26 @@ export class UserDAO {
     return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users/${id}`, method: 'delete'});
   }
 
-  static getAll(paginationQuery: PaginationQuery): Promise<BiResponse> {
+  static getAll(paginationQuery: PaginationQuery, {field, order}: UserSort):
+
+      Promise<BiResponse> {
 
     return new Promise<BiResponse>(((resolve, reject) => {
-
-      api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/users`, method: 'get'})
-        .then((response: any) => {
-          const biResponse = new BiResponse(response.data);
-          resolve(biResponse);
-        }).catch((error) => {
-          reject(error);
-        })
+      const config = {
+        url: `${process.env.VUE_APP_BI_API_V1_PATH}/users`,
+        method: 'get',
+        params: {
+          sortField: field,
+          sortOrder: order
+        }
+      }
+      api.call(config)
+          .then((response: any) => {
+            const biResponse = new BiResponse(response.data);
+            resolve(biResponse);
+          }).catch((error) => {
+        reject(error);
+      })
 
     }))
 

--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -51,11 +51,11 @@ export enum OntologySortField {
 
 export class OntologySort {
   field: OntologySortField;
-  flag: boolean;
+  order: SortOrder;
 
-  constructor(field: OntologySortField, flag: boolean) {
+  constructor(field: OntologySortField, order: SortOrder) {
     this.field = field;
-    this.flag = flag;
+    this.order = order;
   }
 }
 

--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -1,0 +1,28 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum SortOrder {
+  Ascending = 'ASC',
+  Descending = 'DESC'
+}
+
+export enum TraitSortField {
+  Name = 'name',
+  MethodDescription = 'methodDescription',
+  ScaleClass = 'scaleClass',
+  ScaleName = 'scaleName'
+}

--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -26,3 +26,79 @@ export enum TraitSortField {
   ScaleClass = 'scaleClass',
   ScaleName = 'scaleName'
 }
+
+// ontology
+export enum OntologySortField {
+  Name = 'name',
+  MethodDescription = 'methodDescription',
+  ScaleClass = 'scaleClass',
+  ScaleName = 'scaleName'
+}
+
+export class OntologySort {
+  field: OntologySortField;
+  order: SortOrder;
+
+  constructor(field: OntologySortField, order: SortOrder) {
+    this.field = field;
+    this.order = order;
+  }
+}
+
+// location
+export enum LocationSortField {
+  Name = 'name',
+  Abbreviation = 'abbreviation',
+  Slope = 'slope'
+}
+
+export class LocationSort {
+  field: LocationSortField;
+  order: SortOrder;
+
+  constructor(field: LocationSortField, order: SortOrder) {
+    this.field = field;
+    this.order = order;
+  }
+}
+
+// user
+export enum UserSortField {
+  Name = 'name',
+  Email = 'email',
+  Roles = 'roles',
+  Active = 'active'
+}
+
+export class UserSort {
+  field: UserSortField;
+  order: SortOrder;
+
+  constructor(field: UserSortField, order: SortOrder) {
+    this.field = field;
+    this.order = order;
+  }
+}
+
+// program
+export enum ProgramSortField {
+  Name = 'name',
+  Abbreviation = 'abbreviation',
+  Objective = 'objective',
+  DocumentationUrl = 'documentationUrl',
+  Active = 'active',
+  BrapiUrl = 'brapiUrl',
+  NumUsers = 'numUsers',
+  SpeciesId = 'speciesId',
+  SpeciesName = 'speciesName'
+}
+
+export class ProgramSort {
+  field: ProgramSortField;
+  order: SortOrder;
+
+  constructor(field: ProgramSortField, order: SortOrder) {
+    this.field = field;
+    this.order = order;
+  }
+}

--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -51,11 +51,11 @@ export enum OntologySortField {
 
 export class OntologySort {
   field: OntologySortField;
-  order: SortOrder;
+  flag: boolean;
 
-  constructor(field: OntologySortField, order: SortOrder) {
+  constructor(field: OntologySortField, flag: boolean) {
     this.field = field;
-    this.order = order;
+    this.flag = flag;
   }
 }
 

--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -20,6 +20,20 @@ export enum SortOrder {
   Descending = 'DESC'
 }
 
+export class Sort {
+  static orderMap: any = {
+    'asc': SortOrder.Ascending,
+    'desc': SortOrder.Descending
+  };
+
+  static orderAsBI(order: string) {
+    if (order in this.orderMap) {
+      return this.orderMap[order];
+    }
+    return SortOrder.Ascending;
+  }
+}
+
 export enum TraitSortField {
   Name = 'name',
   MethodDescription = 'methodDescription',

--- a/src/breeding-insight/service/ProgramLocationService.ts
+++ b/src/breeding-insight/service/ProgramLocationService.ts
@@ -113,9 +113,6 @@ export class ProgramLocationService {
       if (programId) {
         ProgramLocationDAO.getAll(programId, paginationQuery, sort).then((biResponse) => {
 
-          //TODO: Remove when backend sorts the data by default
-          //biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
-
           let programLocations: ProgramLocation[] = [];
 
           programLocations = biResponse.result.data.map((programLocation: any) => {

--- a/src/breeding-insight/service/ProgramLocationService.ts
+++ b/src/breeding-insight/service/ProgramLocationService.ts
@@ -105,14 +105,10 @@ export class ProgramLocationService {
     }));
   }
 
-  static getAll(programId: string, paginationQuery?: PaginationQuery, sort?: LocationSort): Promise<[ProgramLocation[], Metadata]> {
+  static getAll(programId: string,
+                paginationQuery: PaginationQuery = new PaginationQuery(0, 0, true),
+                sort: LocationSort = new LocationSort(LocationSortField.Name, SortOrder.Ascending)): Promise<[ProgramLocation[], Metadata]> {
     return new Promise<[ProgramLocation[], Metadata]>(((resolve, reject) => {
-
-      if (paginationQuery === undefined){
-        paginationQuery = new PaginationQuery(0, 0, true);
-      }
-
-      if (sort === undefined) sort = new LocationSort(LocationSortField.Name, SortOrder.Ascending);
 
       if (programId) {
         ProgramLocationDAO.getAll(programId, paginationQuery, sort).then((biResponse) => {

--- a/src/breeding-insight/service/ProgramLocationService.ts
+++ b/src/breeding-insight/service/ProgramLocationService.ts
@@ -20,6 +20,7 @@ import {ProgramLocation} from "@/breeding-insight/model/ProgramLocation";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
+import {LocationSort, LocationSortField, SortOrder} from "@/breeding-insight/model/Sort";
 
 export class ProgramLocationService {
 
@@ -104,18 +105,20 @@ export class ProgramLocationService {
     }));
   }
 
-  static getAll(programId: string, paginationQuery?: PaginationQuery): Promise<[ProgramLocation[], Metadata]> {
+  static getAll(programId: string, paginationQuery?: PaginationQuery, sort?: LocationSort): Promise<[ProgramLocation[], Metadata]> {
     return new Promise<[ProgramLocation[], Metadata]>(((resolve, reject) => {
 
       if (paginationQuery === undefined){
         paginationQuery = new PaginationQuery(0, 0, true);
       }
 
+      if (sort === undefined) sort = new LocationSort(LocationSortField.Name, SortOrder.Ascending);
+
       if (programId) {
-        ProgramLocationDAO.getAll(programId, paginationQuery).then((biResponse) => {
+        ProgramLocationDAO.getAll(programId, paginationQuery, sort).then((biResponse) => {
 
           //TODO: Remove when backend sorts the data by default
-          biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
+          //biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
 
           let programLocations: ProgramLocation[] = [];
 

--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -17,10 +17,11 @@
 
 import {ProgramDAO} from "@/breeding-insight/dao/ProgramDAO";
 import {Program} from "@/breeding-insight/model/Program";
-import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {ProgramObservationLevel} from "@/breeding-insight/model/ProgramObservationLevel";
+import {ProgramSort, ProgramSortField, SortOrder} from "@/breeding-insight/model/Sort";
 
 export class ProgramService {
 
@@ -90,17 +91,12 @@ export class ProgramService {
     }));
   }
 
-  static getAll(paginationQuery?: PaginationQuery): Promise<[Program[], Metadata]> {
+  static getAll(paginationQuery: PaginationQuery = new PaginationQuery(0, 0, true),
+                sort: ProgramSort = new ProgramSort(ProgramSortField.Name, SortOrder.Ascending)): Promise<[Program[], Metadata]> {
     return new Promise<[Program[], Metadata]>(((resolve, reject) => {
 
-      if (paginationQuery === undefined){
-        paginationQuery = new PaginationQuery(0, 0, true);
-      }
-      ProgramDAO.getAll(paginationQuery).then((biResponse) => {
-
-        //TODO: Remove when backend sorts the data by default
-        biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
-
+      ProgramDAO.getAll(paginationQuery, sort).then((biResponse) => {
+        
         let programs: Program[] = [];
 
         // Parse our programs into the vue programs param

--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -96,7 +96,7 @@ export class ProgramService {
     return new Promise<[Program[], Metadata]>(((resolve, reject) => {
 
       ProgramDAO.getAll(paginationQuery, sort).then((biResponse) => {
-        
+
         let programs: Program[] = [];
 
         // Parse our programs into the vue programs param

--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -21,9 +21,7 @@ import {Program} from "@/breeding-insight/model/Program";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
-import {User} from "@/breeding-insight/model/User";
-import {UserService} from "@/breeding-insight/service/UserService";
-import {SortField} from "@/breeding-insight/model/SortField";
+import {SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
 export class ProgramUserService {
 
@@ -107,15 +105,17 @@ export class ProgramUserService {
     }));
   }
 
-  static getAll(programId: string, paginationQuery?: PaginationQuery, sortField?: SortField): Promise<[ProgramUser[], Metadata]> {
+  static getAll(programId: string, paginationQuery?: PaginationQuery, sort?: UserSort): Promise<[ProgramUser[], Metadata]> {
     return new Promise<[ProgramUser[], Metadata]>(((resolve, reject) => {
 
       if (paginationQuery === undefined){
         paginationQuery = new PaginationQuery(0, 0, true);
       }
 
+      if (sort === undefined) sort = new UserSort(UserSortField.Name, SortOrder.Ascending);
+
       if (programId) {
-        ProgramUserDAO.getAll(programId, paginationQuery, sortField).then((biResponse) => {
+        ProgramUserDAO.getAll(programId, paginationQuery, sort).then((biResponse) => {
 
           let programUsers: ProgramUser[] = [];
 

--- a/src/breeding-insight/service/ProgramUserService.ts
+++ b/src/breeding-insight/service/ProgramUserService.ts
@@ -105,14 +105,10 @@ export class ProgramUserService {
     }));
   }
 
-  static getAll(programId: string, paginationQuery?: PaginationQuery, sort?: UserSort): Promise<[ProgramUser[], Metadata]> {
+  static getAll(programId: string,
+                paginationQuery: PaginationQuery = new PaginationQuery(0, 0, true),
+                sort: UserSort = new UserSort(UserSortField.Name, SortOrder.Ascending)): Promise<[ProgramUser[], Metadata]> {
     return new Promise<[ProgramUser[], Metadata]>(((resolve, reject) => {
-
-      if (paginationQuery === undefined){
-        paginationQuery = new PaginationQuery(0, 0, true);
-      }
-
-      if (sort === undefined) sort = new UserSort(UserSortField.Name, SortOrder.Ascending);
 
       if (programId) {
         ProgramUserDAO.getAll(programId, paginationQuery, sort).then((biResponse) => {

--- a/src/breeding-insight/service/TraitService.ts
+++ b/src/breeding-insight/service/TraitService.ts
@@ -124,7 +124,7 @@ export class TraitService {
                            paginationQuery: PaginationQuery = new PaginationQuery(0, 0, true),
                            full: boolean = false,
                            filters?: TraitFilter[],
-                           sort: OntologySort = new OntologySort(OntologySortField.Name, true)): Promise<[Trait[], Metadata]> {
+                           sort: OntologySort = new OntologySort(OntologySortField.Name, SortOrder.Ascending)): Promise<[Trait[], Metadata]> {
     return new Promise<[Trait[], Metadata]>(((resolve, reject) => {
 
       if (programId) {

--- a/src/breeding-insight/service/TraitService.ts
+++ b/src/breeding-insight/service/TraitService.ts
@@ -134,7 +134,7 @@ export class TraitService {
       }
 
       if (programId) {
-        TraitDAO.getFilteredTraits(programId, paginationQuery, full, filters, sortField, sortOrder).then((biResponse) => {
+        TraitDAO.getFilteredTraits(programId, paginationQuery, full, sortField, sortOrder, filters).then((biResponse) => {
 
           let traits: Trait[] = [];
 

--- a/src/breeding-insight/service/TraitService.ts
+++ b/src/breeding-insight/service/TraitService.ts
@@ -17,12 +17,12 @@
 
 import {TraitDAO} from "@/breeding-insight/dao/TraitDAO";
 import {Trait} from "@/breeding-insight/model/Trait";
-import {BiResponse, Metadata} from "@/breeding-insight/model/BiResponse";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {TraitUploadService} from "@/breeding-insight/service/TraitUploadService";
-import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 import {TraitFilter} from "@/breeding-insight/model/TraitSelector";
+import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
 
 export class TraitService {
 
@@ -93,7 +93,7 @@ export class TraitService {
       }
 
       if (programId) {
-        TraitDAO.getAll(programId, paginationQuery, full).then((biResponse) => {
+        TraitDAO.getAll(programId, paginationQuery, full).then(biResponse => {
 
           let traits: Trait[] = [];
 
@@ -120,19 +120,21 @@ export class TraitService {
     }));
   }
 
-  static getFilteredTraits(programId: string, paginationQuery?: PaginationQuery, full?: boolean, filters?: TraitFilter[]): Promise<[Trait[], Metadata]> {
+  static getFilteredTraits(programId: string, paginationQuery?: PaginationQuery, full?: boolean, filters?: TraitFilter[], sortField?: TraitSortField, sortOrder?: SortOrder): Promise<[Trait[], Metadata]> {
     return new Promise<[Trait[], Metadata]>(((resolve, reject) => {
 
       if (paginationQuery === undefined) {
         paginationQuery = new PaginationQuery(0, 0, true);
       }
 
+      if (sortField === undefined) sortField = TraitSortField.Name;
+      if (sortOrder === undefined) sortOrder = SortOrder.Ascending;
       if (full === undefined) {
         full = false;
       }
 
       if (programId) {
-        TraitDAO.getFilteredTraits(programId, paginationQuery, full, filters).then((biResponse) => {
+        TraitDAO.getFilteredTraits(programId, paginationQuery, full, filters, sortField, sortOrder).then((biResponse) => {
 
           let traits: Trait[] = [];
 

--- a/src/breeding-insight/service/TraitService.ts
+++ b/src/breeding-insight/service/TraitService.ts
@@ -22,7 +22,7 @@ import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {TraitUploadService} from "@/breeding-insight/service/TraitUploadService";
 import {TraitFilter} from "@/breeding-insight/model/TraitSelector";
-import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
+import {OntologySort, OntologySortField, SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
 
 export class TraitService {
 
@@ -120,21 +120,15 @@ export class TraitService {
     }));
   }
 
-  static getFilteredTraits(programId: string, paginationQuery?: PaginationQuery, full?: boolean, filters?: TraitFilter[], sortField?: TraitSortField, sortOrder?: SortOrder): Promise<[Trait[], Metadata]> {
+  static getFilteredTraits(programId: string,
+                           paginationQuery: PaginationQuery = new PaginationQuery(0, 0, true),
+                           full: boolean = false,
+                           filters?: TraitFilter[],
+                           sort: OntologySort = new OntologySort(OntologySortField.Name, true)): Promise<[Trait[], Metadata]> {
     return new Promise<[Trait[], Metadata]>(((resolve, reject) => {
 
-      if (paginationQuery === undefined) {
-        paginationQuery = new PaginationQuery(0, 0, true);
-      }
-
-      if (sortField === undefined) sortField = TraitSortField.Name;
-      if (sortOrder === undefined) sortOrder = SortOrder.Ascending;
-      if (full === undefined) {
-        full = false;
-      }
-
       if (programId) {
-        TraitDAO.getFilteredTraits(programId, paginationQuery, full, sortField, sortOrder, filters).then((biResponse) => {
+        TraitDAO.getFilteredTraits(programId, paginationQuery, full, sort, filters).then((biResponse) => {
 
           let traits: Trait[] = [];
 

--- a/src/breeding-insight/service/TraitService.ts
+++ b/src/breeding-insight/service/TraitService.ts
@@ -140,7 +140,6 @@ export class TraitService {
 
           if (biResponse.result.data) {
             //TODO: Remove when backend default sorting is implemented
-            biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
             traits = biResponse.result.data.map((trait: any) => {
               return trait as Trait;
             });

--- a/src/breeding-insight/service/TraitService.ts
+++ b/src/breeding-insight/service/TraitService.ts
@@ -133,7 +133,6 @@ export class TraitService {
           let traits: Trait[] = [];
 
           if (biResponse.result.data) {
-            //TODO: Remove when backend default sorting is implemented
             traits = biResponse.result.data.map((trait: any) => {
               return trait as Trait;
             });

--- a/src/breeding-insight/service/TraitUploadService.ts
+++ b/src/breeding-insight/service/TraitUploadService.ts
@@ -22,7 +22,7 @@ import {Trait} from "@/breeding-insight/model/Trait";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
-import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
+import {OntologySort, OntologySortField, SortOrder} from "@/breeding-insight/model/Sort";
 
 export class TraitUploadService {
 
@@ -76,7 +76,7 @@ export class TraitUploadService {
 
   static getTraits(programId: string,
                    paginationQuery: PaginationQuery = new PaginationQuery(0,0,true),
-                   sort: OntologySort = new OntologySort(OntologySortField.Name, true)): Promise<[ProgramUpload, Metadata]> {
+                   sort: OntologySort = new OntologySort(OntologySortField.Name, SortOrder.Ascending)): Promise<[ProgramUpload, Metadata]> {
     return new Promise<[ProgramUpload, Metadata]>(((resolve, reject) => {
 
       if (programId) {

--- a/src/breeding-insight/service/TraitUploadService.ts
+++ b/src/breeding-insight/service/TraitUploadService.ts
@@ -16,13 +16,13 @@
  */
 
 import {ProgramUpload} from "@/breeding-insight/model/ProgramUpload";
-import { TraitUploadDAO } from '@/breeding-insight/dao/TraitUploadDAO';
+import {TraitUploadDAO} from '@/breeding-insight/dao/TraitUploadDAO';
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {Trait} from "@/breeding-insight/model/Trait";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
-import {ProgramDAO} from "@/breeding-insight/dao/ProgramDAO";
+import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
 
 export class TraitUploadService {
 
@@ -74,18 +74,14 @@ export class TraitUploadService {
     });
   }
 
-  static getTraits(programId: string, paginationQuery?: PaginationQuery): Promise<[ProgramUpload, Metadata]> {
+  static getTraits(programId: string,
+                   paginationQuery: PaginationQuery = new PaginationQuery(0,0,true),
+                   sort: OntologySort = new OntologySort(OntologySortField.Name, true)): Promise<[ProgramUpload, Metadata]> {
     return new Promise<[ProgramUpload, Metadata]>(((resolve, reject) => {
 
-      if (paginationQuery === undefined){
-        paginationQuery = new PaginationQuery(0, 0, true);
-      }
-
       if (programId) {
-        TraitUploadDAO.getTraitUpload(programId, paginationQuery).then((biResponse) => {
+        TraitUploadDAO.getTraitUpload(programId, paginationQuery, sort).then((biResponse) => {
 
-          //TODO: Remove when backend sorts the data by default
-          biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
           let traits: Trait[] = [];
 
           traits = biResponse.result.data.map((trait: any) => {

--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -24,6 +24,7 @@ import {Program} from "@/breeding-insight/model/Program";
 import {ProgramUser} from "@/breeding-insight/model/ProgramUser";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
+import {ProgramSort, SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
 export class UserService {
 
@@ -130,14 +131,11 @@ export class UserService {
     }))
   }
 
-  static getAll(paginationQuery?: PaginationQuery): Promise<[User[], Metadata]> {
+  static getAll(paginationQuery: PaginationQuery = new PaginationQuery(0, 0, true),
+                sort: UserSort = new UserSort(UserSortField.Name, SortOrder.Ascending)): Promise<[User[], Metadata]> {
     return new Promise<[User[], Metadata]>(((resolve, reject) => {
 
-      if (paginationQuery === undefined){
-        paginationQuery = new PaginationQuery(0, 0, true);
-      }
-
-      UserDAO.getAll(paginationQuery).then((biResponse) => {
+      UserDAO.getAll(paginationQuery, sort).then((biResponse) => {
 
         biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
         // Parse our users into the vue users param

--- a/src/components/admin/AdminProgramsTable.vue
+++ b/src/components/admin/AdminProgramsTable.vue
@@ -205,7 +205,7 @@
     DEACTIVATE_ALL_NOTIFICATIONS,
   } from "@/store/mutation-types";
   import {UPDATE_PROGRAM_SORT} from "@/store/sorting/mutation-types";
-  import {ProgramSort, ProgramSortField, SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+  import {ProgramSort, ProgramSortField, Sort, SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
   // create custom validation to handle cases default url validation doesn't
   const url = helpers.withParams(
@@ -301,13 +301,12 @@ export default class AdminProgramsTable extends Vue {
       'data.numUsers': ProgramSortField.NumUsers,
       'data.brapiUrl': ProgramSortField.BrapiUrl
     };
-    const orderMap: any = {'asc': SortOrder.Ascending, 'desc': SortOrder.Descending};
-    if (field in fieldMap && order in orderMap) {
-      this.updateSort(new ProgramSort(fieldMap[field], orderMap[order]));
+
+    if (field in fieldMap) {
+      this.updateSort(new ProgramSort(fieldMap[field], Sort.orderAsBI(order)));
       this.getPrograms();
     }
   }
-
 
   @Watch('paginationController', { deep: true})
   getPrograms() {

--- a/src/components/admin/AdminProgramsTable.vue
+++ b/src/components/admin/AdminProgramsTable.vue
@@ -303,7 +303,7 @@ export default class AdminProgramsTable extends Vue {
     };
     const orderMap: any = {'asc': SortOrder.Ascending, 'desc': SortOrder.Descending};
     if (field in fieldMap && order in orderMap) {
-      this.updateSort(new UserSort(fieldMap[field], orderMap[order]));
+      this.updateSort(new ProgramSort(fieldMap[field], orderMap[order]));
       this.getPrograms();
     }
   }

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -263,7 +263,7 @@
     DEACTIVATE_ALL_NOTIFICATIONS
   } from "@/store/mutation-types";
   import {UPDATE_SYSTEM_USER_SORT} from "@/store/sorting/mutation-types";
-  import {ProgramSortField, SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+  import {ProgramSortField, Sort, SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
   @Component({
   components: {
@@ -325,9 +325,8 @@ export default class AdminUsersTable extends Vue {
         'data.email': UserSortField.Email,
         'data.name': UserSortField.Name
       };
-      const orderMap: any = {'asc': SortOrder.Ascending, 'desc': SortOrder.Descending};
-      if (field in fieldMap && order in orderMap) {
-        this.updateSort(new UserSort(fieldMap[field], orderMap[order]));
+      if (field in fieldMap) {
+        this.updateSort(new UserSort(fieldMap[field], Sort.orderAsBI(order)));
         this.getUsers();
       }
     }

--- a/src/components/ontology/OntologyActiveTable.vue
+++ b/src/components/ontology/OntologyActiveTable.vue
@@ -18,16 +18,9 @@
 <template>
   <ontology-table
       v-bind:active="true"
-      v-bind:traitSortField="activeTraitSortField"
-      v-bind:nameSortOrder="activeOntNameSortOrder"
-      v-bind:methodSortOrder="activeOntMethodSortOrder"
-      v-bind:scaleClassSortOrder="activeOntScaleClassSortOrder"
-      v-bind:unitSortOrder="activeOntUnitSortOrder"
-      v-on:newSortColumn="changeSortColumn"
-      v-on:toggleNameSortOrder="changeNameSortOrder"
-      v-on:toggleMethodSortOrder="changeMethodSortOrder"
-      v-on:toggleScaleClassSortOrder="changeScaleClassSortOrder"
-      v-on:toggleUnitSortOrder="changeUnitSortOrder"
+      v-bind:ontologySort="activeOntologySort"
+      v-on:newSortColumn="newSortColumn"
+      v-on:toggleSortOrder="toggleSortOrder"
       @show-success-notification="$emit('show-success-notification', $event)"
       @show-info-notification="$emit('show-info-notification', $event)"
       @show-error-notification="$emit('show-error-notification', $event)"
@@ -36,59 +29,34 @@
 </template>
 
 <script lang="ts">
-import { Prop, Component, Vue } from 'vue-property-decorator'
+import { Component, Vue } from 'vue-property-decorator'
 import OntologyTable from "@/components/ontology/OntologyTable.vue";
 import {mapGetters, mapMutations} from 'vuex'
 import {
   ACTIVE_ONT_NEW_SORT_COLUMN,
-  ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER, ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER,
-  ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
-  ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER
+  ACTIVE_ONT_TOGGLE_SORT_ORDER
 } from "@/store/sorting/mutation-types";
-import {TraitSortField} from "@/breeding-insight/model/Sort";
+import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
 
 @Component({
   components: {OntologyTable},
   computed: {
     ...mapGetters('sorting',[
-      'activeTraitSortField',
-      'activeOntNameSortOrder',
-      'activeOntMethodSortOrder',
-      'activeOntScaleClassSortOrder',
-      'activeOntUnitSortOrder'
+      'activeOntologySort',
     ])
   },
   methods: {
-    ...mapMutations('sorting', [
-      ACTIVE_ONT_NEW_SORT_COLUMN,
-      ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER,
-      ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER,
-      ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
-      ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER
-    ])
+    ...mapMutations('sorting', {
+      newSortColumn: ACTIVE_ONT_NEW_SORT_COLUMN,
+      toggleSortOrder: ACTIVE_ONT_TOGGLE_SORT_ORDER
+    })
   }
 })
 
 export default class OntologyActiveTable extends Vue {
 
-  changeSortColumn(field: TraitSortField) {
-    this[ACTIVE_ONT_NEW_SORT_COLUMN as keyof OntologyActiveTable](field);
-  }
-
-  changeNameSortOrder() {
-    this[ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER as keyof OntologyActiveTable]();
-  }
-
-  changeMethodSortOrder() {
-    this[ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER as keyof OntologyActiveTable]();
-  }
-
-  changeScaleClassSortOrder() {
-    this[ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER as keyof OntologyActiveTable]();
-  }
-
-  changeUnitSortOrder() {
-    this[ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER as keyof OntologyActiveTable]();
-  }
+  private activeOntologySort!: OntologySort;
+  private newSortColumn!: (field: OntologySortField) => void;
+  private toggleSortOrder!: () => void;
 }
 </script>

--- a/src/components/ontology/OntologyActiveTable.vue
+++ b/src/components/ontology/OntologyActiveTable.vue
@@ -18,6 +18,16 @@
 <template>
   <ontology-table
       v-bind:active="true"
+      v-bind:traitSortField="activeTraitSortField"
+      v-bind:nameSortOrder="activeOntNameSortOrder"
+      v-bind:methodSortOrder="activeOntMethodSortOrder"
+      v-bind:scaleClassSortOrder="activeOntScaleClassSortOrder"
+      v-bind:unitSortOrder="activeOntUnitSortOrder"
+      v-on:newSortColumn="changeSortColumn"
+      v-on:toggleNameSortOrder="changeNameSortOrder"
+      v-on:toggleMethodSortOrder="changeMethodSortOrder"
+      v-on:toggleScaleClassSortOrder="changeScaleClassSortOrder"
+      v-on:toggleUnitSortOrder="changeUnitSortOrder"
       @show-success-notification="$emit('show-success-notification', $event)"
       @show-info-notification="$emit('show-info-notification', $event)"
       @show-error-notification="$emit('show-error-notification', $event)"
@@ -28,10 +38,57 @@
 <script lang="ts">
 import { Prop, Component, Vue } from 'vue-property-decorator'
 import OntologyTable from "@/components/ontology/OntologyTable.vue";
+import {mapGetters, mapMutations} from 'vuex'
+import {
+  ACTIVE_ONT_NEW_SORT_COLUMN,
+  ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER, ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER,
+  ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
+  ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER
+} from "@/store/sorting/mutation-types";
+import {TraitSortField} from "@/breeding-insight/model/Sort";
 
-  @Component({
-  components: { OntologyTable },
-})
-export default class OntologyActiveTable extends Vue {
+@Component({
+  components: {OntologyTable},
+  computed: {
+    ...mapGetters('sorting',[
+      'activeTraitSortField',
+      'activeOntNameSortOrder',
+      'activeOntMethodSortOrder',
+      'activeOntScaleClassSortOrder',
+      'activeOntUnitSortOrder'
+    ])
+  },
+  methods: {
+    ...mapMutations('sorting', [
+      ACTIVE_ONT_NEW_SORT_COLUMN,
+      ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER,
+      ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER,
+      ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
+      ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER
+    ])
   }
+})
+
+export default class OntologyActiveTable extends Vue {
+
+  changeSortColumn(field: TraitSortField) {
+    this[ACTIVE_ONT_NEW_SORT_COLUMN](field);
+  }
+
+  changeNameSortOrder() {
+    this[ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER]();
+  }
+
+  changeMethodSortOrder() {
+    this[ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER]();
+  }
+
+  changeScaleClassSortOrder() {
+    this[ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER]();
+  }
+
+  changeUnitSortOrder() {
+    this[ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER]();
+  }
+}
 </script>

--- a/src/components/ontology/OntologyActiveTable.vue
+++ b/src/components/ontology/OntologyActiveTable.vue
@@ -42,7 +42,7 @@ import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
   components: {OntologyTable},
   computed: {
     ...mapGetters('sorting',[
-      'activeOntologySort',
+      'activeOntologySort'
     ])
   },
   methods: {

--- a/src/components/ontology/OntologyActiveTable.vue
+++ b/src/components/ontology/OntologyActiveTable.vue
@@ -72,23 +72,23 @@ import {TraitSortField} from "@/breeding-insight/model/Sort";
 export default class OntologyActiveTable extends Vue {
 
   changeSortColumn(field: TraitSortField) {
-    this[ACTIVE_ONT_NEW_SORT_COLUMN](field);
+    this[ACTIVE_ONT_NEW_SORT_COLUMN as keyof OntologyActiveTable](field);
   }
 
   changeNameSortOrder() {
-    this[ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER]();
+    this[ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER as keyof OntologyActiveTable]();
   }
 
   changeMethodSortOrder() {
-    this[ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER]();
+    this[ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER as keyof OntologyActiveTable]();
   }
 
   changeScaleClassSortOrder() {
-    this[ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER]();
+    this[ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER as keyof OntologyActiveTable]();
   }
 
   changeUnitSortOrder() {
-    this[ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER]();
+    this[ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER as keyof OntologyActiveTable]();
   }
 }
 </script>

--- a/src/components/ontology/OntologyArchivedTable.vue
+++ b/src/components/ontology/OntologyArchivedTable.vue
@@ -69,23 +69,23 @@ import {TraitSortField} from "@/breeding-insight/model/Sort";
 })
 export default class OntologyArchivedTable extends Vue {
   changeSortColumn(field: TraitSortField) {
-    this[ARCHIVED_ONT_NEW_SORT_COLUMN](field);
+    this[ARCHIVED_ONT_NEW_SORT_COLUMN as keyof OntologyArchivedTable](field);
   }
 
   changeNameSortOrder() {
-    this[ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER]();
+    this[ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER as keyof OntologyArchivedTable]();
   }
 
   changeMethodSortOrder() {
-    this[ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER]();
+    this[ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER as keyof OntologyArchivedTable]();
   }
 
   changeScaleClassSortOrder() {
-    this[ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER]();
+    this[ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER as keyof OntologyArchivedTable]();
   }
 
   changeUnitSortOrder() {
-    this[ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER]();
+    this[ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER as keyof OntologyArchivedTable]();
   }
 }
 </script>

--- a/src/components/ontology/OntologyArchivedTable.vue
+++ b/src/components/ontology/OntologyArchivedTable.vue
@@ -18,16 +18,9 @@
 <template>
   <ontology-table
       v-bind:active="false"
-      v-bind:traitSortField="archivedTraitSortField"
-      v-bind:nameSortOrder="archivedOntNameSortOrder"
-      v-bind:methodSortOrder="archivedOntMethodSortOrder"
-      v-bind:scaleClassSortOrder="archivedOntScaleClassSortOrder"
-      v-bind:unitSortOrder="archivedOntUnitSortOrder"
-      v-on:newSortColumn="changeSortColumn"
-      v-on:toggleNameSortOrder="changeNameSortOrder"
-      v-on:toggleMethodSortOrder="changeMethodSortOrder"
-      v-on:toggleScaleClassSortOrder="changeScaleClassSortOrder"
-      v-on:toggleUnitSortOrder="changeUnitSortOrder"
+      v-bind:ontologySort="archivedOntologySort"
+      v-on:newSortColumn="newSortColumn"
+      v-on:toggleSortOrder="toggleSortOrder"
       @show-success-notification="$emit('show-success-notification', $event)"
       @show-info-notification="$emit('show-info-notification', $event)"
       @show-error-notification="$emit('show-error-notification', $event)"
@@ -40,9 +33,8 @@ import { Prop, Component, Vue } from 'vue-property-decorator'
 import OntologyTable from "@/components/ontology/OntologyTable.vue";
 import {mapGetters, mapMutations} from 'vuex'
 import {
-  ARCHIVED_ONT_NEW_SORT_COLUMN, ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER, ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER,
-  ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
-  ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER
+  ARCHIVED_ONT_NEW_SORT_COLUMN,
+  ARCHIVED_ONT_TOGGLE_SORT_ORDER
 } from "@/store/sorting/mutation-types";
 import {TraitSortField} from "@/breeding-insight/model/Sort";
 
@@ -50,21 +42,14 @@ import {TraitSortField} from "@/breeding-insight/model/Sort";
   components: {OntologyTable},
   computed: {
     ...mapGetters('sorting', [
-      'archivedTraitSortField',
-      'archivedOntNameSortOrder',
-      'archivedOntMethodSortOrder',
-      'archivedOntScaleClassSortOrder',
-      'archivedOntUnitSortOrder'
+        'archivedOntologySort'
     ])
   },
   methods: {
-    ...mapMutations('sorting', [
-      ARCHIVED_ONT_NEW_SORT_COLUMN,
-      ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER,
-      ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER,
-      ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
-      ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER
-    ])
+    ...mapMutations('sorting', {
+      newSortColumn: ARCHIVED_ONT_NEW_SORT_COLUMN,
+      toggleSortOrder: ARCHIVED_ONT_TOGGLE_SORT_ORDER
+    })
   }
 })
 export default class OntologyArchivedTable extends Vue {

--- a/src/components/ontology/OntologyArchivedTable.vue
+++ b/src/components/ontology/OntologyArchivedTable.vue
@@ -36,7 +36,8 @@ import {
   ARCHIVED_ONT_NEW_SORT_COLUMN,
   ARCHIVED_ONT_TOGGLE_SORT_ORDER
 } from "@/store/sorting/mutation-types";
-import {TraitSortField} from "@/breeding-insight/model/Sort";
+import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
+
 
 @Component({
   components: {OntologyTable},
@@ -53,24 +54,9 @@ import {TraitSortField} from "@/breeding-insight/model/Sort";
   }
 })
 export default class OntologyArchivedTable extends Vue {
-  changeSortColumn(field: TraitSortField) {
-    this[ARCHIVED_ONT_NEW_SORT_COLUMN as keyof OntologyArchivedTable](field);
-  }
+  private archivedOntologySort!: OntologySort;
+  private newSortColumn!: (field: OntologySortField) => void;
+  private toggleSortOrder!: () => void;
 
-  changeNameSortOrder() {
-    this[ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER as keyof OntologyArchivedTable]();
-  }
-
-  changeMethodSortOrder() {
-    this[ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER as keyof OntologyArchivedTable]();
-  }
-
-  changeScaleClassSortOrder() {
-    this[ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER as keyof OntologyArchivedTable]();
-  }
-
-  changeUnitSortOrder() {
-    this[ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER as keyof OntologyArchivedTable]();
-  }
 }
 </script>

--- a/src/components/ontology/OntologyArchivedTable.vue
+++ b/src/components/ontology/OntologyArchivedTable.vue
@@ -18,6 +18,16 @@
 <template>
   <ontology-table
       v-bind:active="false"
+      v-bind:traitSortField="archivedTraitSortField"
+      v-bind:nameSortOrder="archivedOntNameSortOrder"
+      v-bind:methodSortOrder="archivedOntMethodSortOrder"
+      v-bind:scaleClassSortOrder="archivedOntScaleClassSortOrder"
+      v-bind:unitSortOrder="archivedOntUnitSortOrder"
+      v-on:newSortColumn="changeSortColumn"
+      v-on:toggleNameSortOrder="changeNameSortOrder"
+      v-on:toggleMethodSortOrder="changeMethodSortOrder"
+      v-on:toggleScaleClassSortOrder="changeScaleClassSortOrder"
+      v-on:toggleUnitSortOrder="changeUnitSortOrder"
       @show-success-notification="$emit('show-success-notification', $event)"
       @show-info-notification="$emit('show-info-notification', $event)"
       @show-error-notification="$emit('show-error-notification', $event)"
@@ -28,10 +38,54 @@
 <script lang="ts">
 import { Prop, Component, Vue } from 'vue-property-decorator'
 import OntologyTable from "@/components/ontology/OntologyTable.vue";
+import {mapGetters, mapMutations} from 'vuex'
+import {
+  ARCHIVED_ONT_NEW_SORT_COLUMN, ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER, ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER,
+  ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
+  ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER
+} from "@/store/sorting/mutation-types";
+import {TraitSortField} from "@/breeding-insight/model/Sort";
 
-  @Component({
-  components: { OntologyTable },
-})
-export default class OntologyActiveTable extends Vue {
+@Component({
+  components: {OntologyTable},
+  computed: {
+    ...mapGetters('sorting', [
+      'archivedTraitSortField',
+      'archivedOntNameSortOrder',
+      'archivedOntMethodSortOrder',
+      'archivedOntScaleClassSortOrder',
+      'archivedOntUnitSortOrder'
+    ])
+  },
+  methods: {
+    ...mapMutations('sorting', [
+      ARCHIVED_ONT_NEW_SORT_COLUMN,
+      ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER,
+      ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER,
+      ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
+      ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER
+    ])
   }
+})
+export default class OntologyArchivedTable extends Vue {
+  changeSortColumn(field: TraitSortField) {
+    this[ARCHIVED_ONT_NEW_SORT_COLUMN](field);
+  }
+
+  changeNameSortOrder() {
+    this[ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER]();
+  }
+
+  changeMethodSortOrder() {
+    this[ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER]();
+  }
+
+  changeScaleClassSortOrder() {
+    this[ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER]();
+  }
+
+  changeUnitSortOrder() {
+    this[ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER]();
+  }
+}
 </script>

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -283,19 +283,19 @@ export default class OntologyTable extends Vue {
   @Prop({default: () => true})
   active?: boolean;
 
-  @Prop()
+  @Prop({default: () => TraitSortField.name})
   traitSortField: TraitSortField;
 
-  @Prop()
+  @Prop({default: () => true})
   nameSortOrder: boolean;
 
-  @Prop()
+  @Prop({default: () => true})
   methodSortOrder: boolean;
 
-  @Prop()
+  @Prop({default: () => true})
   scaleClassSortOrder: boolean;
 
-  @Prop()
+  @Prop({default: () => true})
   unitSortOrder: boolean;
 
   private activeProgram?: Program;
@@ -423,6 +423,7 @@ export default class OntologyTable extends Vue {
         order = this.unitSortOrder ? SortOrder.Ascending : SortOrder.Descending;
         break;
       default:
+        order = SortOrder.Ascending;
         break;
     }
 

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -299,7 +299,6 @@ export default class OntologyTable extends Vue {
   private loadingTraitEditable = true;
 
   // table column sorting
-  private sortOptions = TraitSortField;
   private traitSortField: string = TraitSortField.Name;
   private nameSortLabel: string = TraitSortField.Name;
   private methodSortLabel: string = TraitSortField.MethodDescription;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -132,8 +132,8 @@
             v-bind:sortFieldLabel="nameSortLabel"
             v-bind:sortable="true"
             v-bind:sortOrder="nameSortOrder"
-            v-on:newSortColumn="changeSortColumn($event)"
-            v-on:toggleSortOrder="changeNameSortOrder"
+            v-on:newSortColumn="$emit('newSortColumn', $event)"
+            v-on:toggleSortOrder="$emit('toggleNameSortOrder')"
         >
           {{ data.observationVariableName }}
         </TableColumn>
@@ -148,8 +148,8 @@
             v-bind:sortFieldLabel="methodSortLabel"
             v-bind:sortable="true"
             v-bind:sortOrder="methodSortOrder"
-            v-on:newSortColumn="changeSortColumn($event)"
-            v-on:toggleSortOrder="changeMethodSortOrder"
+            v-on:newSortColumn="$emit('newSortColumn', $event)"
+            v-on:toggleSortOrder="$emit('toggleMethodSortOrder')"
         >
           {{ data.method.description + " " + StringFormatters.toStartCase(data.method.methodClass) }}
         </TableColumn>
@@ -161,8 +161,8 @@
             v-bind:sortFieldLabel="scaleClassSortLabel"
             v-bind:sortable="true"
             v-bind:sortOrder="scaleClassSortOrder"
-            v-on:newSortColumn="changeSortColumn($event)"
-            v-on:toggleSortOrder="changeScaleClassSortOrder"
+            v-on:newSortColumn="$emit('newSortColumn', $event)"
+            v-on:toggleSortOrder="$emit('toggleScaleClassSortOrder')"
         >
           {{ TraitStringFormatters.getScaleTypeString(data.scale) }}
         </TableColumn>
@@ -174,8 +174,8 @@
             v-bind:sortFieldLabel="unitSortLabel"
             v-bind:sortable="true"
             v-bind:sortOrder="unitSortOrder"
-            v-on:newSortColumn="changeSortColumn($event)"
-            v-on:toggleSortOrder="changeUnitSortOrder"
+            v-on:newSortColumn="$emit('newSortColumn', $event)"
+            v-on:toggleSortOrder="$emit('toggleUnitSortOrder')"
         >
           <template v-if="data.scale.dataType==='NUMERICAL'">
             {{ data.scale.scaleName }}
@@ -241,7 +241,7 @@ import WarningModal from '@/components/modals/WarningModal.vue'
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate';
 import {Trait} from '@/breeding-insight/model/Trait'
-import {mapGetters, mapMutations} from 'vuex'
+import {mapGetters} from 'vuex'
 import {Program} from "@/breeding-insight/model/Program";
 import NewDataForm from '@/components/forms/NewDataForm.vue'
 import BasicInputField from "@/components/forms/BasicInputField.vue";
@@ -265,12 +265,6 @@ import {DataFormEventBusHandler} from '@/components/forms/DataFormEventBusHandle
 import {integer, maxLength} from "vuelidate/lib/validators";
 import {TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
 import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
-import {
-  NEW_SORT_COLUMN,
-  TOGGLE_METHOD_SORT_ORDER,
-  TOGGLE_NAME_SORT_ORDER,
-  TOGGLE_SCALE_CLASS_SORT_ORDER, TOGGLE_UNIT_SORT_ORDER
-} from "@/store/sorting/mutation-types";
 
 @Component({
   mixins: [validationMixin],
@@ -281,22 +275,6 @@ import {
   computed: {
     ...mapGetters([
       'activeProgram'
-    ]),
-    ...mapGetters('sorting',[
-      'traitSortField',
-      'nameSortOrder',
-      'methodSortOrder',
-      'scaleClassSortOrder',
-      'unitSortOrder'
-    ])
-  },
-  methods: {
-    ...mapMutations('sorting', [
-      NEW_SORT_COLUMN,
-      TOGGLE_NAME_SORT_ORDER,
-      TOGGLE_METHOD_SORT_ORDER,
-      TOGGLE_SCALE_CLASS_SORT_ORDER,
-      TOGGLE_UNIT_SORT_ORDER
     ])
   },
   data: () => ({Trait, StringFormatters, TraitStringFormatters})
@@ -304,6 +282,21 @@ import {
 export default class OntologyTable extends Vue {
   @Prop({default: () => true})
   active?: boolean;
+
+  @Prop()
+  traitSortField: TraitSortField;
+
+  @Prop()
+  nameSortOrder: boolean;
+
+  @Prop()
+  methodSortOrder: boolean;
+
+  @Prop()
+  scaleClassSortOrder: boolean;
+
+  @Prop()
+  unitSortOrder: boolean;
 
   private activeProgram?: Program;
   private traits: Trait[] = [];
@@ -398,26 +391,6 @@ export default class OntologyTable extends Vue {
 
   archiveWarning() {
     return this.editTrait && this.editTrait.active ? 'restore' : 'archive';
-  }
-
-  changeSortColumn(field: TraitSortField) {
-    this[NEW_SORT_COLUMN](field);
-  }
-
-  changeNameSortOrder() {
-    this[TOGGLE_NAME_SORT_ORDER]();
-  }
-
-  changeMethodSortOrder() {
-    this[TOGGLE_METHOD_SORT_ORDER]();
-  }
-
-  changeScaleClassSortOrder() {
-    this[TOGGLE_SCALE_CLASS_SORT_ORDER]();
-  }
-
-  changeUnitSortOrder() {
-    this[TOGGLE_UNIT_SORT_ORDER]();
   }
 
   @Watch('traitSortField')

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -132,8 +132,8 @@
             v-bind:sortFieldLabel="nameSortLabel"
             v-bind:sortable="true"
             v-bind:sortOrder="nameSortOrder"
-            v-on:newSortColumn="traitSortField = $event"
-            v-on:toggleSortOrder="nameSortOrder = !nameSortOrder"
+            v-on:newSortColumn="changeSortColumn($event)"
+            v-on:toggleSortOrder="changeNameSortOrder"
         >
           {{ data.observationVariableName }}
         </TableColumn>
@@ -148,8 +148,8 @@
             v-bind:sortFieldLabel="methodSortLabel"
             v-bind:sortable="true"
             v-bind:sortOrder="methodSortOrder"
-            v-on:newSortColumn="traitSortField = $event"
-            v-on:toggleSortOrder="methodSortOrder = !methodSortOrder"
+            v-on:newSortColumn="changeSortColumn($event)"
+            v-on:toggleSortOrder="changeMethodSortOrder"
         >
           {{ data.method.description + " " + StringFormatters.toStartCase(data.method.methodClass) }}
         </TableColumn>
@@ -161,8 +161,8 @@
             v-bind:sortFieldLabel="scaleClassSortLabel"
             v-bind:sortable="true"
             v-bind:sortOrder="scaleClassSortOrder"
-            v-on:newSortColumn="traitSortField = $event"
-            v-on:toggleSortOrder="scaleClassSortOrder = !scaleClassSortOrder"
+            v-on:newSortColumn="changeSortColumn($event)"
+            v-on:toggleSortOrder="changeScaleClassSortOrder"
         >
           {{ TraitStringFormatters.getScaleTypeString(data.scale) }}
         </TableColumn>
@@ -174,8 +174,8 @@
             v-bind:sortFieldLabel="unitSortLabel"
             v-bind:sortable="true"
             v-bind:sortOrder="unitSortOrder"
-            v-on:newSortColumn="traitSortField = $event"
-            v-on:toggleSortOrder="unitSortOrder = !unitSortOrder"
+            v-on:newSortColumn="changeSortColumn($event)"
+            v-on:toggleSortOrder="changeUnitSortOrder"
         >
           <template v-if="data.scale.dataType==='NUMERICAL'">
             {{ data.scale.scaleName }}
@@ -241,7 +241,7 @@ import WarningModal from '@/components/modals/WarningModal.vue'
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate';
 import {Trait} from '@/breeding-insight/model/Trait'
-import {mapGetters} from 'vuex'
+import {mapGetters, mapMutations} from 'vuex'
 import {Program} from "@/breeding-insight/model/Program";
 import NewDataForm from '@/components/forms/NewDataForm.vue'
 import BasicInputField from "@/components/forms/BasicInputField.vue";
@@ -265,6 +265,12 @@ import {DataFormEventBusHandler} from '@/components/forms/DataFormEventBusHandle
 import {integer, maxLength} from "vuelidate/lib/validators";
 import {TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
 import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
+import {
+  NEW_SORT_COLUMN,
+  TOGGLE_METHOD_SORT_ORDER,
+  TOGGLE_NAME_SORT_ORDER,
+  TOGGLE_SCALE_CLASS_SORT_ORDER, TOGGLE_UNIT_SORT_ORDER
+} from "@/store/sorting/mutation-types";
 
 @Component({
   mixins: [validationMixin],
@@ -275,6 +281,22 @@ import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
   computed: {
     ...mapGetters([
       'activeProgram'
+    ]),
+    ...mapGetters('sorting',[
+      'traitSortField',
+      'nameSortOrder',
+      'methodSortOrder',
+      'scaleClassSortOrder',
+      'unitSortOrder'
+    ])
+  },
+  methods: {
+    ...mapMutations('sorting', [
+      NEW_SORT_COLUMN,
+      TOGGLE_NAME_SORT_ORDER,
+      TOGGLE_METHOD_SORT_ORDER,
+      TOGGLE_SCALE_CLASS_SORT_ORDER,
+      TOGGLE_UNIT_SORT_ORDER
     ])
   },
   data: () => ({Trait, StringFormatters, TraitStringFormatters})
@@ -299,15 +321,10 @@ export default class OntologyTable extends Vue {
   private loadingTraitEditable = true;
 
   // table column sorting
-  private traitSortField: string = TraitSortField.Name;
   private nameSortLabel: string = TraitSortField.Name;
   private methodSortLabel: string = TraitSortField.MethodDescription;
   private scaleClassSortLabel: string = TraitSortField.ScaleClass;
   private unitSortLabel: string = TraitSortField.ScaleName;
-  private nameSortOrder: boolean = true;
-  private methodSortOrder: boolean = true;
-  private scaleClassSortOrder: boolean = true;
-  private unitSortOrder: boolean = true;
 
   // New trait form
   private newTraitActive: boolean = false;
@@ -381,6 +398,26 @@ export default class OntologyTable extends Vue {
 
   archiveWarning() {
     return this.editTrait && this.editTrait.active ? 'restore' : 'archive';
+  }
+
+  changeSortColumn(field: TraitSortField) {
+    this[NEW_SORT_COLUMN](field);
+  }
+
+  changeNameSortOrder() {
+    this[TOGGLE_NAME_SORT_ORDER]();
+  }
+
+  changeMethodSortOrder() {
+    this[TOGGLE_METHOD_SORT_ORDER]();
+  }
+
+  changeScaleClassSortOrder() {
+    this[TOGGLE_SCALE_CLASS_SORT_ORDER]();
+  }
+
+  changeUnitSortOrder() {
+    this[TOGGLE_UNIT_SORT_ORDER]();
   }
 
   @Watch('traitSortField')

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -283,20 +283,20 @@ export default class OntologyTable extends Vue {
   @Prop({default: () => true})
   active?: boolean;
 
-  @Prop({default: () => TraitSortField.name})
-  traitSortField: TraitSortField;
+  @Prop({default: () => TraitSortField.Name})
+  traitSortField!: TraitSortField;
 
   @Prop({default: () => true})
-  nameSortOrder: boolean;
+  nameSortOrder!: boolean;
 
   @Prop({default: () => true})
-  methodSortOrder: boolean;
+  methodSortOrder!: boolean;
 
   @Prop({default: () => true})
-  scaleClassSortOrder: boolean;
+  scaleClassSortOrder!: boolean;
 
   @Prop({default: () => true})
-  unitSortOrder: boolean;
+  unitSortOrder!: boolean;
 
   private activeProgram?: Program;
   private traits: Trait[] = [];

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -390,7 +390,7 @@ export default class OntologyTable extends Vue {
 
     // filter the terms pulled from the back-end
     let filters: TraitFilter[] = [{ field: TraitField.STATUS, value: this.active}];
-console.log(this.ontologySort.order);
+
     TraitService.getFilteredTraits(this.activeProgram!.id!, paginationQuery, true, filters, this.ontologySort).then(([traits, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = traits;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -125,19 +125,58 @@
         data: T
       -->
       <template v-slot:columns="data">
-        <TableColumn name="name" v-bind:label="'Name'">
+        <TableColumn
+            name="name"
+            v-bind:label="'Name'"
+            v-bind:sortField="traitSortField"
+            v-bind:sortFieldLabel="nameSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="nameSortOrder"
+            v-on:newSortColumn="traitSortField = $event"
+            v-on:toggleSortOrder="nameSortOrder = !nameSortOrder"
+        >
           {{ data.observationVariableName }}
         </TableColumn>
         <TableColumn name="trait" v-bind:label="'Trait'" v-bind:visible="!traitSidePanelState.collapseColumns">
           {{ StringFormatters.toStartCase(data.traitDescription) }}
         </TableColumn>
-        <TableColumn name="method" v-bind:label="'Method'" v-bind:visible="!traitSidePanelState.collapseColumns">
+        <TableColumn
+            name="method"
+            v-bind:label="'Method'"
+            v-bind:visible="!traitSidePanelState.collapseColumns"
+            v-bind:sortField="traitSortField"
+            v-bind:sortFieldLabel="methodSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="methodSortOrder"
+            v-on:newSortColumn="traitSortField = $event"
+            v-on:toggleSortOrder="methodSortOrder = !methodSortOrder"
+        >
           {{ data.method.description + " " + StringFormatters.toStartCase(data.method.methodClass) }}
         </TableColumn>
-        <TableColumn name="scaleClass" v-bind:label="'Scale Class'" v-bind:visible="!traitSidePanelState.collapseColumns">
+        <TableColumn
+            name="scaleClass"
+            v-bind:label="'Scale Class'"
+            v-bind:visible="!traitSidePanelState.collapseColumns"
+            v-bind:sortField="traitSortField"
+            v-bind:sortFieldLabel="scaleClassSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="scaleClassSortOrder"
+            v-on:newSortColumn="traitSortField = $event"
+            v-on:toggleSortOrder="scaleClassSortOrder = !scaleClassSortOrder"
+        >
           {{ TraitStringFormatters.getScaleTypeString(data.scale) }}
         </TableColumn>
-        <TableColumn name="unit" v-bind:label="'Unit'" v-bind:visible="!traitSidePanelState.collapseColumns">
+        <TableColumn
+            name="unit"
+            v-bind:label="'Unit'"
+            v-bind:visible="!traitSidePanelState.collapseColumns"
+            v-bind:sortField="traitSortField"
+            v-bind:sortFieldLabel="unitSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="unitSortOrder"
+            v-on:newSortColumn="traitSortField = $event"
+            v-on:toggleSortOrder="unitSortOrder = !unitSortOrder"
+        >
           <template v-if="data.scale.dataType==='NUMERICAL'">
             {{ data.scale.scaleName }}
           </template>
@@ -197,12 +236,12 @@
 </template>
 
 <script lang="ts">
-import {Prop, Component, Vue, Watch} from 'vue-property-decorator'
+import {Component, Prop, Vue, Watch} from 'vue-property-decorator'
 import WarningModal from '@/components/modals/WarningModal.vue'
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate';
 import {Trait} from '@/breeding-insight/model/Trait'
-import { mapGetters } from 'vuex'
+import {mapGetters} from 'vuex'
 import {Program} from "@/breeding-insight/model/Program";
 import NewDataForm from '@/components/forms/NewDataForm.vue'
 import BasicInputField from "@/components/forms/BasicInputField.vue";
@@ -214,19 +253,20 @@ import TableColumn from "@/components/tables/TableColumn.vue";
 import {Metadata, Pagination} from "@/breeding-insight/model/BiResponse";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
-import { StringFormatters } from '@/breeding-insight/utils/StringFormatters';
-import { TraitStringFormatters } from '@/breeding-insight/utils/TraitStringFormatters';
+import {StringFormatters} from '@/breeding-insight/utils/StringFormatters';
+import {TraitStringFormatters} from '@/breeding-insight/utils/TraitStringFormatters';
 import BaseTraitForm from "@/components/trait/forms/BaseTraitForm.vue";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 import {ProgramService} from "@/breeding-insight/service/ProgramService";
 import {MethodClass} from "@/breeding-insight/model/Method";
 import {DataType, Scale} from "@/breeding-insight/model/Scale";
 import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableEventBus";
-import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
-import {email, required, integer, maxLength} from "vuelidate/lib/validators";
-import {TraitFilter, TraitField} from "@/breeding-insight/model/TraitSelector";
+import {DataFormEventBusHandler} from '@/components/forms/DataFormEventBusHandler';
+import {integer, maxLength} from "vuelidate/lib/validators";
+import {TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
+import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
 
-  @Component({
+@Component({
   mixins: [validationMixin],
   components: {
     BaseTraitForm, NewDataForm, BasicInputField, SidePanelTable, EmptyTableMessage, TableColumn,
@@ -257,6 +297,18 @@ export default class OntologyTable extends Vue {
   private newTrait: Trait = new Trait();
   private currentTraitEditable = false;
   private loadingTraitEditable = true;
+
+  // table column sorting
+  private sortOptions = TraitSortField;
+  private traitSortField: string = TraitSortField.Name;
+  private nameSortLabel: string = TraitSortField.Name;
+  private methodSortLabel: string = TraitSortField.MethodDescription;
+  private scaleClassSortLabel: string = TraitSortField.ScaleClass;
+  private unitSortLabel: string = TraitSortField.ScaleName;
+  private nameSortOrder: boolean = true;
+  private methodSortOrder: boolean = true;
+  private scaleClassSortOrder: boolean = true;
+  private unitSortOrder: boolean = true;
 
   // New trait form
   private newTraitActive: boolean = false;
@@ -341,7 +393,26 @@ export default class OntologyTable extends Vue {
     // filter the terms pulled from the back-end
     let filters: TraitFilter[] = [{ field: TraitField.STATUS, value: this.active}];
 
-    TraitService.getFilteredTraits(this.activeProgram!.id!, paginationQuery, true, filters).then(([traits, metadata]) => {
+    // order the sorting of traits along a column
+    let order: SortOrder;
+    switch(this.traitSortField) {
+      case TraitSortField.Name:
+        order = this.nameSortOrder ? SortOrder.Ascending : SortOrder.Descending;
+        break;
+      case TraitSortField.MethodDescription:
+        order = this.methodSortOrder ? SortOrder.Ascending : SortOrder.Descending;
+        break;
+      case TraitSortField.ScaleClass:
+        order = this.scaleClassSortOrder ? SortOrder.Ascending : SortOrder.Descending;
+        break;
+      case TraitSortField.ScaleName:
+        order = this.unitSortOrder ? SortOrder.Ascending : SortOrder.Descending;
+        break;
+      default:
+        break;
+    }
+
+    TraitService.getFilteredTraits(this.activeProgram!.id!, paginationQuery, true, filters, this.traitSortField, order).then(([traits, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = traits;
         this.traitsPagination = metadata.pagination;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -128,12 +128,12 @@
         <TableColumn
             name="name"
             v-bind:label="'Name'"
-            v-bind:sortField="traitSortField"
+            v-bind:sortField="ontologySort.field"
             v-bind:sortFieldLabel="nameSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="nameSortOrder"
+            v-bind:sortOrder="ontologySort.flag"
             v-on:newSortColumn="$emit('newSortColumn', $event)"
-            v-on:toggleSortOrder="$emit('toggleNameSortOrder')"
+            v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
           {{ data.observationVariableName }}
         </TableColumn>
@@ -144,12 +144,12 @@
             name="method"
             v-bind:label="'Method'"
             v-bind:visible="!traitSidePanelState.collapseColumns"
-            v-bind:sortField="traitSortField"
+            v-bind:sortField="ontologySort.field"
             v-bind:sortFieldLabel="methodSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="methodSortOrder"
+            v-bind:sortOrder="ontologySort.flag"
             v-on:newSortColumn="$emit('newSortColumn', $event)"
-            v-on:toggleSortOrder="$emit('toggleMethodSortOrder')"
+            v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
           {{ data.method.description + " " + StringFormatters.toStartCase(data.method.methodClass) }}
         </TableColumn>
@@ -157,12 +157,12 @@
             name="scaleClass"
             v-bind:label="'Scale Class'"
             v-bind:visible="!traitSidePanelState.collapseColumns"
-            v-bind:sortField="traitSortField"
+            v-bind:sortField="ontologySort.field"
             v-bind:sortFieldLabel="scaleClassSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="scaleClassSortOrder"
+            v-bind:sortOrder="ontologySort.flag"
             v-on:newSortColumn="$emit('newSortColumn', $event)"
-            v-on:toggleSortOrder="$emit('toggleScaleClassSortOrder')"
+            v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
           {{ TraitStringFormatters.getScaleTypeString(data.scale) }}
         </TableColumn>
@@ -170,12 +170,12 @@
             name="unit"
             v-bind:label="'Unit'"
             v-bind:visible="!traitSidePanelState.collapseColumns"
-            v-bind:sortField="traitSortField"
+            v-bind:sortField="ontologySort.field"
             v-bind:sortFieldLabel="unitSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="unitSortOrder"
+            v-bind:sortOrder="ontologySort.flag"
             v-on:newSortColumn="$emit('newSortColumn', $event)"
-            v-on:toggleSortOrder="$emit('toggleUnitSortOrder')"
+            v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
           <template v-if="data.scale.dataType==='NUMERICAL'">
             {{ data.scale.scaleName }}
@@ -264,7 +264,7 @@ import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableE
 import {DataFormEventBusHandler} from '@/components/forms/DataFormEventBusHandler';
 import {integer, maxLength} from "vuelidate/lib/validators";
 import {TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
-import {SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
+import {OntologySort, SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
 
 @Component({
   mixins: [validationMixin],
@@ -283,20 +283,8 @@ export default class OntologyTable extends Vue {
   @Prop({default: () => true})
   active?: boolean;
 
-  @Prop({default: () => TraitSortField.Name})
-  traitSortField!: TraitSortField;
-
-  @Prop({default: () => true})
-  nameSortOrder!: boolean;
-
-  @Prop({default: () => true})
-  methodSortOrder!: boolean;
-
-  @Prop({default: () => true})
-  scaleClassSortOrder!: boolean;
-
-  @Prop({default: () => true})
-  unitSortOrder!: boolean;
+  @Prop()
+  ontologySort!: OntologySort;
 
   private activeProgram?: Program;
   private traits: Trait[] = [];
@@ -393,11 +381,7 @@ export default class OntologyTable extends Vue {
     return this.editTrait && this.editTrait.active ? 'restore' : 'archive';
   }
 
-  @Watch('traitSortField')
-  @Watch('nameSortOrder')
-  @Watch('methodSortOrder')
-  @Watch('scaleClassSortOrder')
-  @Watch('unitSortOrder')
+  @Watch('ontologySort', {deep: true})
   @Watch('paginationController', { deep: true})
   getTraits() {
     let paginationQuery: PaginationQuery = PaginationController.getPaginationSelections(
@@ -407,27 +391,7 @@ export default class OntologyTable extends Vue {
     // filter the terms pulled from the back-end
     let filters: TraitFilter[] = [{ field: TraitField.STATUS, value: this.active}];
 
-    // order the sorting of traits along a column
-    let order: SortOrder;
-    switch(this.traitSortField) {
-      case TraitSortField.Name:
-        order = this.nameSortOrder ? SortOrder.Ascending : SortOrder.Descending;
-        break;
-      case TraitSortField.MethodDescription:
-        order = this.methodSortOrder ? SortOrder.Ascending : SortOrder.Descending;
-        break;
-      case TraitSortField.ScaleClass:
-        order = this.scaleClassSortOrder ? SortOrder.Ascending : SortOrder.Descending;
-        break;
-      case TraitSortField.ScaleName:
-        order = this.unitSortOrder ? SortOrder.Ascending : SortOrder.Descending;
-        break;
-      default:
-        order = SortOrder.Ascending;
-        break;
-    }
-
-    TraitService.getFilteredTraits(this.activeProgram!.id!, paginationQuery, true, filters, this.traitSortField, order).then(([traits, metadata]) => {
+    TraitService.getFilteredTraits(this.activeProgram!.id!, paginationQuery, true, filters, this.ontologySort).then(([traits, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = traits;
         this.traitsPagination = metadata.pagination;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -384,6 +384,11 @@ export default class OntologyTable extends Vue {
     return this.editTrait && this.editTrait.active ? 'restore' : 'archive';
   }
 
+  @Watch('traitSortField')
+  @Watch('nameSortOrder')
+  @Watch('methodSortOrder')
+  @Watch('scaleClassSortOrder')
+  @Watch('unitSortOrder')
   @Watch('paginationController', { deep: true})
   getTraits() {
     let paginationQuery: PaginationQuery = PaginationController.getPaginationSelections(

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -264,7 +264,7 @@ import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableE
 import {DataFormEventBusHandler} from '@/components/forms/DataFormEventBusHandler';
 import {integer, maxLength} from "vuelidate/lib/validators";
 import {TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
-import {OntologySort, SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
+import {OntologySort, OntologySortField, SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
 
 @Component({
   mixins: [validationMixin],
@@ -302,10 +302,10 @@ export default class OntologyTable extends Vue {
   private loadingTraitEditable = true;
 
   // table column sorting
-  private nameSortLabel: string = TraitSortField.Name;
-  private methodSortLabel: string = TraitSortField.MethodDescription;
-  private scaleClassSortLabel: string = TraitSortField.ScaleClass;
-  private unitSortLabel: string = TraitSortField.ScaleName;
+  private nameSortLabel: string = OntologySortField.Name;
+  private methodSortLabel: string = OntologySortField.MethodDescription;
+  private scaleClassSortLabel: string = OntologySortField.ScaleClass;
+  private unitSortLabel: string = OntologySortField.ScaleName;
 
   // New trait form
   private newTraitActive: boolean = false;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -131,7 +131,7 @@
             v-bind:sortField="ontologySort.field"
             v-bind:sortFieldLabel="nameSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="ontologySort.flag"
+            v-bind:sortOrder="ontologySort.order"
             v-on:newSortColumn="$emit('newSortColumn', $event)"
             v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
@@ -147,7 +147,7 @@
             v-bind:sortField="ontologySort.field"
             v-bind:sortFieldLabel="methodSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="ontologySort.flag"
+            v-bind:sortOrder="ontologySort.order"
             v-on:newSortColumn="$emit('newSortColumn', $event)"
             v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
@@ -160,7 +160,7 @@
             v-bind:sortField="ontologySort.field"
             v-bind:sortFieldLabel="scaleClassSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="ontologySort.flag"
+            v-bind:sortOrder="ontologySort.order"
             v-on:newSortColumn="$emit('newSortColumn', $event)"
             v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
@@ -173,7 +173,7 @@
             v-bind:sortField="ontologySort.field"
             v-bind:sortFieldLabel="unitSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="ontologySort.flag"
+            v-bind:sortOrder="ontologySort.order"
             v-on:newSortColumn="$emit('newSortColumn', $event)"
             v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
@@ -390,7 +390,7 @@ export default class OntologyTable extends Vue {
 
     // filter the terms pulled from the back-end
     let filters: TraitFilter[] = [{ field: TraitField.STATUS, value: this.active}];
-
+console.log(this.ontologySort.order);
     TraitService.getFilteredTraits(this.activeProgram!.id!, paginationQuery, true, filters, this.ontologySort).then(([traits, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = traits;

--- a/src/components/program/ProgramLocationsTable.vue
+++ b/src/components/program/ProgramLocationsTable.vue
@@ -100,7 +100,7 @@
       <b-table-column field="data.name" label="Name" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ props.row.data.name }}
       </b-table-column>
-      <b-table-column field="data.numExperiments" label="# Experiments" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="data.numExperiments" label="# Experiments" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ props.row.data.numExperiments }}
       </b-table-column>
       <template v-slot:edit="{editData, validations}">
@@ -149,7 +149,7 @@
     DEACTIVATE_ALL_NOTIFICATIONS
   } from "@/store/mutation-types";
   import {UPDATE_LOCATION_SORT} from "@/store/sorting/mutation-types";
-  import {LocationSort, LocationSortField, SortOrder, UserSort} from "@/breeding-insight/model/Sort";
+  import {LocationSort, LocationSortField, Sort, SortOrder, UserSort} from "@/breeding-insight/model/Sort";
 
 @Component({
   mixins: [validationMixin],
@@ -203,9 +203,8 @@ export default class ProgramLocationsTable extends Vue {
 
   setSort(field: string, order: string) {
     const fieldMap: any = {'data.name': LocationSortField.Name};
-    const orderMap: any = {'asc': SortOrder.Ascending, 'desc': SortOrder.Descending};
-    if (field in fieldMap && order in orderMap) {
-      this.updateSort(new LocationSort(fieldMap[field], orderMap[order]));
+    if (field in fieldMap) {
+      this.updateSort(new LocationSort(fieldMap[field], Sort.orderAsBI(order)));
       this.getLocations();
     }
   }

--- a/src/components/program/ProgramLocationsTable.vue
+++ b/src/components/program/ProgramLocationsTable.vue
@@ -191,7 +191,7 @@ export default class ProgramLocationsTable extends Vue {
   private editLocationFormState: DataFormEventBusHandler = new DataFormEventBusHandler();
 
   private locationSort!: LocationSort;
-  private updateSort!: (field: LocationSortField, order: SortOrder) => void;
+  private updateSort!: (sort: LocationSort) => void;
 
   locationValidations = {
     name: {required}

--- a/src/components/program/ProgramLocationsTable.vue
+++ b/src/components/program/ProgramLocationsTable.vue
@@ -94,7 +94,7 @@
       v-on:paginate-toggle-all="paginationController.toggleShowAll()"
       v-on:paginate-page-size="paginationController.updatePageSize($event)"
       backend-sorting
-      v-bind:default-sort="[locationSortFieldAsBuefy, locationSortOrderAsBuefy]"
+      v-bind:default-sort="['data.name', locationSortOrderAsBuefy]"
       v-on:sort="setSort"
     >
       <b-table-column field="data.name" label="Name" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
@@ -132,7 +132,6 @@
   import WarningModal from '@/components/modals/WarningModal.vue'
   import {PlusCircleIcon} from 'vue-feather-icons'
   import {validationMixin} from 'vuelidate';
-  import {Validations} from 'vuelidate-property-decorators'
   import {required} from 'vuelidate/lib/validators'
   import {ProgramLocation} from '@/breeding-insight/model/ProgramLocation'
   import { mapGetters, mapMutations } from 'vuex'
@@ -163,7 +162,6 @@
     ]),
     ...mapGetters('sorting',[
         'locationSort',
-        'locationSortFieldAsBuefy',
         'locationSortOrderAsBuefy'
     ])
   },

--- a/src/components/program/ProgramLocationsTable.vue
+++ b/src/components/program/ProgramLocationsTable.vue
@@ -149,7 +149,7 @@
     DEACTIVATE_ALL_NOTIFICATIONS
   } from "@/store/mutation-types";
   import {UPDATE_LOCATION_SORT} from "@/store/sorting/mutation-types";
-  import {LocationSortField, SortOrder, UserSort} from "@/breeding-insight/model/Sort";
+  import {LocationSort, LocationSortField, SortOrder, UserSort} from "@/breeding-insight/model/Sort";
 
 @Component({
   mixins: [validationMixin],
@@ -189,6 +189,9 @@ export default class ProgramLocationsTable extends Vue {
 
   private newLocationFormState: DataFormEventBusHandler = new DataFormEventBusHandler();
   private editLocationFormState: DataFormEventBusHandler = new DataFormEventBusHandler();
+
+  private locationSort!: LocationSort;
+  private updateSort!: (field: LocationSortField, order: SortOrder) => void;
 
   locationValidations = {
     name: {required}

--- a/src/components/program/ProgramLocationsTable.vue
+++ b/src/components/program/ProgramLocationsTable.vue
@@ -205,7 +205,7 @@ export default class ProgramLocationsTable extends Vue {
     const fieldMap: any = {'data.name': LocationSortField.Name};
     const orderMap: any = {'asc': SortOrder.Ascending, 'desc': SortOrder.Descending};
     if (field in fieldMap && order in orderMap) {
-      this.updateSort(new UserSort(fieldMap[field], orderMap[order]));
+      this.updateSort(new LocationSort(fieldMap[field], orderMap[order]));
       this.getLocations();
     }
   }

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -191,7 +191,7 @@
   import {DEACTIVATE_ALL_NOTIFICATIONS, LOGIN} from "@/store/mutation-types";
   import {defineAbilityFor} from "@/config/ability";
   import ExpandableTable from '@/components/tables/expandableTable/ExpandableTable.vue';
-  import {SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+  import {Sort, SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
   import {
     UPDATE_PROGRAM_USER_SORT
   } from "@/store/sorting/mutation-types";
@@ -265,9 +265,8 @@ export default class ProgramUsersTable extends Vue {
 
   setSort(field: string, order: string) {
     const fieldMap: any = {'data.email': UserSortField.Email, 'data.name': UserSortField.Name};
-    const orderMap: any = {'asc': SortOrder.Ascending, 'desc': SortOrder.Descending};
-    if (field in fieldMap && order in orderMap) {
-      this.updateSort(new UserSort(fieldMap[field], orderMap[order]));
+    if (field in fieldMap) {
+      this.updateSort(new UserSort(fieldMap[field], Sort.orderAsBI(order)));
       this.getUsers();
     }
   }

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -243,6 +243,9 @@ export default class ProgramUsersTable extends Vue {
   private rolesLoading = true;
   private usersLoading = true;
 
+  private programUserSort!: UserSort;
+  private updateSort!: (field: UserSortField, order: SortOrder) => void;
+
   newUserValidations = {
     name: {required},
     email: {required, email},

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -131,7 +131,7 @@
       <b-table-column field="data.email" label="Email" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ props.row.data.email }}
       </b-table-column>
-      <b-table-column :custom-sort="sortRole" label="Role" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column :custom-sort="sortRole" label="Role" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         <template v-if="rolesMap.size > 0">
           {{ getRoleName(props.row.data.roleId) }}
         </template>

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -191,7 +191,7 @@
   import {DEACTIVATE_ALL_NOTIFICATIONS, LOGIN} from "@/store/mutation-types";
   import {defineAbilityFor} from "@/config/ability";
   import ExpandableTable from '@/components/tables/expandableTable/ExpandableTable.vue';
-  import {Sort, SortOrder, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+  import {Sort, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
   import {
     UPDATE_PROGRAM_USER_SORT
   } from "@/store/sorting/mutation-types";
@@ -224,7 +224,6 @@ export default class ProgramUsersTable extends Vue {
   public users: ProgramUser[] = [];
   public systemUsers: User[] = [];
   private usersPagination?: Pagination = new Pagination();
-  private lastSortState?: SortField = undefined;
 
   private deactivateActive: boolean = false;
   private newUserActive: boolean = false;

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -244,7 +244,7 @@ export default class ProgramUsersTable extends Vue {
   private usersLoading = true;
 
   private programUserSort!: UserSort;
-  private updateSort!: (field: UserSortField, order: SortOrder) => void;
+  private updateSort!: (sort: UserSort) => void;
 
   newUserValidations = {
     name: {required},

--- a/src/components/tables/BaseTable.vue
+++ b/src/components/tables/BaseTable.vue
@@ -44,7 +44,7 @@
                 v-bind:style="{visibility: column.isSortable && column.currentSortField === column.sortLabel ? 'visible' : 'hidden' }"
                 v-on:click="column.toggleSortOrder()"
                 v-bind:class="{ascending: column.order, descending: !column.order}"
-            ><i class="fas fa-chevron-circle-up"></i></span>
+            ><ArrowUpIcon size="1x" aria-hidden="true"></ArrowUpIcon></span>
           </th>
           <!-- Add a header column to match spacing for row controls if specified -->
           <template v-if="showExpandControls">
@@ -68,10 +68,11 @@
   import {TableRow} from "@/breeding-insight/model/view_models/TableRow"
   import TableColumn from "@/components/tables/TableColumn.vue";
   import { VBreakpoint } from '@/components/VBreakpoint';
+  import {ArrowUpIcon} from 'vue-feather-icons';
   import {SortOrder} from "@/breeding-insight/model/Sort";
 
   @Component({
-    components: { VBreakpoint
+    components: { VBreakpoint, ArrowUpIcon
     }
   })
   export default class BaseTable extends Vue {

--- a/src/components/tables/BaseTable.vue
+++ b/src/components/tables/BaseTable.vue
@@ -42,7 +42,6 @@
             <span
                 class="icon sort-control"
                 v-bind:style="{visibility: column.isSortable && column.currentSortField === column.sortLabel ? 'visible' : 'hidden' }"
-                v-on:click="column.toggleSortOrder()"
                 v-bind:class="{ascending: column.order, descending: !column.order}"
             ><ArrowUpIcon size="1x" aria-hidden="true"></ArrowUpIcon></span>
           </th>

--- a/src/components/tables/BaseTable.vue
+++ b/src/components/tables/BaseTable.vue
@@ -34,8 +34,17 @@
                 width: column.width === undefined ? null :
                 (isNaN(column.width) ? column.width : column.width + 'px')
               }"
+              v-bind:class="{activesort: column.isSortable && column.currentSortField === column.sortLabel,
+                             sortcolumn: column.isSortable}"
+              v-on:click="column.changeSortColumn(column.sortLabel)"
           >
             {{ column.label }}
+            <span
+                class="icon sort-control"
+                v-bind:style="{visibility: column.isSortable && column.currentSortField === column.sortLabel ? 'visible' : 'hidden' }"
+                v-on:click="column.toggleSortOrder()"
+                v-bind:class="{ascending: column.order, descending: !column.order}"
+            ><i class="fas fa-chevron-circle-up"></i></span>
           </th>
           <!-- Add a header column to match spacing for row controls if specified -->
           <template v-if="showExpandControls">
@@ -59,6 +68,7 @@
   import {TableRow} from "@/breeding-insight/model/view_models/TableRow"
   import TableColumn from "@/components/tables/TableColumn.vue";
   import { VBreakpoint } from '@/components/VBreakpoint';
+  import {SortOrder} from "@/breeding-insight/model/Sort";
 
   @Component({
     components: { VBreakpoint
@@ -85,6 +95,7 @@
     private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
     private updatedColumns: Array<TableColumn> = [...this.columns];
     private isMobile = false;
+    private orderOptions = SortOrder;
 
     /**
      * Used by TableColumn component to find it's parent BaseTable

--- a/src/components/tables/TableColumn.vue
+++ b/src/components/tables/TableColumn.vue
@@ -44,16 +44,16 @@ import BaseTable from '@/components/tables/BaseTable.vue';
     @Prop([Number, String])
     private width!: number | string | undefined;
 
-    @Prop()
+    @Prop({default: () => ''})
     private sortField: string;
 
-    @Prop()
+    @Prop({default: () => ''})
     private sortFieldLabel: string;
 
-    @Prop()
+    @Prop({default: () => true})
     private sortOrder: boolean;
 
-    @Prop({ default: false })
+    @Prop({default: () => false})
     private sortable: boolean;
 
     private table!: BaseTable;

--- a/src/components/tables/TableColumn.vue
+++ b/src/components/tables/TableColumn.vue
@@ -45,16 +45,16 @@ import BaseTable from '@/components/tables/BaseTable.vue';
     private width!: number | string | undefined;
 
     @Prop({default: () => ''})
-    private sortField: string;
+    private sortField!: string;
 
     @Prop({default: () => ''})
-    private sortFieldLabel: string;
+    private sortFieldLabel!: string;
 
     @Prop({default: () => true})
-    private sortOrder: boolean;
+    private sortOrder!: boolean;
 
     @Prop({default: () => false})
-    private sortable: boolean;
+    private sortable!: boolean;
 
     private table!: BaseTable;
 

--- a/src/components/tables/TableColumn.vue
+++ b/src/components/tables/TableColumn.vue
@@ -27,7 +27,6 @@
 
 import {Component, Prop, Vue} from "vue-property-decorator";
 import BaseTable from '@/components/tables/BaseTable.vue';
-import {SortOrder} from "@/breeding-insight/model/Sort";
 
 @Component({
   })

--- a/src/components/tables/TableColumn.vue
+++ b/src/components/tables/TableColumn.vue
@@ -27,6 +27,7 @@
 
 import {Component, Prop, Vue} from "vue-property-decorator";
 import BaseTable from '@/components/tables/BaseTable.vue';
+import {SortOrder} from "@/breeding-insight/model/Sort";
 
 @Component({
   })
@@ -51,7 +52,7 @@ import BaseTable from '@/components/tables/BaseTable.vue';
     private sortFieldLabel!: string;
 
     @Prop()
-    private sortOrder!: boolean;
+    private sortOrder!: SortOrder;
 
     @Prop()
     private sortable!: boolean;
@@ -87,7 +88,7 @@ import BaseTable from '@/components/tables/BaseTable.vue';
     }
 
     get order() {
-      return this.sortOrder;
+      return this.sortOrder === SortOrder.Ascending;
     }
 
     // any update to column props here will update column in parent table

--- a/src/components/tables/TableColumn.vue
+++ b/src/components/tables/TableColumn.vue
@@ -25,10 +25,11 @@
 
 <script lang="ts">
 
-  import {Component, Prop, Vue} from "vue-property-decorator";
-  import BaseTable from '@/components/tables/BaseTable.vue';
+import {Component, Prop, Vue} from "vue-property-decorator";
+import BaseTable from '@/components/tables/BaseTable.vue';
+import {SortOrder} from "@/breeding-insight/model/Sort";
 
-  @Component({
+@Component({
   })
   export default class TableColumn extends Vue {
 
@@ -44,7 +45,27 @@
     @Prop([Number, String])
     private width!: number | string | undefined;
 
+    @Prop()
+    private sortField: string;
+
+    @Prop()
+    private sortFieldLabel: string;
+
+    @Prop()
+    private sortOrder: boolean;
+
+    @Prop({ default: false })
+    private sortable: boolean;
+
     private table!: BaseTable;
+
+    changeSortColumn(field: string) {
+      this.$emit('newSortColumn', field);
+    }
+
+    toggleSortOrder() {
+      this.$emit('toggleSortOrder');
+    }
 
     get isVisible() {
       return this.visible;
@@ -52,6 +73,22 @@
 
     get newKey() {
       return this.label;
+    }
+
+    get isSortable() {
+      return this.sortable;
+    }
+
+    get currentSortField() {
+      return this.sortField;
+    }
+
+    get sortLabel() {
+      return this.sortFieldLabel;
+    }
+
+    get order() {
+      return this.sortOrder;
     }
 
     // any update to column props here will update column in parent table

--- a/src/components/tables/TableColumn.vue
+++ b/src/components/tables/TableColumn.vue
@@ -44,16 +44,16 @@ import BaseTable from '@/components/tables/BaseTable.vue';
     @Prop([Number, String])
     private width!: number | string | undefined;
 
-    @Prop({default: () => ''})
+    @Prop()
     private sortField!: string;
 
-    @Prop({default: () => ''})
+    @Prop()
     private sortFieldLabel!: string;
 
-    @Prop({default: () => true})
+    @Prop()
     private sortOrder!: boolean;
 
-    @Prop({default: () => false})
+    @Prop()
     private sortable!: boolean;
 
     private table!: BaseTable;

--- a/src/components/tables/TableColumn.vue
+++ b/src/components/tables/TableColumn.vue
@@ -60,11 +60,11 @@ import {SortOrder} from "@/breeding-insight/model/Sort";
     private table!: BaseTable;
 
     changeSortColumn(field: string) {
-      this.$emit('newSortColumn', field);
-    }
-
-    toggleSortOrder() {
-      this.$emit('toggleSortOrder');
+      if (this.sortField === this.sortFieldLabel) {
+        this.$emit('toggleSortOrder');
+      } else {
+        this.$emit('newSortColumn', field);
+      }
     }
 
     get isVisible() {

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -42,7 +42,7 @@
             v-bind:sortField="importPreviewOntologySort.field"
             v-bind:sortFieldLabel="nameSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="importPreviewOntologySort.flag"
+            v-bind:sortOrder="importPreviewOntologySort.order"
             v-on:newSortColumn="newSortColumn"
             v-on:toggleSortOrder="toggleSortOrder"
         >
@@ -64,7 +64,7 @@
             v-bind:sortField="importPreviewOntologySort.field"
             v-bind:sortFieldLabel="methodSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="importPreviewOntologySort.flag"
+            v-bind:sortOrder="importPreviewOntologySort.order"
             v-on:newSortColumn="newSortColumn"
             v-on:toggleSortOrder="toggleSortOrder"
         >
@@ -77,7 +77,7 @@
             v-bind:sortField="importPreviewOntologySort.field"
             v-bind:sortFieldLabel="scaleClassSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="importPreviewOntologySort.flag"
+            v-bind:sortOrder="importPreviewOntologySort.order"
             v-on:newSortColumn="newSortColumn"
             v-on:toggleSortOrder="toggleSortOrder"
         >
@@ -90,7 +90,7 @@
             v-bind:sortField="importPreviewOntologySort.field"
             v-bind:sortFieldLabel="unitSortLabel"
             v-bind:sortable="true"
-            v-bind:sortOrder="importPreviewOntologySort.flag"
+            v-bind:sortOrder="importPreviewOntologySort.order"
             v-on:newSortColumn="newSortColumn"
             v-on:toggleSortOrder="toggleSortOrder"
         >

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -36,7 +36,16 @@
         data: T
       -->
       <template v-slot:columns="data">
-        <TableColumn name="name" v-bind:label="'Name'">
+        <TableColumn
+            name="name"
+            v-bind:label="'Name'"
+            v-bind:sortField="importPreviewOntologySort.field"
+            v-bind:sortFieldLabel="nameSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="importPreviewOntologySort.flag"
+            v-on:newSortColumn="newSortColumn"
+            v-on:toggleSortOrder="toggleSortOrder"
+        >
             <AlertTriangleIcon
                 size="1x"
                 class="has-vertical-align-middle"
@@ -48,13 +57,43 @@
         <TableColumn name="trait" v-bind:label="'Trait'" v-bind:visible="!collapseColumns">
           {{ StringFormatters.toStartCase(data.traitDescription) }}
         </TableColumn>
-        <TableColumn name="method" v-bind:label="'Method'" v-bind:visible="!collapseColumns">
+        <TableColumn
+            name="method"
+            v-bind:label="'Method'"
+            v-bind:visible="!collapseColumns"
+            v-bind:sortField="importPreviewOntologySort.field"
+            v-bind:sortFieldLabel="methodSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="importPreviewOntologySort.flag"
+            v-on:newSortColumn="newSortColumn"
+            v-on:toggleSortOrder="toggleSortOrder"
+        >
           {{ data.method.description + " " + StringFormatters.toStartCase(data.method.methodClass) }}
         </TableColumn>
-        <TableColumn name="scaleClass" v-bind:label="'Scale Class'" v-bind:visible="!collapseColumns">
+        <TableColumn
+            name="scaleClass"
+            v-bind:label="'Scale Class'"
+            v-bind:visible="!collapseColumns"
+            v-bind:sortField="importPreviewOntologySort.field"
+            v-bind:sortFieldLabel="scaleClassSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="importPreviewOntologySort.flag"
+            v-on:newSortColumn="newSortColumn"
+            v-on:toggleSortOrder="toggleSortOrder"
+        >
           {{ TraitStringFormatters.getScaleTypeString(data.scale) }}
         </TableColumn>
-        <TableColumn name="unit" v-bind:label="'Unit'" v-bind:visible="!traitSidePanelState.collapseColumns">
+        <TableColumn
+            name="unit"
+            v-bind:label="'Unit'"
+            v-bind:visible="!traitSidePanelState.collapseColumns"
+            v-bind:sortField="importPreviewOntologySort.field"
+            v-bind:sortFieldLabel="unitSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="importPreviewOntologySort.flag"
+            v-on:newSortColumn="newSortColumn"
+            v-on:toggleSortOrder="toggleSortOrder"
+        >
           <template v-if="data.scale.dataType==='NUMERICAL'">
             {{ data.scale.scaleName }}
           </template>
@@ -97,7 +136,7 @@
   import TraitDetailPanel from "@/components/trait/TraitDetailPanel.vue";
   import TableColumn from "@/components/tables/TableColumn.vue";
   import {Trait} from '@/breeding-insight/model/Trait'
-  import { mapGetters } from 'vuex'
+  import { mapGetters, mapMutations } from 'vuex'
   import {Program} from "@/breeding-insight/model/Program";
   import EmptyTableMessage from "@/components/tables/EmtpyTableMessage.vue";
   import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
@@ -110,19 +149,34 @@
   import {ProgramUpload} from "@/breeding-insight/model/ProgramUpload";
   import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableEventBus";
   import { AlertTriangleIcon } from 'vue-feather-icons';
-  
-@Component({
-  mixins: [validationMixin],
-  components: { TableColumn, SidePanelTable, TraitDetailPanel,
-                PlusCircleIcon, EmptyTableMessage, AlertTriangleIcon
-              },
-  computed: {
-    ...mapGetters([
-      'activeProgram'
-    ]),
-  },
-  data: () => ({StringFormatters, TraitStringFormatters})
-})
+  import {
+    IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN,
+    IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER
+  } from "@/store/sorting/mutation-types";
+  import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
+
+  @Component({
+    mixins: [validationMixin],
+    components: {
+      TableColumn, SidePanelTable, TraitDetailPanel,
+      PlusCircleIcon, EmptyTableMessage, AlertTriangleIcon
+    },
+    computed: {
+      ...mapGetters([
+        'activeProgram'
+      ]),
+      ...mapGetters('sorting', [
+        'importPreviewOntologySort'
+      ])
+    },
+    methods: {
+      ...mapMutations('sorting', {
+        newSortColumn: IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN,
+        toggleSortOrder: IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER
+      })
+    },
+    data: () => ({StringFormatters, TraitStringFormatters})
+  })
 export default class TraitsImportTable extends Vue {
 
   private activeProgram?: Program;
@@ -133,19 +187,29 @@ export default class TraitsImportTable extends Vue {
   private loaded = false;
   private collapseColumns = false;
   private traitSidePanelState: SidePanelTableEventBusHandler = new SidePanelTableEventBusHandler();
+  private importPreviewOntologySort!: OntologySort;
+  private newSortColumn!: (field: OntologySortField) => void;
+  private toggleSortOrder!: () => void;
+
+  // table column sorting
+  private nameSortLabel: string = OntologySortField.Name;
+  private methodSortLabel: string = OntologySortField.MethodDescription;
+  private scaleClassSortLabel: string = OntologySortField.ScaleClass;
+  private unitSortLabel: string = OntologySortField.ScaleName;
 
   mounted() {
     this.getTraitUpload();
   }
 
   @Watch('paginationController', { deep: true})
+  @Watch('importPreviewOntologySort', {deep: true})
   getTraitUpload() {
 
     let paginationQuery: PaginationQuery = PaginationController.getPaginationSelections(
       this.paginationController.currentPage, this.paginationController.pageSize, this.paginationController.showAll);
     this.paginationController.setCurrentCall(paginationQuery);
 
-    TraitUploadService.getTraits(this.activeProgram!.id!, paginationQuery).then(([upload, metadata]) => {
+    TraitUploadService.getTraits(this.activeProgram!.id!, paginationQuery, this.importPreviewOntologySort).then(([upload, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = upload.data || [];
         this.traitsPagination = metadata.pagination;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -20,6 +20,7 @@ import Vuex, { StoreOptions } from 'vuex';
 import { RootState } from './types';
 import { mutations } from './mutations';
 import {actions} from './actions';
+import {sorting} from '@/store/sorting/index';
 
 Vue.use(Vuex);
 
@@ -43,6 +44,9 @@ const store: StoreOptions<RootState> = {
     warningNotificationActive: false,
     warningNotificationMsg: '',
     showSidebarMobile: true
+  },
+  modules: {
+    sorting
   },
   mutations,
   actions,

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -27,6 +27,8 @@ import {
     UserSortField
 } from "@/breeding-insight/model/Sort";
 
+const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
+
 export const getters: GetterTree<SortState, RootState> = {
     // active ontology table
     activeTraitSortField(state: SortState): TraitSortField {
@@ -71,7 +73,6 @@ export const getters: GetterTree<SortState, RootState> = {
         return fieldMap[state.programUserSort.field];
     },
     programUserSortOrderAsBuefy(state: SortState): string {
-        const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
         return orderMap[state.programUserSort.order];
     },
 
@@ -80,7 +81,6 @@ export const getters: GetterTree<SortState, RootState> = {
         return state.locationSort;
     },
     locationSortOrderAsBuefy(state: SortState): string {
-        const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
         return orderMap[state.locationSort.order];
     }
 };

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -18,7 +18,14 @@
 import {GetterTree} from 'vuex';
 import {RootState} from "@/store/types";
 import {SortState} from "@/store/sorting/types";
-import {SortOrder, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+import {
+    LocationSort,
+    LocationSortField,
+    SortOrder,
+    TraitSortField,
+    UserSort,
+    UserSortField
+} from "@/breeding-insight/model/Sort";
 
 export const getters: GetterTree<SortState, RootState> = {
     // active ontology table
@@ -66,5 +73,18 @@ export const getters: GetterTree<SortState, RootState> = {
     programUserSortOrderAsBuefy(state: SortState): string {
         const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
         return orderMap[state.programUserSort.order];
+    },
+
+    // location table
+    locationSort(state: SortState): LocationSort {
+        return state.locationSort;
+    },
+    locationSortFieldAsBuefy(state: SortState): string {
+        const fieldMap: any = {[LocationSortField.Name]: 'data.name'};
+        return fieldMap[state.locationSort.field];
+    },
+    locationSortOrderAsBuefy(state: SortState): string {
+        const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
+        return orderMap[state.locationSort.order];
     }
 };

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -1,0 +1,39 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {GetterTree} from 'vuex';
+import {RootState} from "@/store/types";
+import {SortState} from "@/store/sorting/types";
+import {TraitSortField} from "@/breeding-insight/model/Sort";
+
+export const getters: GetterTree<SortState, RootState> = {
+    traitSortField(state: SortState): TraitSortField {
+        return state.traitSortField;
+    },
+    nameSortOrder(state: SortState): boolean {
+        return state.nameSortOrder;
+    },
+    methodSortOrder(state: SortState): boolean {
+        return state.methodSortOrder;
+    },
+    scaleClassSortOrder(state: SortState): boolean {
+        return state.scaleClassSortOrder;
+    },
+    unitSortOrder(state: SortState): boolean {
+        return state.unitSortOrder;
+    }
+};

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -48,6 +48,14 @@ export const getters: GetterTree<SortState, RootState> = {
         return state.archivedOntologySort.flag ? SortOrder.Ascending : SortOrder.Descending;
     },
 
+    // archived ontology table
+    importPreviewOntologySort(state: SortState): OntologySort {
+        return state.importPreviewOntologySort;
+    },
+    importPreviewOntologySortOrder(state: SortState): SortOrder {
+        return state.importPreviewOntologySort.flag ? SortOrder.Ascending : SortOrder.Descending;
+    },
+
     // program user table
     programUserSort(state: SortState): UserSort {
         return state.programUserSort;

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -41,20 +41,11 @@ export const getters: GetterTree<SortState, RootState> = {
     },
 
     // archived ontology table
-    archivedTraitSortField(state: SortState): TraitSortField {
-        return state.archivedTraitSortField;
+    archivedOntologySort(state: SortState): OntologySort {
+        return state.archivedOntologySort;
     },
-    archivedOntNameSortOrder(state: SortState): boolean {
-        return state.archivedOntNameSortOrder;
-    },
-    archivedOntMethodSortOrder(state: SortState): boolean {
-        return state.archivedOntMethodSortOrder;
-    },
-    archivedOntScaleClassSortOrder(state: SortState): boolean {
-        return state.archivedOntScaleClassSortOrder;
-    },
-    archivedOntUnitSortOrder(state: SortState): boolean {
-        return state.archivedOntUnitSortOrder;
+    archivedOntologySortOrder(state: SortState): SortOrder {
+        return state.archivedOntologySort.flag ? SortOrder.Ascending : SortOrder.Descending;
     },
 
     // program user table

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -21,19 +21,37 @@ import {SortState} from "@/store/sorting/types";
 import {TraitSortField} from "@/breeding-insight/model/Sort";
 
 export const getters: GetterTree<SortState, RootState> = {
-    traitSortField(state: SortState): TraitSortField {
-        return state.traitSortField;
+    // active ontology table
+    activeTraitSortField(state: SortState): TraitSortField {
+        return state.activeTraitSortField;
     },
-    nameSortOrder(state: SortState): boolean {
-        return state.nameSortOrder;
+    activeOntNameSortOrder(state: SortState): boolean {
+        return state.activeOntNameSortOrder;
     },
-    methodSortOrder(state: SortState): boolean {
-        return state.methodSortOrder;
+    activeOntMethodSortOrder(state: SortState): boolean {
+        return state.activeOntMethodSortOrder;
     },
-    scaleClassSortOrder(state: SortState): boolean {
-        return state.scaleClassSortOrder;
+    activeOntScaleClassSortOrder(state: SortState): boolean {
+        return state.activeOntScaleClassSortOrder;
     },
-    unitSortOrder(state: SortState): boolean {
-        return state.unitSortOrder;
+    activeOntUnitSortOrder(state: SortState): boolean {
+        return state.activeOntUnitSortOrder;
+    },
+
+    // archived ontology table
+    archivedTraitSortField(state: SortState): TraitSortField {
+        return state.archivedTraitSortField;
+    },
+    archivedOntNameSortOrder(state: SortState): boolean {
+        return state.archivedOntNameSortOrder;
+    },
+    archivedOntMethodSortOrder(state: SortState): boolean {
+        return state.archivedOntMethodSortOrder;
+    },
+    archivedOntScaleClassSortOrder(state: SortState): boolean {
+        return state.archivedOntScaleClassSortOrder;
+    },
+    archivedOntUnitSortOrder(state: SortState): boolean {
+        return state.archivedOntUnitSortOrder;
     }
 };

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -19,7 +19,7 @@ import {GetterTree} from 'vuex';
 import {RootState} from "@/store/types";
 import {SortState} from "@/store/sorting/types";
 import {
-    LocationSort,
+    LocationSort, OntologySort,
     ProgramSort,
     ProgramSortField,
     SortOrder,
@@ -33,20 +33,11 @@ const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'de
 export const getters: GetterTree<SortState, RootState> = {
 
     // active ontology table
-    activeTraitSortField(state: SortState): TraitSortField {
-        return state.activeTraitSortField;
+    activeOntologySort(state: SortState): OntologySort {
+        return state.activeOntologySort;
     },
-    activeOntNameSortOrder(state: SortState): boolean {
-        return state.activeOntNameSortOrder;
-    },
-    activeOntMethodSortOrder(state: SortState): boolean {
-        return state.activeOntMethodSortOrder;
-    },
-    activeOntScaleClassSortOrder(state: SortState): boolean {
-        return state.activeOntScaleClassSortOrder;
-    },
-    activeOntUnitSortOrder(state: SortState): boolean {
-        return state.activeOntUnitSortOrder;
+    activeOntologySortOrder(state: SortState): SortOrder {
+      return state.activeOntologySort.flag ? SortOrder.Ascending : SortOrder.Descending;
     },
 
     // archived ontology table

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -79,10 +79,6 @@ export const getters: GetterTree<SortState, RootState> = {
     locationSort(state: SortState): LocationSort {
         return state.locationSort;
     },
-    locationSortFieldAsBuefy(state: SortState): string {
-        const fieldMap: any = {[LocationSortField.Name]: 'data.name'};
-        return fieldMap[state.locationSort.field];
-    },
     locationSortOrderAsBuefy(state: SortState): string {
         const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
         return orderMap[state.locationSort.order];

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -20,7 +20,8 @@ import {RootState} from "@/store/types";
 import {SortState} from "@/store/sorting/types";
 import {
     LocationSort,
-    LocationSortField, ProgramSort, ProgramSortField,
+    ProgramSort,
+    ProgramSortField,
     SortOrder,
     TraitSortField,
     UserSort,
@@ -30,6 +31,7 @@ import {
 const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
 
 export const getters: GetterTree<SortState, RootState> = {
+
     // active ontology table
     activeTraitSortField(state: SortState): TraitSortField {
         return state.activeTraitSortField;

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -37,7 +37,7 @@ export const getters: GetterTree<SortState, RootState> = {
         return state.activeOntologySort;
     },
     activeOntologySortOrder(state: SortState): SortOrder {
-      return state.activeOntologySort.flag ? SortOrder.Ascending : SortOrder.Descending;
+      return state.activeOntologySort.order;
     },
 
     // archived ontology table
@@ -45,7 +45,7 @@ export const getters: GetterTree<SortState, RootState> = {
         return state.archivedOntologySort;
     },
     archivedOntologySortOrder(state: SortState): SortOrder {
-        return state.archivedOntologySort.flag ? SortOrder.Ascending : SortOrder.Descending;
+        return state.archivedOntologySort.order;
     },
 
     // archived ontology table
@@ -53,7 +53,7 @@ export const getters: GetterTree<SortState, RootState> = {
         return state.importPreviewOntologySort;
     },
     importPreviewOntologySortOrder(state: SortState): SortOrder {
-        return state.importPreviewOntologySort.flag ? SortOrder.Ascending : SortOrder.Descending;
+        return state.importPreviewOntologySort.order;
     },
 
     // program user table

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -18,7 +18,7 @@
 import {GetterTree} from 'vuex';
 import {RootState} from "@/store/types";
 import {SortState} from "@/store/sorting/types";
-import {TraitSortField} from "@/breeding-insight/model/Sort";
+import {SortOrder, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
 export const getters: GetterTree<SortState, RootState> = {
     // active ontology table
@@ -53,5 +53,18 @@ export const getters: GetterTree<SortState, RootState> = {
     },
     archivedOntUnitSortOrder(state: SortState): boolean {
         return state.archivedOntUnitSortOrder;
+    },
+
+    // program user table
+    programUserSort(state: SortState): UserSort {
+        return state.programUserSort;
+    },
+    programUserSortFieldAsBuefy(state: SortState): string {
+        const fieldMap: any = {[UserSortField.Email]: 'data.email', [UserSortField.Name]: 'data.name'};
+        return fieldMap[state.programUserSort.field];
+    },
+    programUserSortOrderAsBuefy(state: SortState): string {
+        const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
+        return orderMap[state.programUserSort.order];
     }
 };

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -20,7 +20,7 @@ import {RootState} from "@/store/types";
 import {SortState} from "@/store/sorting/types";
 import {
     LocationSort,
-    LocationSortField,
+    LocationSortField, ProgramSort, ProgramSortField,
     SortOrder,
     TraitSortField,
     UserSort,
@@ -82,5 +82,37 @@ export const getters: GetterTree<SortState, RootState> = {
     },
     locationSortOrderAsBuefy(state: SortState): string {
         return orderMap[state.locationSort.order];
+    },
+
+    // system user table
+    systemUserSort(state: SortState): UserSort {
+        return state.systemUserSort;
+    },
+    systemUserSortFieldAsBuefy(state: SortState): string {
+        const fieldMap: any = {
+            [UserSortField.Email]: 'data.email',
+            [UserSortField.Name]: 'data.name'
+        };
+        return fieldMap[state.systemUserSort.field];
+    },
+    systemUserSortOrderAsBuefy(state: SortState): string {
+        return orderMap[state.systemUserSort.order];
+    },
+
+    // program table
+    programSort(state: SortState): ProgramSort {
+        return state.programSort;
+    },
+    programSortFieldAsBuefy(state: SortState): string {
+        const fieldMap: any = {
+            [ProgramSortField.Name]: 'data.name',
+            [ProgramSortField.SpeciesName]: 'data.species',
+            [ProgramSortField.NumUsers]: 'data.numUsers',
+            [ProgramSortField.BrapiUrl]: 'data.brapiUrl'
+        };
+        return fieldMap[state.programSort.field];
+    },
+    programSortOrderAsBuefy(state: SortState): string {
+        return orderMap[state.programSort.order];
     }
 };

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -35,13 +35,13 @@ import {SortState} from "@/store/sorting/types";
 export let state: SortState;
 state = {
     // active ontology table
-    activeOntologySort: new OntologySort(OntologySortField.Name, true),
+    activeOntologySort: new OntologySort(OntologySortField.Name, SortOrder.Ascending),
 
     // archived ontology table
-    archivedOntologySort: new OntologySort(OntologySortField.Name, true),
+    archivedOntologySort: new OntologySort(OntologySortField.Name, SortOrder.Ascending),
 
     // import preview ontology table
-    importPreviewOntologySort: new OntologySort(OntologySortField.Name, true),
+    importPreviewOntologySort: new OntologySort(OntologySortField.Name, SortOrder.Ascending),
 
     // program user table
     programUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending),

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -39,12 +39,7 @@ state = {
     activeOntologySort: new OntologySort(OntologySortField.Name, true),
 
     // archived ontology table
-    archivedOntologySort: new OntologySort(OntologySortField.Name, SortOrder.Ascending),
-    archivedTraitSortField: TraitSortField.Name,
-    archivedOntNameSortOrder: true,
-    archivedOntMethodSortOrder: true,
-    archivedOntScaleClassSortOrder: true,
-    archivedOntUnitSortOrder: true,
+    archivedOntologySort: new OntologySort(OntologySortField.Name, true),
 
     // program user table
     programUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending),

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -1,0 +1,41 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Module} from 'vuex';
+import {getters} from '@/store/sorting/getters';
+import {mutations} from '@/store/sorting/mutations';
+import {RootState} from '@/store/types';
+import {TraitSortField} from "@/breeding-insight/model/Sort";
+import {SortState} from "@/store/sorting/types";
+
+export const state: SortState = {
+    // ontology table
+    traitSortField: TraitSortField.Name,
+    nameSortOrder: true,
+    methodSortOrder: true,
+    scaleClassSortOrder: true,
+    unitSortOrder: true
+};
+
+const namespaced: boolean = true
+
+export const sorting: Module<SortState, RootState> = {
+    namespaced,
+    state,
+    getters,
+    mutations
+};

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -23,12 +23,19 @@ import {TraitSortField} from "@/breeding-insight/model/Sort";
 import {SortState} from "@/store/sorting/types";
 
 export const state: SortState = {
-    // ontology table
-    traitSortField: TraitSortField.Name,
-    nameSortOrder: true,
-    methodSortOrder: true,
-    scaleClassSortOrder: true,
-    unitSortOrder: true
+    // active ontology table
+    activeTraitSortField: TraitSortField.Name,
+    activeOntNameSortOrder: true,
+    activeOntMethodSortOrder: true,
+    activeOntScaleClassSortOrder: true,
+    activeOntUnitSortOrder: true,
+
+    // archived ontology table
+    archivedTraitSortField: TraitSortField.Name,
+    archivedOntNameSortOrder: true,
+    archivedOntMethodSortOrder: true,
+    archivedOntScaleClassSortOrder: true,
+    archivedOntUnitSortOrder: true
 };
 
 const namespaced: boolean = true

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -22,6 +22,8 @@ import {RootState} from '@/store/types';
 import {
     LocationSort,
     LocationSortField,
+    OntologySort,
+    OntologySortField,
     ProgramSort,
     ProgramSortField,
     SortOrder,
@@ -34,13 +36,10 @@ import {SortState} from "@/store/sorting/types";
 export let state: SortState;
 state = {
     // active ontology table
-    activeTraitSortField: TraitSortField.Name,
-    activeOntNameSortOrder: true,
-    activeOntMethodSortOrder: true,
-    activeOntScaleClassSortOrder: true,
-    activeOntUnitSortOrder: true,
+    activeOntologySort: new OntologySort(OntologySortField.Name, true),
 
     // archived ontology table
+    archivedOntologySort: new OntologySort(OntologySortField.Name, SortOrder.Ascending),
     archivedTraitSortField: TraitSortField.Name,
     archivedOntNameSortOrder: true,
     archivedOntMethodSortOrder: true,

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -19,10 +19,11 @@ import {Module} from 'vuex';
 import {getters} from '@/store/sorting/getters';
 import {mutations} from '@/store/sorting/mutations';
 import {RootState} from '@/store/types';
-import {TraitSortField} from "@/breeding-insight/model/Sort";
+import {SortOrder, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 import {SortState} from "@/store/sorting/types";
 
-export const state: SortState = {
+export let state: SortState;
+state = {
     // active ontology table
     activeTraitSortField: TraitSortField.Name,
     activeOntNameSortOrder: true,
@@ -35,7 +36,10 @@ export const state: SortState = {
     archivedOntNameSortOrder: true,
     archivedOntMethodSortOrder: true,
     archivedOntScaleClassSortOrder: true,
-    archivedOntUnitSortOrder: true
+    archivedOntUnitSortOrder: true,
+
+    // program user table
+    programUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending)
 };
 
 const namespaced: boolean = true

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -19,7 +19,14 @@ import {Module} from 'vuex';
 import {getters} from '@/store/sorting/getters';
 import {mutations} from '@/store/sorting/mutations';
 import {RootState} from '@/store/types';
-import {SortOrder, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+import {
+    LocationSort,
+    LocationSortField,
+    SortOrder,
+    TraitSortField,
+    UserSort,
+    UserSortField
+} from "@/breeding-insight/model/Sort";
 import {SortState} from "@/store/sorting/types";
 
 export let state: SortState;
@@ -39,7 +46,10 @@ state = {
     archivedOntUnitSortOrder: true,
 
     // program user table
-    programUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending)
+    programUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending),
+
+    // location table
+    locationSort: new LocationSort(LocationSortField.Name, SortOrder.Ascending)
 };
 
 const namespaced: boolean = true

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -22,6 +22,8 @@ import {RootState} from '@/store/types';
 import {
     LocationSort,
     LocationSortField,
+    ProgramSort,
+    ProgramSortField,
     SortOrder,
     TraitSortField,
     UserSort,
@@ -49,7 +51,13 @@ state = {
     programUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending),
 
     // location table
-    locationSort: new LocationSort(LocationSortField.Name, SortOrder.Ascending)
+    locationSort: new LocationSort(LocationSortField.Name, SortOrder.Ascending),
+
+    // system user table
+    systemUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending),
+
+    // program table
+    programSort: new ProgramSort(ProgramSortField.Name, SortOrder.Ascending)
 };
 
 const namespaced: boolean = true

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -27,7 +27,6 @@ import {
     ProgramSort,
     ProgramSortField,
     SortOrder,
-    TraitSortField,
     UserSort,
     UserSortField
 } from "@/breeding-insight/model/Sort";
@@ -40,6 +39,9 @@ state = {
 
     // archived ontology table
     archivedOntologySort: new OntologySort(OntologySortField.Name, true),
+
+    // import preview ontology table
+    importPreviewOntologySort: new OntologySort(OntologySortField.Name, true),
 
     // program user table
     programUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending),

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -15,8 +15,16 @@
  * limitations under the License.
  */
 
-export const NEW_SORT_COLUMN = 'newSortColumn';
-export const TOGGLE_NAME_SORT_ORDER = 'toggleNameSortOrder';
-export const TOGGLE_METHOD_SORT_ORDER = 'toggleMethodSortOrder';
-export const TOGGLE_SCALE_CLASS_SORT_ORDER = 'toggleScaleClassSortOrder';
-export const TOGGLE_UNIT_SORT_ORDER = 'toggleUnitSortOrder';
+// active ontology table
+export const ACTIVE_ONT_NEW_SORT_COLUMN = 'activeOntNewSortColumn';
+export const ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER = 'activeOntToggleNameSortOrder';
+export const ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER = 'activeOntToggleMethodSortOrder';
+export const ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER = 'activeOntToggleScaleClassSortOrder';
+export const ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER = 'activeOntToggleUnitSortOrder';
+
+// archived ontology table
+export const ARCHIVED_ONT_NEW_SORT_COLUMN = 'archivedOntNewSortColumn';
+export const ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER = 'archivedOntToggleNameSortOrder';
+export const ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER = 'archivedOntToggleMethodSortOrder';
+export const ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER = 'archivedOntToggleScaleClassSortOrder';
+export const ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER = 'archivedOntToggleUnitSortOrder';

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -23,6 +23,10 @@ export const ACTIVE_ONT_TOGGLE_SORT_ORDER = 'activeOntToggleSortOrder';
 export const ARCHIVED_ONT_NEW_SORT_COLUMN = 'archivedOntNewSortColumn';
 export const ARCHIVED_ONT_TOGGLE_SORT_ORDER = 'archivedOntToggleSortOrder';
 
+// importPreview ontology table
+export const IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN = 'importPreviewOntNewSortColumn';
+export const IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER = 'importPreviewOntToggleSortOrder';
+
 // program users table
 export const UPDATE_PROGRAM_USER_SORT = 'updateProgramUserSort';
 

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -31,3 +31,6 @@ export const ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER = 'archivedOntToggleUnitSortOrd
 
 // program users table
 export const UPDATE_PROGRAM_USER_SORT = 'updateProgramUserSort';
+
+// location table
+export const UPDATE_LOCATION_SORT = 'updateLocationSort';

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -17,12 +17,10 @@
 
 // active ontology table
 export const ACTIVE_ONT_NEW_SORT_COLUMN = 'activeOntNewSortColumn';
-export const ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER = 'activeOntToggleNameSortOrder';
-export const ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER = 'activeOntToggleMethodSortOrder';
-export const ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER = 'activeOntToggleScaleClassSortOrder';
-export const ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER = 'activeOntToggleUnitSortOrder';
+export const ACTIVE_ONT_TOGGLE_SORT_ORDER = 'activeOntToggleNameSortOrder';
 
 // archived ontology table
+export const UPDATE_ARCHIVED_ONT_SORT = 'updateArchivedOntologySort';
 export const ARCHIVED_ONT_NEW_SORT_COLUMN = 'archivedOntNewSortColumn';
 export const ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER = 'archivedOntToggleNameSortOrder';
 export const ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER = 'archivedOntToggleMethodSortOrder';

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -28,3 +28,6 @@ export const ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER = 'archivedOntToggleNameSortOrd
 export const ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER = 'archivedOntToggleMethodSortOrder';
 export const ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER = 'archivedOntToggleScaleClassSortOrder';
 export const ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER = 'archivedOntToggleUnitSortOrder';
+
+// program users table
+export const UPDATE_PROGRAM_USER_SORT = 'updateProgramUserSort';

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -17,15 +17,11 @@
 
 // active ontology table
 export const ACTIVE_ONT_NEW_SORT_COLUMN = 'activeOntNewSortColumn';
-export const ACTIVE_ONT_TOGGLE_SORT_ORDER = 'activeOntToggleNameSortOrder';
+export const ACTIVE_ONT_TOGGLE_SORT_ORDER = 'activeOntToggleSortOrder';
 
 // archived ontology table
-export const UPDATE_ARCHIVED_ONT_SORT = 'updateArchivedOntologySort';
 export const ARCHIVED_ONT_NEW_SORT_COLUMN = 'archivedOntNewSortColumn';
-export const ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER = 'archivedOntToggleNameSortOrder';
-export const ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER = 'archivedOntToggleMethodSortOrder';
-export const ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER = 'archivedOntToggleScaleClassSortOrder';
-export const ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER = 'archivedOntToggleUnitSortOrder';
+export const ARCHIVED_ONT_TOGGLE_SORT_ORDER = 'archivedOntToggleSortOrder';
 
 // program users table
 export const UPDATE_PROGRAM_USER_SORT = 'updateProgramUserSort';

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -34,3 +34,9 @@ export const UPDATE_PROGRAM_USER_SORT = 'updateProgramUserSort';
 
 // location table
 export const UPDATE_LOCATION_SORT = 'updateLocationSort';
+
+// system users table
+export const UPDATE_SYSTEM_USER_SORT = 'updateSystemUserSort';
+
+// program table
+export const UPDATE_PROGRAM_SORT = 'updateProgramSort'

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -1,0 +1,22 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const NEW_SORT_COLUMN = 'newSortColumn';
+export const TOGGLE_NAME_SORT_ORDER = 'toggleNameSortOrder';
+export const TOGGLE_METHOD_SORT_ORDER = 'toggleMethodSortOrder';
+export const TOGGLE_SCALE_CLASS_SORT_ORDER = 'toggleScaleClassSortOrder';
+export const TOGGLE_UNIT_SORT_ORDER = 'toggleUnitSortOrder';

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -18,16 +18,12 @@
 import {MutationTree} from 'vuex';
 import {
     ARCHIVED_ONT_NEW_SORT_COLUMN,
-    ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER,
-    ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER,
-    ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
-    ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER,
     ACTIVE_ONT_NEW_SORT_COLUMN,
     UPDATE_PROGRAM_USER_SORT,
     UPDATE_LOCATION_SORT,
     UPDATE_SYSTEM_USER_SORT,
     UPDATE_PROGRAM_SORT,
-    UPDATE_ARCHIVED_ONT_SORT, ACTIVE_ONT_TOGGLE_SORT_ORDER
+    ACTIVE_ONT_TOGGLE_SORT_ORDER, ARCHIVED_ONT_TOGGLE_SORT_ORDER
 } from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
 import {
@@ -47,24 +43,11 @@ export const mutations: MutationTree<SortState> = {
     },
 
     // archived ontology table
-    [UPDATE_ARCHIVED_ONT_SORT](state: SortState, sort: OntologySort) {
-        state.archivedOntologySort.field = sort.field;
-        state.archivedOntologySort.order = sort.order;
+    [ARCHIVED_ONT_TOGGLE_SORT_ORDER](state: SortState) {
+        state.archivedOntologySort.flag = !state.archivedOntologySort.flag;
     },
-    [ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER](state: SortState) {
-        state.archivedOntNameSortOrder = !state.archivedOntNameSortOrder;
-    },
-    [ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER](state: SortState) {
-        state.archivedOntMethodSortOrder = !state.archivedOntMethodSortOrder;
-    },
-    [ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER](state: SortState) {
-        state.archivedOntScaleClassSortOrder = !state.archivedOntScaleClassSortOrder;
-    },
-    [ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER](state: SortState) {
-        state.archivedOntUnitSortOrder = !state.archivedOntUnitSortOrder;
-    },
-    [ARCHIVED_ONT_NEW_SORT_COLUMN](state: SortState, field: TraitSortField) {
-        state.archivedTraitSortField = field;
+    [ARCHIVED_ONT_NEW_SORT_COLUMN](state: SortState, field: OntologySortField) {
+        state.archivedOntologySort.field = field;
     },
 
     //program user table

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -27,10 +27,17 @@ import {
     ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
     ACTIVE_ONT_NEW_SORT_COLUMN,
     ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER,
-    UPDATE_PROGRAM_USER_SORT, UPDATE_LOCATION_SORT
+    UPDATE_PROGRAM_USER_SORT, UPDATE_LOCATION_SORT, UPDATE_SYSTEM_USER_SORT, UPDATE_PROGRAM_SORT
 } from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
-import {LocationSort, SortOrder, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+import {
+    LocationSort,
+    ProgramSort,
+    SortOrder,
+    TraitSortField,
+    UserSort,
+    UserSortField
+} from "@/breeding-insight/model/Sort";
 
 export const mutations: MutationTree<SortState> = {
     // active ontology table
@@ -77,6 +84,17 @@ export const mutations: MutationTree<SortState> = {
     [UPDATE_LOCATION_SORT](state: SortState, sort: LocationSort) {
         state.locationSort.field = sort.field;
         state.locationSort.order = sort.order;
-    }
+    },
 
+    //system user table
+    [UPDATE_SYSTEM_USER_SORT](state: SortState, sort: UserSort) {
+        state.systemUserSort.field = sort.field;
+        state.systemUserSort.order = sort.order;
+    },
+
+    //program table
+    [UPDATE_PROGRAM_SORT](state: SortState, sort: ProgramSort) {
+        state.programSort.field = sort.field;
+        state.programSort.order = sort.order;
+    }
 };

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -1,0 +1,43 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MutationTree} from 'vuex';
+import {NEW_SORT_COLUMN,
+    TOGGLE_NAME_SORT_ORDER,
+    TOGGLE_METHOD_SORT_ORDER,
+    TOGGLE_SCALE_CLASS_SORT_ORDER,
+    TOGGLE_UNIT_SORT_ORDER} from "@/store/sorting/mutation-types";
+import {SortState} from "@/store/sorting/types";
+import {TraitSortField} from "@/breeding-insight/model/Sort";
+
+export const mutations: MutationTree<SortState> = {
+    [TOGGLE_NAME_SORT_ORDER](state: SortState) {
+        state.nameSortOrder = !state.nameSortOrder;
+    },
+    [TOGGLE_METHOD_SORT_ORDER](state: SortState) {
+        state.methodSortOrder = !state.methodSortOrder;
+    },
+    [TOGGLE_SCALE_CLASS_SORT_ORDER](state: SortState) {
+        state.scaleClassSortOrder = !state.scaleClassSortOrder;
+    },
+    [TOGGLE_UNIT_SORT_ORDER](state: SortState) {
+        state.unitSortOrder = !state.unitSortOrder;
+    },
+    [NEW_SORT_COLUMN](state: SortState, field: TraitSortField) {
+        state.traitSortField = field;
+    }
+};

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -27,10 +27,10 @@ import {
     ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
     ACTIVE_ONT_NEW_SORT_COLUMN,
     ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER,
-    UPDATE_PROGRAM_USER_SORT
+    UPDATE_PROGRAM_USER_SORT, UPDATE_LOCATION_SORT
 } from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
-import {SortOrder, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+import {LocationSort, SortOrder, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
 export const mutations: MutationTree<SortState> = {
     // active ontology table
@@ -71,6 +71,12 @@ export const mutations: MutationTree<SortState> = {
     [UPDATE_PROGRAM_USER_SORT](state: SortState, sort: UserSort) {
         state.programUserSort.field = sort.field;
         state.programUserSort.order = sort.order;
+    },
+
+    //location table
+    [UPDATE_LOCATION_SORT](state: SortState, sort: LocationSort) {
+        state.locationSort.field = sort.field;
+        state.locationSort.order = sort.order;
     }
 
 };

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -16,28 +16,51 @@
  */
 
 import {MutationTree} from 'vuex';
-import {NEW_SORT_COLUMN,
-    TOGGLE_NAME_SORT_ORDER,
-    TOGGLE_METHOD_SORT_ORDER,
-    TOGGLE_SCALE_CLASS_SORT_ORDER,
-    TOGGLE_UNIT_SORT_ORDER} from "@/store/sorting/mutation-types";
+import {
+    ARCHIVED_ONT_NEW_SORT_COLUMN,
+    ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER,
+    ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER,
+    ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
+    ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER,
+    ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER,
+    ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER,
+    ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER, ACTIVE_ONT_NEW_SORT_COLUMN, ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER
+} from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
 import {TraitSortField} from "@/breeding-insight/model/Sort";
 
 export const mutations: MutationTree<SortState> = {
-    [TOGGLE_NAME_SORT_ORDER](state: SortState) {
-        state.nameSortOrder = !state.nameSortOrder;
+    // active ontology table
+    [ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER](state: SortState) {
+        state.activeOntNameSortOrder = !state.activeOntNameSortOrder;
     },
-    [TOGGLE_METHOD_SORT_ORDER](state: SortState) {
-        state.methodSortOrder = !state.methodSortOrder;
+    [ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER](state: SortState) {
+        state.activeOntMethodSortOrder = !state.activeOntMethodSortOrder;
     },
-    [TOGGLE_SCALE_CLASS_SORT_ORDER](state: SortState) {
-        state.scaleClassSortOrder = !state.scaleClassSortOrder;
+    [ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER](state: SortState) {
+        state.activeOntScaleClassSortOrder = !state.activeOntScaleClassSortOrder;
     },
-    [TOGGLE_UNIT_SORT_ORDER](state: SortState) {
-        state.unitSortOrder = !state.unitSortOrder;
+    [ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER](state: SortState) {
+        state.activeOntUnitSortOrder = !state.activeOntUnitSortOrder;
     },
-    [NEW_SORT_COLUMN](state: SortState, field: TraitSortField) {
-        state.traitSortField = field;
+    [ACTIVE_ONT_NEW_SORT_COLUMN](state: SortState, field: TraitSortField) {
+        state.activeTraitSortField = field;
+    },
+
+    // archived ontology table
+    [ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER](state: SortState) {
+        state.archivedOntNameSortOrder = !state.archivedOntNameSortOrder;
+    },
+    [ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER](state: SortState) {
+        state.archivedOntMethodSortOrder = !state.archivedOntMethodSortOrder;
+    },
+    [ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER](state: SortState) {
+        state.archivedOntScaleClassSortOrder = !state.archivedOntScaleClassSortOrder;
+    },
+    [ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER](state: SortState) {
+        state.archivedOntUnitSortOrder = !state.archivedOntUnitSortOrder;
+    },
+    [ARCHIVED_ONT_NEW_SORT_COLUMN](state: SortState, field: TraitSortField) {
+        state.archivedTraitSortField = field;
     }
 };

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -22,42 +22,35 @@ import {
     ARCHIVED_ONT_TOGGLE_METHOD_SORT_ORDER,
     ARCHIVED_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
     ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER,
-    ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER,
-    ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER,
-    ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
     ACTIVE_ONT_NEW_SORT_COLUMN,
-    ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER,
-    UPDATE_PROGRAM_USER_SORT, UPDATE_LOCATION_SORT, UPDATE_SYSTEM_USER_SORT, UPDATE_PROGRAM_SORT
+    UPDATE_PROGRAM_USER_SORT,
+    UPDATE_LOCATION_SORT,
+    UPDATE_SYSTEM_USER_SORT,
+    UPDATE_PROGRAM_SORT,
+    UPDATE_ARCHIVED_ONT_SORT, ACTIVE_ONT_TOGGLE_SORT_ORDER
 } from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
 import {
-    LocationSort,
+    LocationSort, OntologySort, OntologySortField,
     ProgramSort,
-    SortOrder,
     TraitSortField,
-    UserSort,
-    UserSortField
+    UserSort
 } from "@/breeding-insight/model/Sort";
 
 export const mutations: MutationTree<SortState> = {
     // active ontology table
-    [ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER](state: SortState) {
-        state.activeOntNameSortOrder = !state.activeOntNameSortOrder;
+    [ACTIVE_ONT_TOGGLE_SORT_ORDER](state: SortState) {
+        state.activeOntologySort.flag = !state.activeOntologySort.flag;
     },
-    [ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER](state: SortState) {
-        state.activeOntMethodSortOrder = !state.activeOntMethodSortOrder;
-    },
-    [ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER](state: SortState) {
-        state.activeOntScaleClassSortOrder = !state.activeOntScaleClassSortOrder;
-    },
-    [ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER](state: SortState) {
-        state.activeOntUnitSortOrder = !state.activeOntUnitSortOrder;
-    },
-    [ACTIVE_ONT_NEW_SORT_COLUMN](state: SortState, field: TraitSortField) {
-        state.activeTraitSortField = field;
+    [ACTIVE_ONT_NEW_SORT_COLUMN](state: SortState, field: OntologySortField) {
+        state.activeOntologySort.field = field;
     },
 
     // archived ontology table
+    [UPDATE_ARCHIVED_ONT_SORT](state: SortState, sort: OntologySort) {
+        state.archivedOntologySort.field = sort.field;
+        state.archivedOntologySort.order = sort.order;
+    },
     [ARCHIVED_ONT_TOGGLE_NAME_SORT_ORDER](state: SortState) {
         state.archivedOntNameSortOrder = !state.archivedOntNameSortOrder;
     },

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -31,7 +31,7 @@ import {
 import {SortState} from "@/store/sorting/types";
 import {
     LocationSort, OntologySort, OntologySortField,
-    ProgramSort,
+    ProgramSort, SortOrder,
     TraitSortField,
     UserSort
 } from "@/breeding-insight/model/Sort";
@@ -39,7 +39,7 @@ import {
 export const mutations: MutationTree<SortState> = {
     // active ontology table
     [ACTIVE_ONT_TOGGLE_SORT_ORDER](state: SortState) {
-        state.activeOntologySort.flag = !state.activeOntologySort.flag;
+        state.activeOntologySort.order = state.activeOntologySort.order === SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
     },
     [ACTIVE_ONT_NEW_SORT_COLUMN](state: SortState, field: OntologySortField) {
         state.activeOntologySort.field = field;
@@ -47,7 +47,7 @@ export const mutations: MutationTree<SortState> = {
 
     // archived ontology table
     [ARCHIVED_ONT_TOGGLE_SORT_ORDER](state: SortState) {
-        state.archivedOntologySort.flag = !state.archivedOntologySort.flag;
+        state.archivedOntologySort.order = state.archivedOntologySort.order === SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
     },
     [ARCHIVED_ONT_NEW_SORT_COLUMN](state: SortState, field: OntologySortField) {
         state.archivedOntologySort.field = field;
@@ -55,7 +55,7 @@ export const mutations: MutationTree<SortState> = {
 
     // importPreview ontology table
     [IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER](state: SortState) {
-        state.importPreviewOntologySort.flag = !state.importPreviewOntologySort.flag;
+        state.importPreviewOntologySort.order = state.importPreviewOntologySort.order === SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
     },
     [IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN](state: SortState, field: OntologySortField) {
         state.importPreviewOntologySort.field = field;

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -24,10 +24,13 @@ import {
     ARCHIVED_ONT_TOGGLE_UNIT_SORT_ORDER,
     ACTIVE_ONT_TOGGLE_METHOD_SORT_ORDER,
     ACTIVE_ONT_TOGGLE_UNIT_SORT_ORDER,
-    ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER, ACTIVE_ONT_NEW_SORT_COLUMN, ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER
+    ACTIVE_ONT_TOGGLE_SCALE_CLASS_SORT_ORDER,
+    ACTIVE_ONT_NEW_SORT_COLUMN,
+    ACTIVE_ONT_TOGGLE_NAME_SORT_ORDER,
+    UPDATE_PROGRAM_USER_SORT
 } from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
-import {TraitSortField} from "@/breeding-insight/model/Sort";
+import {SortOrder, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
 export const mutations: MutationTree<SortState> = {
     // active ontology table
@@ -62,5 +65,12 @@ export const mutations: MutationTree<SortState> = {
     },
     [ARCHIVED_ONT_NEW_SORT_COLUMN](state: SortState, field: TraitSortField) {
         state.archivedTraitSortField = field;
+    },
+
+    //program user table
+    [UPDATE_PROGRAM_USER_SORT](state: SortState, sort: UserSort) {
+        state.programUserSort.field = sort.field;
+        state.programUserSort.order = sort.order;
     }
+
 };

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -23,7 +23,10 @@ import {
     UPDATE_LOCATION_SORT,
     UPDATE_SYSTEM_USER_SORT,
     UPDATE_PROGRAM_SORT,
-    ACTIVE_ONT_TOGGLE_SORT_ORDER, ARCHIVED_ONT_TOGGLE_SORT_ORDER
+    ACTIVE_ONT_TOGGLE_SORT_ORDER,
+    ARCHIVED_ONT_TOGGLE_SORT_ORDER,
+    IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER,
+    IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN
 } from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
 import {
@@ -48,6 +51,14 @@ export const mutations: MutationTree<SortState> = {
     },
     [ARCHIVED_ONT_NEW_SORT_COLUMN](state: SortState, field: OntologySortField) {
         state.archivedOntologySort.field = field;
+    },
+
+    // importPreview ontology table
+    [IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER](state: SortState) {
+        state.importPreviewOntologySort.flag = !state.importPreviewOntologySort.flag;
+    },
+    [IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN](state: SortState, field: OntologySortField) {
+        state.importPreviewOntologySort.field = field;
     },
 
     //program user table

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -13,11 +13,6 @@ export interface SortState {
 
     // archived ontology table
     archivedOntologySort: OntologySort,
-    archivedTraitSortField: TraitSortField,
-    archivedOntNameSortOrder: boolean,
-    archivedOntMethodSortOrder: boolean,
-    archivedOntScaleClassSortOrder: boolean,
-    archivedOntUnitSortOrder: boolean,
 
     // program users table
     programUserSort: UserSort,

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -1,0 +1,10 @@
+import {TraitSortField} from "@/breeding-insight/model/Sort";
+
+export interface SortState {
+    // ontology table
+    traitSortField: TraitSortField,
+    nameSortOrder: boolean,
+    methodSortOrder: boolean,
+    scaleClassSortOrder: boolean,
+    unitSortOrder: boolean
+}

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -1,4 +1,4 @@
-import {TraitSortField} from "@/breeding-insight/model/Sort";
+import {TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
 export interface SortState {
     // active ontology table
@@ -13,5 +13,8 @@ export interface SortState {
     archivedOntNameSortOrder: boolean,
     archivedOntMethodSortOrder: boolean,
     archivedOntScaleClassSortOrder: boolean,
-    archivedOntUnitSortOrder: boolean
+    archivedOntUnitSortOrder: boolean,
+
+    // program users table
+    programUserSort: UserSort
 }

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -1,10 +1,17 @@
 import {TraitSortField} from "@/breeding-insight/model/Sort";
 
 export interface SortState {
-    // ontology table
-    traitSortField: TraitSortField,
-    nameSortOrder: boolean,
-    methodSortOrder: boolean,
-    scaleClassSortOrder: boolean,
-    unitSortOrder: boolean
+    // active ontology table
+    activeTraitSortField: TraitSortField,
+    activeOntNameSortOrder: boolean,
+    activeOntMethodSortOrder: boolean,
+    activeOntScaleClassSortOrder: boolean,
+    activeOntUnitSortOrder: boolean
+
+    // archived ontology table
+    archivedTraitSortField: TraitSortField,
+    archivedOntNameSortOrder: boolean,
+    archivedOntMethodSortOrder: boolean,
+    archivedOntScaleClassSortOrder: boolean,
+    archivedOntUnitSortOrder: boolean
 }

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -14,6 +14,9 @@ export interface SortState {
     // archived ontology table
     archivedOntologySort: OntologySort,
 
+    // import preview ontology table
+    importPreviewOntologySort: OntologySort,
+
     // program users table
     programUserSort: UserSort,
 

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -1,4 +1,4 @@
-import {TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+import {LocationSort, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
 export interface SortState {
     // active ontology table
@@ -16,5 +16,8 @@ export interface SortState {
     archivedOntUnitSortOrder: boolean,
 
     // program users table
-    programUserSort: UserSort
+    programUserSort: UserSort,
+
+    // program locations table
+    locationSort: LocationSort
 }

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -1,4 +1,4 @@
-import {LocationSort, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+import {LocationSort, ProgramSort, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
 
 export interface SortState {
     // active ontology table
@@ -19,5 +19,11 @@ export interface SortState {
     programUserSort: UserSort,
 
     // program locations table
-    locationSort: LocationSort
+    locationSort: LocationSort,
+
+    // system users table
+    systemUserSort: UserSort,
+
+    // program table
+    programSort: ProgramSort
 }

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -1,14 +1,18 @@
-import {LocationSort, ProgramSort, TraitSortField, UserSort, UserSortField} from "@/breeding-insight/model/Sort";
+import {
+    LocationSort,
+    OntologySort,
+    ProgramSort, Sort, SortOrder,
+    TraitSortField,
+    UserSort,
+    UserSortField
+} from "@/breeding-insight/model/Sort";
 
 export interface SortState {
     // active ontology table
-    activeTraitSortField: TraitSortField,
-    activeOntNameSortOrder: boolean,
-    activeOntMethodSortOrder: boolean,
-    activeOntScaleClassSortOrder: boolean,
-    activeOntUnitSortOrder: boolean
+    activeOntologySort: OntologySort,
 
     // archived ontology table
+    archivedOntologySort: OntologySort,
     archivedTraitSortField: TraitSortField,
     archivedOntNameSortOrder: boolean,
     archivedOntMethodSortOrder: boolean,

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -27,6 +27,7 @@ import { defineAbilityFor } from '@/config/ability';
 import {User} from "@/breeding-insight/model/User";
 import {ProgramUser} from "@/breeding-insight/model/ProgramUser";
 import {Role} from "@/breeding-insight/model/Role";
+import {sorting} from '@/store/sorting/index';
 import {SHOW_SUCCESS_NOTIFICATION} from "@/store/mutation-types";
 
 const localVue = createLocalVue();
@@ -43,6 +44,10 @@ Vue.use(Vuelidate);
 const fakeProgram = new Program('1', 'Test Program');
 export const defaultStore = new Vuex.Store({
   state:{
+    apiError: false,
+    apiUnavailable: false,
+    loginServerError: false,
+    loggedIn: false,
     errorNotificationActive: false,
     errorNotificationMsg: '',
     successNotificationActive: false,
@@ -52,6 +57,9 @@ export const defaultStore = new Vuex.Store({
     warningNotificationActive: false,
     warningNotificationMsg: '',
     showSidebarMobile: true
+  },
+  modules: {
+    sorting
   },
   getters: {
     activeProgram: () => fakeProgram
@@ -67,8 +75,6 @@ export const defaultStore = new Vuex.Store({
       state.successNotificationActive = true;
     },
   }
-
-
 });
 
 const fakeUser: User = new User('1', 'Test User','1', 'email@email.com',


### PR DESCRIPTION
The service and dao for Traits was changed to pass the query params used for sorting.
Vuex was used to store sort control state for each table. This was necessary to ensure that the display for a table is preserved when a user selects the other tab in the interface or when the user navigates to another list table.

The approach used here will be replicated for tables in the remaining sub tasks of [BI-618](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-618).

Backend sorting was implemented for the following tables:
admin users,
programs,
program users,
locations,
active ontology,
archived ontology,
trait import preview.

The ontology and trait import preview table sorting was styled to match that used in the other Buefy tables.

The bugfix for [BI-1115](https://breedinginsight.atlassian.net/browse/BI-1115) was also merged in, so backend pagination is being used for the program users table.

