### PR TITLE
[BI-1288] Trait column on Ontology List page should be concatenation of trait entity + attribute

### DIFF
--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -148,7 +148,7 @@
           v-on:newSortColumn="$emit('newSortColumn', $event)"
           v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
-          {{ data.entity }} {{data.attribute | capitalize }}
+          {{ data.entity | capitalize }} {{data.attribute | capitalize }}
         </TableColumn>
         <TableColumn
             name="method"

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -148,7 +148,7 @@
           v-on:newSortColumn="$emit('newSortColumn', $event)"
           v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
-          {{ StringFormatters.toStartCase(data.traitDescription) }}
+          {{ data.entity }} {{data.attribute | capitalize }}
         </TableColumn>
         <TableColumn
             name="method"
@@ -287,6 +287,12 @@ import {BackendPaginationController} from "@/breeding-insight/model/view_models/
     ...mapGetters([
       'activeProgram'
     ])
+  },
+  filters: {
+    capitalize: function(value: string | undefined) : string | undefined {
+      if (value === undefined) value = '';
+      return StringFormatters.toStartCase(value);
+    }
   },
   data: () => ({Trait, StringFormatters, TraitStringFormatters})
 })

--- a/src/components/ontology/OntologyTable.vue.js
+++ b/src/components/ontology/OntologyTable.vue.js
@@ -1,0 +1,3 @@
+import Vue from 'vue';
+export default Vue;
+//# sourceMappingURL=OntologyTable.vue.js.map

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -55,7 +55,7 @@
           {{ data.observationVariableName }}
         </TableColumn>
         <TableColumn name="trait" v-bind:label="'Trait'" v-bind:visible="!collapseColumns">
-          {{ data.entity }} {{ data.attribute | capitalize }}
+          {{ data.entity | capitalize }} {{ data.attribute | capitalize }}
         </TableColumn>
         <TableColumn
             name="method"

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -55,7 +55,7 @@
           {{ data.observationVariableName }}
         </TableColumn>
         <TableColumn name="trait" v-bind:label="'Trait'" v-bind:visible="!collapseColumns">
-          {{ StringFormatters.toStartCase(data.traitDescription) }}
+          {{ data.entity }} {{ data.attribute | capitalize }}
         </TableColumn>
         <TableColumn
             name="method"
@@ -175,6 +175,12 @@
         newSortColumn: IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN,
         toggleSortOrder: IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER
       })
+    },
+    filters: {
+      capitalize: function(value: string | undefined) : string | undefined {
+        if (value === undefined) value = '';
+        return StringFormatters.toStartCase(value);
+      }
     },
     data: () => ({StringFormatters, TraitStringFormatters})
   })


### PR DESCRIPTION
# Description
[BI-1288](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1288)

Active and archived ontology lists as well as ontology import preview tables updated to show trait columns as entity + attribute.



# Dependencies
bi-api `develop`

# Testing



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
