### PR TITLE
[BI-1370] ontology table: add trait description sorting

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -46,7 +46,8 @@ export enum OntologySortField {
   Name = 'name',
   MethodDescription = 'methodDescription',
   ScaleClass = 'scaleClass',
-  ScaleName = 'scaleName'
+  ScaleName = 'scaleName',
+  TraitDescription = 'traitDescription'
 }
 
 export class OntologySort {

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -137,7 +137,17 @@
         >
           {{ data.observationVariableName }}
         </TableColumn>
-        <TableColumn name="trait" v-bind:label="'Trait'" v-bind:visible="!traitSidePanelState.collapseColumns">
+        <TableColumn
+          name="trait"
+          v-bind:label="'Trait'"
+          v-bind:visible="!traitSidePanelState.collapseColumns"
+          v-bind:sortField="ontologySort.field"
+          v-bind:sortFieldLabel="traitDescriptionSortLabel"
+          v-bind:sortable="true"
+          v-bind:sortOrder="ontologySort.order"
+          v-on:newSortColumn="$emit('newSortColumn', $event)"
+          v-on:toggleSortOrder="$emit('toggleSortOrder')"
+        >
           {{ StringFormatters.toStartCase(data.traitDescription) }}
         </TableColumn>
         <TableColumn
@@ -307,6 +317,7 @@ export default class OntologyTable extends Vue {
   private methodSortLabel: string = OntologySortField.MethodDescription;
   private scaleClassSortLabel: string = OntologySortField.ScaleClass;
   private unitSortLabel: string = OntologySortField.ScaleName;
+  private traitDescriptionSortLabel: string = OntologySortField.TraitDescription;
 
   // New trait form
   private newTraitActive: boolean = false;


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1370

Made the trait description (Trait) sortable in the ontology table. 



# Dependencies
bi-api: BI-1370

# Testing
Here is a file to get some traits in your system if you need them. 

[BI_1373_good_traits.xls](https://github.com/Breeding-Insight/bi-web/files/8089813/BI_1373_good_traits.xls)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
