### PR TITLE
[BI-1258] prevent categories array from being zeroed out.

### DIFF
--- a/src/components/trait/forms/CategoryTraitForm.vue
+++ b/src/components/trait/forms/CategoryTraitForm.vue
@@ -133,11 +133,10 @@ export default class CategoryTraitForm extends Vue {
 
   @Watch('type', {immediate: true})
   updateCategories() {
-    if (this.data.filter((value,index) => {
+    this.data = this.data.filter((value,index) => {
       return (value.value !== undefined || value.label !== undefined);
-    }).length !== 0) {
-      this.data.splice(0, this.data.length)
-    }
+    });
+    
     if (this.data.length === 0) {
       this.prepopulateCategories();
     }


### PR DESCRIPTION
# Description
**Story:** [BI-1258](https://breedinginsight.atlassian.net/browse/BI-1258)

The updateCategories() in CategoryTraitForm.vue was zeroing out the catigories array


# Dependencies
None

# Testing
see [BI-1258](https://breedinginsight.atlassian.net/browse/BI-1258)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF.
