### PR TITLE
[BI-1145] Add experiment import stub out

### DIFF
--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -159,13 +159,18 @@
               </router-link>
               <ul v-show="importFileActive">
                 <li>
-                  <router-link v-bind:to="{name: 'ontology', params: {programId: activeProgram.id}}">
+                  <router-link v-bind:to="{name: 'import-ontology', params: {programId: activeProgram.id}}">
                     Ontology
                   </router-link>
                 </li>
                 <li>
                   <router-link v-bind:to="{name: 'germplasm-import', params: {programId: activeProgram.id}}">
                     Germplasm
+                  </router-link>
+                </li>
+                <li>
+                  <router-link v-bind:to="{name: 'experiment-import', params: {programId: activeProgram.id}}">
+                    Experiments & Observations
                   </router-link>
                 </li>
                 <li>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -66,6 +66,7 @@ import OntologyActiveTable from "@/components/ontology/OntologyActiveTable.vue";
 import OntologyArchivedTable from "@/components/ontology/OntologyArchivedTable.vue";
 import PageNotFound from "@/views/PageNotFound.vue";
 import Germplasm from "@/views/germplasm/Germplasm.vue";
+import ImportExperiment from "@/views/import/ImportExperiment.vue";
 
 Vue.use(VueRouter);
 
@@ -369,6 +370,15 @@ const routes = [
           layout: layouts.userSideBar
         },
         component: ImportGermplasm
+      },
+      {
+        path: 'experiment',
+        name: 'experiment-import',
+        meta: {
+          title: 'Experiments & Observations',
+          layout: layouts.userSideBar
+        },
+        component: ImportExperiment
       },
       {
         path: 'brapi-import',

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -16,7 +16,7 @@
   -->
 
 <template>
-  <div id="import-germplasm">
+  <div id="import-experiment">
     <ImportTemplate
         v-bind:abort-msg="'No records will be added, and the import in progress will be completely removed.'"
         v-bind:system-import-template-name="experimentImportTemplateName"

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -1,0 +1,100 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div id="import-germplasm">
+    <ImportTemplate
+        v-bind:abort-msg="'No records will be added, and the import in progress will be completely removed.'"
+        v-bind:system-import-template-name="experimentImportTemplateName"
+        v-bind:confirm-msg="'Confirm New Experiments & Observations Records'"
+        v-bind:import-type-name="'Experiments & Observations'"
+        v-bind:confirm-import-state="confirmImportState"
+        v-on="$listeners"
+        v-on:finished="importFinished"
+    >
+
+      <template v-slot:importInfoTemplateMessageBox>
+        <ImportInfoTemplateMessageBox v-bind:import-type-name="'Experiments & Observations'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/ecmwixiwp5wl3cjq493hvhi4agq03cyh.xls'"
+                                      class="mb-5">
+          <strong>Before You Import...</strong>
+          <br/>
+          Experimental germplasm and ontology terms must be created in the system before experiments can be created via import.
+          See the import template for more information about data requirements. Importing phenotypic
+          observations into existing experiments requires only Observation Unit IDs
+          to match with the experimental design.
+        </ImportInfoTemplateMessageBox>
+      </template>
+
+      <template v-slot:confirmImportMessageBox="{ statistics, abort, confirm, rows }">
+        <ConfirmImportMessageBox v-bind:num-records="getNumNewExperimentRecords(statistics)"
+                                 v-bind:import-type-name="'Experiments & Observations'"
+                                 v-bind:confirm-import-state="confirmImportState"
+                                 v-on:abort="abort"
+                                 v-on:confirm="confirm"
+                                 class="mb-4">
+          <div>
+            <p class="is-size-5 mb-2"><strong>Import Summary</strong></p>
+            <p>Total number of entries: {{ rows.length }}</p>
+          </div>
+        </ConfirmImportMessageBox>
+      </template>
+
+      <template v-slot:importPreviewTable="previewData">
+      </template>
+
+    </ImportTemplate>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component } from 'vue-property-decorator'
+import ProgramsBase from "@/components/program/ProgramsBase.vue";
+import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTemplateMessageBox.vue";
+import ConfirmImportMessageBox from "@/components/trait/ConfirmImportMessageBox.vue";
+import ImportTemplate from "@/views/import/ImportTemplate.vue";
+import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
+import ReportTable from "@/components/report/ReportTable.vue";
+import {ImportFormatter} from "@/breeding-insight/model/report/ImportFormatter";
+import {ReportStruct} from "@/breeding-insight/model/report/ReportStruct";
+import defaultRenames from '@/config/report/ReportRenames';
+import { AlertTriangleIcon } from 'vue-feather-icons';
+import {GermplasmList} from "@/breeding-insight/model/GermplasmList";
+import BasicInputField from "@/components/forms/BasicInputField.vue";
+
+@Component({
+  components: {
+    ImportInfoTemplateMessageBox, ConfirmImportMessageBox, ImportTemplate, AlertTriangleIcon, BasicInputField
+  },
+  data: () => ({ImportFormatter})
+})
+export default class ImportExperiment extends ProgramsBase {
+
+  private experimentImportTemplateName = 'ExperimentsTemplateMap';
+  private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
+
+  private germplasmList: GermplasmList = new GermplasmList();
+
+
+  getNumNewExperimentRecords(statistics: any): number | undefined {
+    return undefined;
+  }
+
+  importFinished(){}
+
+}
+</script>

--- a/src/views/import/ImportFile.vue
+++ b/src/views/import/ImportFile.vue
@@ -35,6 +35,11 @@
             <a>Germplasm</a>
           </router-link>
           <router-link
+              v-bind:to="{name: 'experiment-import', params: {programId: activeProgram.id}}"
+              tag="li" active-class="is-active">
+            <a>Experiments & Observations</a>
+          </router-link>
+          <router-link
               v-bind:to="{name: 'brapi-import', params: {programId: activeProgram.id}}"
               tag="li" active-class="is-active">
             <a>BrAPI Import<span class="ml-2 tag is-warning">Beta</span></a>


### PR DESCRIPTION
# Description
Adds a stub out of the experimental import. 

# Dependencies
develop on bi-api

# Testing
Go to the experimental import page. Download the template and verify.

# TAF Report
Ran TAF and results were the same as result on develop (https://github.com/Breeding-Insight/taf/suites/5050389765/artifacts/149608412).

One test failed in the full run, so ran it by itself and it worked fine. Reports below.

[taf-bi-1145-1.pdf](https://github.com/Breeding-Insight/bi-web/files/7937080/taf-bi-1145-1.pdf)
[taf-bi-1145.pdf](https://github.com/Breeding-Insight/bi-web/files/7937081/taf-bi-1145.pdf)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF.
