### PR TITLE
[BI-1149] Highlighting duplicate germplasm

### DIFF
--- a/src/breeding-insight/model/import/ImportObjectState.ts
+++ b/src/breeding-insight/model/import/ImportObjectState.ts
@@ -1,0 +1,18 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+export enum ImportObjectState {
+  EXISTING = 'EXISTING',
+  NEW = 'NEW'
+}

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -147,9 +147,9 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
 
   calculateRowClass(row: TableRow<any>, index: Number) {
     if (this.isVisibleDetailRow(row)) {
-      return this.rowClasses && this.rowClasses[row.data.id] ? this.rowClasses[row.data.id] + " is-edited" : " is-edited";
+      return this.rowClasses && this.rowClasses[row.data.id] ? this.rowClasses[row.data.id] + " is-edited" : "is-edited";
     } else if (row.new) {
-      return this.rowClasses && this.rowClasses[row.data.id] ? this.rowClasses[row.data.id] + " is-new" : " is-new";
+      return this.rowClasses && this.rowClasses[row.data.id] ? this.rowClasses[row.data.id] + " is-new" : "is-new";
     }
     
     return this.rowClasses && this.rowClasses[row.data.id] ? this.rowClasses[row.data.id] : "";

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -123,6 +123,7 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   dataFormState!: DataFormEventBusHandler;
   @Prop()
   defaultSort!: String[];
+  @Prop()
   rowClasses: any;
 
   private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -136,7 +136,8 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   }
 
   isVisibleDetailRow(row:any) {
-    return (this.$refs[this.tableRef] as Vue & { isVisibleDetailRow: (row:any) => boolean }).isVisibleDetailRow(row);
+    // If data is passed in at same time as component loading, this ref won't be assigned yet. Check if assigned before referencing.
+    return this.$refs[this.tableRef] ? (this.$refs[this.tableRef] as Vue & { isVisibleDetailRow: (row:any) => boolean }).isVisibleDetailRow(row): false;
   }
 
   detailsVisible() {

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -123,6 +123,7 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   dataFormState!: DataFormEventBusHandler;
   @Prop()
   defaultSort!: String[];
+  rowClasses: any;
 
   private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
   private openDetail: Array<TableRow<any>> = new Array<TableRow<any>>();
@@ -146,12 +147,12 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
 
   calculateRowClass(row: TableRow<any>, index: Number) {
     if (this.isVisibleDetailRow(row)) {
-      return "is-edited";
+      return this.rowClasses && this.rowClasses[row.data.id] ? this.rowClasses[row.data.id] + " is-edited" : " is-edited";
     } else if (row.new) {
-      return "is-new";
+      return this.rowClasses && this.rowClasses[row.data.id] ? this.rowClasses[row.data.id] + " is-new" : " is-new";
     }
     
-    return "";
+    return this.rowClasses && this.rowClasses[row.data.id] ? this.rowClasses[row.data.id] : "";
   }
 
   updated() {

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -120,9 +120,8 @@
 
           <template v-slot:emptyMessage>
             <p class="has-text-weight-bold">
-              No germplasm are currently defined for this program.
+              No germplasm were found in this import file.
             </p>
-            Germplasm are able to be created through the germplasm import.<br>
           </template>
         </ExpandableTable>
       </template>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -86,12 +86,35 @@
       </template>
 
       <template v-slot:importPreviewTable="previewData">
-        <report-table
-            v-bind:report="processPreviewData(previewData.import)"
-            v-bind:config="importConfig"
-            detailed
-            paginated
-        />
+        <ExpandableTable
+            v-bind:records="processPreviewData(previewData.import)"
+            v-bind:loading="false"
+            v-bind:pagination="previewData.pagination"
+            v-on:show-error-notification="$emit('show-error-notification', $event)"
+        >
+          <b-table-column field="defaultDisplayName" label="Name" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+            {{ props.row.data.brAPIObject.defaultDisplayName }}
+          </b-table-column>
+          <b-table-column field="breedingMethod" label="Breeding Method" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+            {{ props.row.data.brAPIObject.additionalInfo.breedingMethod }}
+          </b-table-column>
+          <b-table-column field="seedSource" label="Source" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+            {{ props.row.data.brAPIObject.seedSource }}
+          </b-table-column>
+          <b-table-column field="pedigree" label="Pedigree" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+            {{ props.row.data.brAPIObject.pedigree }}
+          </b-table-column>
+          <b-table-column field="importEntryNumber" label="Entry No." v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+            {{ props.row.data.brAPIObject.additionalInfo.importEntryNumber }}
+          </b-table-column>
+
+          <template v-slot:emptyMessage>
+            <p class="has-text-weight-bold">
+              No germplasm are currently defined for this program.
+            </p>
+            Germplasm are able to be created through the germplasm import.<br>
+          </template>
+        </ExpandableTable>
       </template>
 
     </ImportTemplate>
@@ -105,17 +128,16 @@ import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTem
 import ConfirmImportMessageBox from "@/components/trait/ConfirmImportMessageBox.vue";
 import ImportTemplate from "@/views/import/ImportTemplate.vue";
 import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
-import ReportTable from "@/components/report/ReportTable.vue";
 import {ImportFormatter} from "@/breeding-insight/model/report/ImportFormatter";
-import {ReportStruct} from "@/breeding-insight/model/report/ReportStruct";
 import defaultRenames from '@/config/report/ReportRenames';
 import { AlertTriangleIcon } from 'vue-feather-icons';
 import {GermplasmList} from "@/breeding-insight/model/GermplasmList";
 import BasicInputField from "@/components/forms/BasicInputField.vue";
+import ExpandableTable from "@/components/tables/expandableTable/ExpandableTable.vue";
 
 @Component({
   components: {
-    ReportTable, ImportInfoTemplateMessageBox, ConfirmImportMessageBox, ImportTemplate, AlertTriangleIcon, BasicInputField
+    ExpandableTable, ImportInfoTemplateMessageBox, ConfirmImportMessageBox, ImportTemplate, AlertTriangleIcon, BasicInputField
   },
   data: () => ({ImportFormatter})
 })
@@ -151,9 +173,9 @@ export default class ImportGermplasm extends ProgramsBase {
     return undefined;
   }
 
-  processPreviewData(previewData: any): ReportStruct {
+  processPreviewData(importPreviewRows: any): any[] {
     // Do special germplasm import formatting here
-    return ImportFormatter.format(previewData, this.importConfig);
+    return importPreviewRows.map((record:any) => record.germplasm);
   }
 
   importFinished() {

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -73,7 +73,7 @@
 
       <slot name="userInput" />
 
-      <slot name="importPreviewTable" v-bind:import="previewData" />
+      <slot name="importPreviewTable" v-bind:import="previewData" v-bind:pagination="pagination"/>
     </template>
 
     <template v-if="state === ImportState.IMPORT_ERROR">
@@ -110,6 +110,7 @@ import {ImportService} from "@/breeding-insight/service/ImportService";
 import {ImportResponse} from "@/breeding-insight/model/import/ImportResponse";
 import { titleCase } from "title-case";
 import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
+import {Pagination} from "@/breeding-insight/model/BiResponse";
 
 enum ImportState {
   CHOOSE_FILE = "CHOOSE_FILE",
@@ -193,6 +194,7 @@ export default class ImportTemplate extends ProgramsBase {
   private activeProgram?: Program;
   private tableLoaded = false;
   private showAbortModal = false;
+  private pagination = new Pagination();
 
   private yesAbortId: string = "import-yes-abort";
 
@@ -470,6 +472,11 @@ export default class ImportTemplate extends ProgramsBase {
             this.previewData = previewResponse.preview.rows as any[];
             this.newObjectCounts = previewResponse.preview.statistics;
             this.importService.send(ImportEvent.IMPORT_SUCCESS);
+            // TODO: Temp pagination
+            this.pagination.totalCount = previewResponse.preview.rows.length;
+            this.pagination.pageSize = 10;
+            this.pagination.currentPage = 1;
+            this.pagination.totalPages = 1;
           }
         }
         return previewResponse;


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1149

- Refactored germplasm import table to use the ExpandableTable. 
- Added highlighting and alert icon on duplicate rows. 
- Fixed a bug with the ExpandableTable where an error was thrown in the table was given data on initialization. 
- Added front end pagination to the ImportTemplate component. 

I am planning to run TAF before merging. 

# Dependencies
bi-api: BI-1149 (https://github.com/Breeding-Insight/bi-api/pull/137)

# TAF Results
All tests that pass in develop taf (https://github.com/Breeding-Insight/taf/suites/5064590044/artifacts/150443801) pass in TAF for this work. 

[taf-bi-1149.pdf](https://github.com/Breeding-Insight/bi-web/files/7943205/taf-bi-1149.pdf)


# Testing
1. Import the in file duplicates test file. You will see two rows highlighted. The duplicate message will be display below the import statistics. 
[BI-1149-file-dups.xls](https://github.com/Breeding-Insight/bi-api/files/7906124/BI-1149-file-dups.xls)
2. Import the no duplicates file. No rows will be highlighted.  The duplicate message will not be display below the import statistics. 
[BI-1149-germplasm-1.xls](https://github.com/Breeding-Insight/bi-api/files/7906131/BI-1149-germplasm-1.xls)
3. Import the database duplicates file. Most rows will be highlighted, some won't.  The duplicate message will be display below the import statistics. 
[BI-1149-germplasm-2.xls](https://github.com/Breeding-Insight/bi-api/files/7906136/BI-1149-germplasm-2.xls)


# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF.
