### PR TITLE
[BI-1282] - Ontology Import Success Banner Not Displaying

### DIFF
--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -345,13 +345,13 @@ export default class TraitsImport extends ProgramsBase {
       await TraitUploadService.confirmUpload(this.activeProgram!.id!, upload!.id!);
 
       // show all program traits
-      this.$emit('show-success-notification', `Imported ontology terms have been added to ${name}.`);
       this.$router.push({
         name: 'traits-list',
         params: {
           programId: this.activeProgram!.id!
         },
       });
+      this.$emit('show-success-notification', `Imported ontology terms have been added to ${name}.`);
     } catch(err) {
       const note = err.message ? err.message : `Error: Imported ontology terms were not added to ${name}.`;
       this.$emit('show-error-notification', `${note}`);


### PR DESCRIPTION
# Description
**Story:** [Ontology Import Success Banner Not Displaying](https://breedinginsight.atlassian.net/browse/BI-1282)

Due to recent changes to make notifications more transient, the ontology import success banner was not displaying as the call to emit it being made before the router redirect back to the Ontology list. The call has now been moved to after the redirect.

# Dependencies
- [taf/BI-1260](https://github.com/Breeding-Insight/taf/pull/38) (in order to run ontology import scenarios with correctly updated files in TAF)

# Testing
- Import valid import file (ie [test_import-xls.xls](https://github.com/Breeding-Insight/taf/blob/14cf50c504715ecbe53a913a7cda483c49ed0945/src/files/TraitImport/test_import-xls.xls))
- Click "Confirm"
- Banner “Imported ontology terms have been added to {program name}“.  should display

Related TAF scenarios that can be run: BI-922, BI-923, BI-925
****NOTE**: as mentioned in dependencies, until BI-1260 is merged to main branch in TAF, ontology import tests will fail on the main branch due to the columns in the example files not yet being updated in response to changes in expected ontology file columns. Relevant TAF scenarios can be run on BI-1260.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [n/a] I have create/modified unit tests to cover this change
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to documentation
- [X] I have run TAF.
