### PR TITLE
[BI-1338] - Germplasm Import Template references DBID instead of GID

### DIFF
--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -30,7 +30,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/rzpfijnvk3x6rn2gb1of64sigqvyxgu5.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/z305olf7o3f0suoxduase05yywr9keid'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>


### PR DESCRIPTION
# Description
**Story:**[ ISSUE: Germplasm Import Template README still references DBID instead of GID](https://breedinginsight.atlassian.net/browse/BI-1338)

Replaced remaining instances of DBID with GID in README.

# Dependencies
bi-api-develop

# Testing
Go to germplasm import, download template, look at readme. All instances of DBID should be replaced with GID.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [n/a] I have create/modified unit tests to cover this change
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/1859956767)
