### PR TITLE
[BI-1219] Changing Parent DB ID to Parent GID

### DIFF
--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -30,7 +30,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/kv3l900otsea9zm3iowp7e9umpcjvsck.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/rzpfijnvk3x6rn2gb1of64sigqvyxgu5.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>


### PR DESCRIPTION
# Description
**Story:** (https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1219)

Changes Parent DB ID references to Parent GID. There was no references on the UI. In the import germplasm table the parents are under "Pedigree". Only the import template needed to be changed. 

# Dependencies
biapi: BI-1219 (https://github.com/Breeding-Insight/bi-api/pull/132)

# Testing
1. This file with import germplasm into your brapi system:
[BI-1219_few_germplasm_in_file_parents.xls](https://github.com/Breeding-Insight/bi-web/files/7822894/BI-1219_few_germplasm_in_file_parents.xls)

 2. This file will make GID references to those germplasm you just imported: 
[BI-1219_few_germplasm_db_parents.xls](https://github.com/Breeding-Insight/bi-web/files/7822901/BI-1219_few_germplasm_db_parents.xls)

3. Try out the old template to see the error message you will get: 
[BI-1056_few_germplasm.xls](https://github.com/Breeding-Insight/bi-web/files/7822921/BI-1056_few_germplasm.xls)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF.
