### PR TITLE
[BI-1253] - Ordinal Label Value Swap Details View

### DIFF
--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -123,11 +123,10 @@
              :key="category.label"
              class="columns is-centered is-mobile is-variable is-multiline is-0 my-0">
           <div class="column is-half p-0">
-            <span v-if="category.label" class="is-pulled-right mr-2">{{ category.label }}</span>
-            <span v-else class="is-pulled-right mr-2">{{ category.value }}</span>
+            <span class="is-pulled-right mr-2">{{ category.value }}</span>
           </div>
           <div class="column is-half p-0">
-            <span v-if="category.label" class="is-size-7 ml-2">{{ category.value }}</span>
+            <span v-if="category.label" class="is-size-7 ml-2">{{ category.label }}</span>
           </div>
         </div>
       </template>


### PR DESCRIPTION
# Description
**Story:** [BI-1253 - ISSUE - Ordinal scale class label and value are swapped on UI - details view](https://breedinginsight.atlassian.net/browse/BI-1253)

Logic fix to display value followed by label in ordinal scale list in ontology details side panel.

# Dependencies
- n/a

# Testing

- Create single ontology term with ordinal scale, open details panel, check that the value is followed by label in list.
- Import file with ontology term with ordinal scale (ie https://github.com/Breeding-Insight/taf/blob/main/src/files/TraitImport/test_import-csv.csv), open details panel in preview table, check that the value is followed by label in list. Finish import, check the details panel again.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [n/a] I have create/modified unit tests to cover this change
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to documentation
- [X] I have run TAF.
