### PR TITLE
[BI-1372] Add ontology sort option for entity + attribute

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -47,7 +47,7 @@ export enum OntologySortField {
   MethodDescription = 'methodDescription',
   ScaleClass = 'scaleClass',
   ScaleName = 'scaleName',
-  TraitDescription = 'traitDescription'
+  entityAttributeSortLabel = 'entityAttribute'
 }
 
 export class OntologySort {

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -142,7 +142,7 @@
           v-bind:label="'Trait'"
           v-bind:visible="!traitSidePanelState.collapseColumns"
           v-bind:sortField="ontologySort.field"
-          v-bind:sortFieldLabel="traitDescriptionSortLabel"
+          v-bind:sortFieldLabel="entityAttributeSortLabel"
           v-bind:sortable="true"
           v-bind:sortOrder="ontologySort.order"
           v-on:newSortColumn="$emit('newSortColumn', $event)"
@@ -323,7 +323,7 @@ export default class OntologyTable extends Vue {
   private methodSortLabel: string = OntologySortField.MethodDescription;
   private scaleClassSortLabel: string = OntologySortField.ScaleClass;
   private unitSortLabel: string = OntologySortField.ScaleName;
-  private traitDescriptionSortLabel: string = OntologySortField.TraitDescription;
+  private entityAttributeSortLabel: string = OntologySortField.entityAttributeSortLabel;
 
   // New trait form
   private newTraitActive: boolean = false;

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -54,7 +54,17 @@
             </AlertTriangleIcon>
           {{ data.observationVariableName }}
         </TableColumn>
-        <TableColumn name="trait" v-bind:label="'Trait'" v-bind:visible="!collapseColumns">
+        <TableColumn
+            name="trait"
+            v-bind:label="'Trait'"
+            v-bind:visible="!collapseColumns"
+            v-bind:sortField="importPreviewOntologySort.field"
+            v-bind:sortFieldLabel="entityAttributeSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="importPreviewOntologySort.order"
+            v-on:newSortColumn="newSortColumn"
+            v-on:toggleSortOrder="toggleSortOrder"
+        >
           {{ data.entity | capitalize }} {{ data.attribute | capitalize }}
         </TableColumn>
         <TableColumn
@@ -203,6 +213,7 @@ export default class TraitsImportTable extends Vue {
   private methodSortLabel: string = OntologySortField.MethodDescription;
   private scaleClassSortLabel: string = OntologySortField.ScaleClass;
   private unitSortLabel: string = OntologySortField.ScaleName;
+  private entityAttributeSortLabel: string = OntologySortField.entityAttributeSortLabel;
 
   mounted() {
     this.updatePagination();


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1372

Fix previous error with sorting (mistook trait description for entity + attribute in previous bug fix). 
Added `Trait` column sorting to import preview. 



# Dependencies
biapi: BI-1372

# Testing
See bi-api PR. 


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
