### PR TITLE
[BI-1289] add Description and Synonyms labels to detail panel

### DIFF
--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -21,19 +21,33 @@
       <p v-if="data.observationVariableName" class="is-size-5 has-text-weight-bold mb-0">
         {{data.observationVariableName}}
         <span v-if="!data.active" class="tag is-link is-normal ml-1">Archived</span>
-      </p>
+      </p><br>
 
-      <p v-if="data.traitDescription" class="is-size-7 mb-0">{{data.traitDescription}}</p>
+      <div v-if="data.traitDescription" class="columns is-multiline is-mobile pt-4 pl-3">
+        <div class="column is-narrow p-0">
+          <span class="is-pulled-left has-text-weight-bold mr-2">Description</span>
+        </div>
+        <div class="column is-narrow p-0">
+          <span class="is-size-7 mb-0">{{data.traitDescription}}</span>
+        </div>
+      </div>
       <!-- just shows first abbreviation AKA main abbreviation and first synonym -->
       <template v-if="abbreviationsSynonymsString">
-        <p class="is-size-7 mb-0">{{ abbreviationsSynonymsString(2)}}</p>
+        <div class="columns is-multiline is-mobile pt-1 pl-3">
+          <div class="column is-narrow p-0">
+            <span class="is-pulled-left has-text-weight-bold mr-2">Synonyms</span>
+          </div>
+          <div class="column is-narrow p-0">
+            <span class="is-size-7 mb-0">{{ abbreviationsSynonymsString(2)}}</span>
+          </div>
+        </div>
       </template>
       <template v-else>
         <p class="mb-0"/>
       </template>
 
       <template v-if="data.tags && data.tags.length > 0">
-        <div class="columns is-multiline is-mobile pt-4 pl-3">
+        <div class="columns is-multiline is-mobile pt-1 pl-3">
           <div class="column is-narrow p-0">
             <span class="is-pulled-left has-text-weight-bold mr-2">Tags</span>
           </div>


### PR DESCRIPTION
# Description
**Story:** [Improve ontology term snapshot](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1289)

Description and Synonyms labels were added to the trait details panel.



# Dependencies
bi-api `develop` branch

# Testing
verify labels exist when viewing detail panel


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
