### PR TITLE
[BI-1356] Ordinal Nominal Switching Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v0.5.0+262",
+  "version": "v0.6.0+262",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v0.5.0+258",
+  "version": "v0.5.0+262",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -88,5 +88,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.6.10"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/8c03be85a2ea878b90265fb7234491f35ae6dd6d"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/3c10cc33dabeec1b27ba2b31641614e7cc120460"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v0.6.0+262",
+  "version": "v0.6.0+266",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -88,5 +88,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.6.10"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/3c10cc33dabeec1b27ba2b31641614e7cc120460"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/49c216f0875ec675b633e5b026ff005e917e38dc"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v0.6.0+266",
+  "version": "v0.5.0+262",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -88,5 +88,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.6.10"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/49c216f0875ec675b633e5b026ff005e917e38dc"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/3c10cc33dabeec1b27ba2b31641614e7cc120460"
 }

--- a/src/breeding-insight/model/errors/ValidationError.ts
+++ b/src/breeding-insight/model/errors/ValidationError.ts
@@ -79,7 +79,7 @@ export class ValidationError {
   clearValidation(rowIndex: number, errorName: string) {
     if (this.rowErrors && this.rowErrors[rowIndex]) {
       for (const [errorIndex, field] of this.rowErrors[rowIndex].errors!.entries()) {
-        if (field.field === errorName) {
+        if ((field) && (field.field === errorName)) {
           delete this.rowErrors[rowIndex].errors![errorIndex];
         }
       }

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -494,7 +494,7 @@ export default class OntologyTable extends Vue {
   async saveTrait() {
     try {
       //For nominal traits switch back label value
-      if ((this.newTrait.scale) && (this.newTrait.scale.dataType) && (Scale.dataTypeEquals(this.newTrait.scale.dataType, DataType.Nominal)) && (this.newTrait.scale.categories)) {
+      if ((this.newTrait) && (this.newTrait.scale) && (this.newTrait.scale.dataType) && (Scale.dataTypeEquals(this.newTrait.scale.dataType, DataType.Nominal)) && (this.newTrait.scale.categories)) {
         this.newTrait.scale.categories.forEach(category => {
           category.value = category.label;
           category.label = undefined;
@@ -551,7 +551,7 @@ export default class OntologyTable extends Vue {
   async updateTrait(archiveStateChanged?: boolean) {
     try {
       //For nominal traits switch back label value
-      if ((this.editTrait.scale) && (this.editTrait.scale.dataType) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal)) && (this.editTrait.scale.categories)) {
+      if ((this.editTrait) && (this.editTrait.scale) && (this.editTrait.scale.dataType) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal)) && (this.editTrait.scale.categories)) {
         this.editTrait.scale.categories.forEach(category => {
           category.value = category.label;
           category.label = undefined;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -493,6 +493,14 @@ export default class OntologyTable extends Vue {
 
   async saveTrait() {
     try {
+      //For nominal traits switch back label value
+      if ((this.newTrait.scale) && (Scale.dataTypeEquals(this.newTrait.scale.dataType, DataType.Nominal))) {
+        this.newTrait.scale.categories.forEach(category => {
+          category.value = category.label;
+          category.label = undefined;
+        });
+      }
+
       this.validationHandler = new ValidationError();
       const [ [savedTrait], metadata ] = await TraitService.createTraits(this.activeProgram!.id!, [this.newTrait]);
       if (this.newTrait.active === false) {
@@ -542,6 +550,14 @@ export default class OntologyTable extends Vue {
 
   async updateTrait(archiveStateChanged?: boolean) {
     try {
+      //For nominal traits switch back label value
+      if ((this.editTrait.scale) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal))) {
+        this.editTrait.scale.categories.forEach(category => {
+          category.value = category.label;
+          category.label = undefined;
+        });
+      }
+
       this.editValidationHandler = new ValidationError();
       const [data] = await TraitService.updateTraits(this.activeProgram!.id!, [this.editTrait!]) as [Trait[], Metadata];
 

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -551,7 +551,7 @@ export default class OntologyTable extends Vue {
   async updateTrait(archiveStateChanged?: boolean) {
     try {
       //For nominal traits switch back label value
-      if ((this.editTrait.scale) && (this.newTrait.scale.dataType) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal)) && (this.newTrait.scale.categories)) {
+      if ((this.editTrait.scale) && (this.editTrait.scale.dataType) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal)) && (this.editTrait.scale.categories)) {
         this.editTrait.scale.categories.forEach(category => {
           category.value = category.label;
           category.label = undefined;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -276,6 +276,7 @@ import {integer, maxLength} from "vuelidate/lib/validators";
 import {TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
 import {OntologySort, OntologySortField, SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
 import {BackendPaginationController} from "@/breeding-insight/model/view_models/BackendPaginationController";
+import {Category} from "@/breeding-insight/model/Category";
 
 @Component({
   mixins: [validationMixin],
@@ -513,7 +514,7 @@ export default class OntologyTable extends Vue {
       //For nominal traits switch back label value
       let traitToSave = JSON.parse(JSON.stringify(this.newTrait));
       if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
-        traitToSave.scale.categories.forEach((category) => {
+        traitToSave.scale.categories.forEach((category: Category) => {
           category.value = category.label;
           category.label = undefined;
         });
@@ -571,7 +572,7 @@ export default class OntologyTable extends Vue {
       //For nominal traits switch back label value
       let traitToSave = JSON.parse(JSON.stringify(this.editTrait));
       if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
-        traitToSave.scale.categories.forEach((category) => {
+        traitToSave.scale.categories.forEach((category: Category) => {
           category.value = category.label;
           category.label = undefined;
         });

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -494,7 +494,7 @@ export default class OntologyTable extends Vue {
   async saveTrait() {
     try {
       //For nominal traits switch back label value
-      if ((this.newTrait.scale) && (Scale.dataTypeEquals(this.newTrait.scale.dataType, DataType.Nominal))) {
+      if ((this.newTrait.scale) && (this.newTrait.scale.dataType) && (Scale.dataTypeEquals(this.newTrait.scale.dataType, DataType.Nominal)) && (this.newTrait.scale.categories)) {
         this.newTrait.scale.categories.forEach(category => {
           category.value = category.label;
           category.label = undefined;
@@ -551,7 +551,7 @@ export default class OntologyTable extends Vue {
   async updateTrait(archiveStateChanged?: boolean) {
     try {
       //For nominal traits switch back label value
-      if ((this.editTrait.scale) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal))) {
+      if ((this.editTrait.scale) && (this.newTrait.scale.dataType) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal)) && (this.newTrait.scale.categories)) {
         this.editTrait.scale.categories.forEach(category => {
           category.value = category.label;
           category.label = undefined;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -512,13 +512,7 @@ export default class OntologyTable extends Vue {
   async saveTrait() {
     try {
       //For nominal traits switch back label value
-      let traitToSave = JSON.parse(JSON.stringify(this.newTrait));
-      if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
-        traitToSave.scale.categories.forEach((category: Category) => {
-          category.value = category.label;
-          category.label = undefined;
-        });
-      }
+      let traitToSave = this.prepareScaleCategoriesForSave(this.newTrait);
 
       this.validationHandler = new ValidationError();
       const [ [savedTrait], metadata ] = await TraitService.createTraits(this.activeProgram!.id!, [traitToSave]);
@@ -570,13 +564,7 @@ export default class OntologyTable extends Vue {
   async updateTrait(archiveStateChanged?: boolean) {
     try {
       //For nominal traits switch back label value
-      let traitToSave = JSON.parse(JSON.stringify(this.editTrait));
-      if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
-        traitToSave.scale.categories.forEach((category: Category) => {
-          category.value = category.label;
-          category.label = undefined;
-        });
-      }
+      let traitToSave = this.prepareScaleCategoriesForSave(this.editTrait);
 
       this.editValidationHandler = new ValidationError();
       const [data] = await TraitService.updateTraits(this.activeProgram!.id!, [traitToSave!]) as [Trait[], Metadata];
@@ -623,6 +611,17 @@ export default class OntologyTable extends Vue {
     this.newTrait = new Trait();
     this.validationHandler = new ValidationError();
     this.newTraitActive = false;
+  }
+
+  prepareScaleCategoriesForSave(inputTrait: Trait){
+    let traitToSave = JSON.parse(JSON.stringify(inputTrait));
+    if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
+      traitToSave.scale.categories.forEach((category: Category) => {
+        category.value = category.label;
+        category.label = undefined;
+      });
+    }
+    return traitToSave;
   }
 
   async getAttributesEntitiesDescriptions() {

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -494,16 +494,17 @@ export default class OntologyTable extends Vue {
   async saveTrait() {
     try {
       //For nominal traits switch back label value
-      if ((this.newTrait) && (this.newTrait.scale) && (this.newTrait.scale.dataType) && (Scale.dataTypeEquals(this.newTrait.scale.dataType, DataType.Nominal)) && (this.newTrait.scale.categories)) {
-        this.newTrait.scale.categories.forEach(category => {
+      let traitToSave = JSON.parse(JSON.stringify(this.newTrait));
+      if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
+        traitToSave.scale.categories.forEach(category => {
           category.value = category.label;
           category.label = undefined;
         });
       }
 
       this.validationHandler = new ValidationError();
-      const [ [savedTrait], metadata ] = await TraitService.createTraits(this.activeProgram!.id!, [this.newTrait]);
-      if (this.newTrait.active === false) {
+      const [ [savedTrait], metadata ] = await TraitService.createTraits(this.activeProgram!.id!, [traitToSave]);
+      if (traitToSave.active === false) {
         savedTrait.active = false;
         await TraitService.archiveTrait(this.activeProgram!.id!, savedTrait);
       }
@@ -551,15 +552,18 @@ export default class OntologyTable extends Vue {
   async updateTrait(archiveStateChanged?: boolean) {
     try {
       //For nominal traits switch back label value
-      if ((this.editTrait) && (this.editTrait.scale) && (this.editTrait.scale.dataType) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal)) && (this.editTrait.scale.categories)) {
-        this.editTrait.scale.categories.forEach(category => {
-          category.value = category.label;
-          category.label = undefined;
-        });
+      if (this.editTrait) {
+        let traitToSave = JSON.parse(JSON.stringify(this.editTrait));
+        if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
+          traitToSave.scale.categories.forEach(category => {
+            category.value = category.label;
+            category.label = undefined;
+          });
+        }
       }
 
       this.editValidationHandler = new ValidationError();
-      const [data] = await TraitService.updateTraits(this.activeProgram!.id!, [this.editTrait!]) as [Trait[], Metadata];
+      const [data] = await TraitService.updateTraits(this.activeProgram!.id!, [traitToSave!]) as [Trait[], Metadata];
 
       // Temporary: Only update the given trait.
       // TODO: Select all traits and find the edited trait within results to keep row open

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -564,7 +564,7 @@ export default class OntologyTable extends Vue {
   async updateTrait(archiveStateChanged?: boolean) {
     try {
       //For nominal traits switch back label value
-      let traitToSave = this.prepareScaleCategoriesForSave(this.editTrait);
+      let traitToSave = this.prepareScaleCategoriesForSave(this.editTrait!);
 
       this.editValidationHandler = new ValidationError();
       const [data] = await TraitService.updateTraits(this.activeProgram!.id!, [traitToSave!]) as [Trait[], Metadata];

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -513,7 +513,7 @@ export default class OntologyTable extends Vue {
       //For nominal traits switch back label value
       let traitToSave = JSON.parse(JSON.stringify(this.newTrait));
       if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
-        traitToSave.scale.categories.forEach((category: Category[]) => {
+        traitToSave.scale.categories.forEach((category) => {
           category.value = category.label;
           category.label = undefined;
         });
@@ -571,7 +571,7 @@ export default class OntologyTable extends Vue {
       //For nominal traits switch back label value
       let traitToSave = JSON.parse(JSON.stringify(this.editTrait));
       if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
-        traitToSave.scale.categories.forEach((category: Category[]) => {
+        traitToSave.scale.categories.forEach((category) => {
           category.value = category.label;
           category.label = undefined;
         });

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -513,7 +513,7 @@ export default class OntologyTable extends Vue {
       //For nominal traits switch back label value
       let traitToSave = JSON.parse(JSON.stringify(this.newTrait));
       if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
-        traitToSave.scale.categories.forEach(category => {
+        traitToSave.scale.categories.forEach((category: Category[]) => {
           category.value = category.label;
           category.label = undefined;
         });
@@ -569,14 +569,12 @@ export default class OntologyTable extends Vue {
   async updateTrait(archiveStateChanged?: boolean) {
     try {
       //For nominal traits switch back label value
-      if (this.editTrait) {
-        let traitToSave = JSON.parse(JSON.stringify(this.editTrait));
-        if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
-          traitToSave.scale.categories.forEach(category => {
-            category.value = category.label;
-            category.label = undefined;
-          });
-        }
+      let traitToSave = JSON.parse(JSON.stringify(this.editTrait));
+      if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
+        traitToSave.scale.categories.forEach((category: Category[]) => {
+          category.value = category.label;
+          category.label = undefined;
+        });
       }
 
       this.editValidationHandler = new ValidationError();

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -268,7 +268,7 @@
       if (this.editActive){
         this.editTrait = Trait.assign({...this.data} as Trait);
         //For nominal, switch value and label for ease of display
-        if ((this.editTrait.scale) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal))) {
+        if ((this.editTrait.scale) && (this.editTrait.scale.dataType) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal)) && (this.editTrait.scale.categories)) {
           this.editTrait.scale.categories.forEach(category => {
             category.label = category.value;
             category.value = undefined;

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -267,6 +267,13 @@
     watchEdit() {
       if (this.editActive){
         this.editTrait = Trait.assign({...this.data} as Trait);
+        //For nominal, switch value and label for ease of display
+        if ((this.editTrait.scale) && (Scale.dataTypeEquals(this.editTrait.scale.dataType, DataType.Nominal))) {
+          this.editTrait.scale.categories.forEach(category => {
+            category.label = category.value;
+            category.value = undefined;
+          });
+        }
       } else {
         this.editTrait = null;
       }

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -327,7 +327,7 @@ export default class BaseTraitForm extends Vue {
   private scaleHistory: {[key: string]: Scale} = {};
   private lastCategoryType: string = '';
 
-  private categories: Category[] = this.trait.scale.categories;
+  private categories: Category[] = [];
 
   get traitName(): string {
     let prefix = '';
@@ -358,6 +358,9 @@ export default class BaseTraitForm extends Vue {
     }
     if (!this.trait.scale){
       this.trait.scale = new Scale();
+    }
+    if ((this.trait.scale) && (this.trait.scale.categories)) {
+      this.categories = this.trait.scale.categories;
     }
   }
 

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -472,29 +472,34 @@ export default class BaseTraitForm extends Vue {
         this.trait.scale.categories = this.prepopulateCategories();
       }
     }
-    this.categories = this.trait.scale.categories;
+    if ((this.trait.scale) && (this.trait.scale.categories)) {
+      this.categories = this.trait.scale.categories;
+    }
   }
 
   prepopulateCategories() {
     let emptyCategories = [];
-    let minCategories = this.trait.scale.dataType === DataType.Ordinal ? 2 : 1;
-    let indexVal = this.trait.scale.dataType === DataType.Ordinal ? true : false;
-    for (const i of Array(minCategories).keys()) {
-      if (indexVal) {
-        emptyCategories.push(new Category(undefined, i + 1 + ''))
-      }
-      else {
-        emptyCategories.push(new Category(undefined, undefined));
+    if ((this.trait.scale) && (this.trait.scale.dataType)) {
+      let minCategories = this.trait.scale.dataType === DataType.Ordinal ? 2 : 1;
+      let indexVal = this.trait.scale.dataType === DataType.Ordinal ? true : false;
+      for (const i of Array(minCategories).keys()) {
+        if (indexVal) {
+          emptyCategories.push(new Category(undefined, i + 1 + ''))
+        } else {
+          emptyCategories.push(new Category(undefined, undefined));
+        }
       }
     }
     return emptyCategories;
   }
 
   restoreMinCategories(minCategories: number) {
-    let belowMinCat = minCategories - this.trait.scale.categories.length;
-    if (belowMinCat > 0) {
-      for (const i of Array(belowMinCat).keys()) {
-        this.trait.scale.categories.push(new Category(undefined, undefined));
+    if ((this.trait.scale) && (this.trait.scale.categories)) {
+      let belowMinCat = minCategories - this.trait.scale.categories.length;
+      if (belowMinCat > 0) {
+        for (const i of Array(belowMinCat).keys()) {
+          this.trait.scale.categories.push(new Category(undefined, undefined));
+        }
       }
     }
   }

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -208,7 +208,7 @@
       <div class="column is-10">
         <CategoryTraitForm
             class="p-0"
-            v-bind:data="trait.scale.categories"
+            v-bind:data="categories"
             v-on:update-data="setCategories($event)"
             v-bind:type="trait.scale.dataType"
             v-bind:validation-handler="validationHandler"
@@ -327,6 +327,8 @@ export default class BaseTraitForm extends Vue {
   private scaleHistory: {[key: string]: Scale} = {};
   private lastCategoryType: string = '';
 
+  private categories: Category[] = [];
+
   get traitName(): string {
     let prefix = '';
     if (this.trait.entity || this.trait.attribute) prefix = '=';
@@ -397,7 +399,6 @@ export default class BaseTraitForm extends Vue {
   }
 
   setScaleClass(value: string) {
-    console.log("setscaleclass");
     // Save history of current scale class
     if (this.trait.scale!.dataType) {
       this.scaleHistory[this.trait.scale!.dataType.toLowerCase()] = Scale.assign({...this.trait.scale!} as Scale);
@@ -417,18 +418,10 @@ export default class BaseTraitForm extends Vue {
 
       // Clear the values, use labels as the new values if they exist
       if (this.trait.scale.categories) {
-        console.log("pre filter");
-        console.log(this.trait.scale.categories);
         //Remove empty categories
         this.trait.scale.categories = this.trait.scale.categories.filter((value,index) => {
-          console.log(value.value);
-          console.log(value.label);
-          console.log(value.value !== undefined);
-          console.log(value.label !== undefined);
-          return (value.value !== undefined || value.label !== undefined);
+          return (((value.value != null) && (value.value !== "")) || ((value.label != null) && (value.label !== "")));
         });
-        console.log("post filter");
-        console.log(this.trait.scale.categories);
         this.trait.scale.categories.forEach(category => {
           category.value = category.label;
           category.label = undefined;
@@ -446,13 +439,9 @@ export default class BaseTraitForm extends Vue {
       // Add 1-based index values to categories
       if (this.trait.scale.categories) {
         //Remove empty categories
-        console.log("pre filter");
-        console.log(this.trait.scale.categories);
         this.trait.scale.categories = this.trait.scale.categories.filter((value,index) => {
-          return (value.value !== undefined || value.label !== undefined);
+          return (((value.value != null) && (value.value !== "")) || ((value.label != null) && (value.label !== "")));
         });
-        console.log("post filter");
-        console.log(this.trait.scale.categories);
 
         //Restore minimum number of categories
         this.restoreMinCategories(2);
@@ -498,12 +487,12 @@ export default class BaseTraitForm extends Vue {
         this.trait.scale.categories = this.prepopulateCategories();
       }
     }
+    this.categories = this.trait.scale.categories;
   }
 
   prepopulateCategories() {
-    console.log('new prepop');
     let emptyCategories = [];
-    let minCategories = this.trait.scale.dataType === DataType.Ordinal ? 2 : 1;
+    let minCategories = this.trait.scale.dataType === DataType.Ordinal ? 2 : 4;
     let indexVal = this.trait.scale.dataType === DataType.Ordinal ? true : false;
     for (const i of Array(minCategories).keys()) {
       if (indexVal) {
@@ -527,8 +516,7 @@ export default class BaseTraitForm extends Vue {
 
   setCategories(categories: Category[]) {
     this.trait.scale!.categories = categories;
-    this.emitTrait(this.trait);
-    //
+    this.categories = categories;
   }
 
   setObservationLevel(value: string) {

--- a/src/components/trait/forms/CategoryTraitForm.vue
+++ b/src/components/trait/forms/CategoryTraitForm.vue
@@ -62,7 +62,7 @@
       </template>
     </template>
     <template v-if="Scale.dataTypeEquals(type, DataType.Nominal)">
-      <template v-for="[i, item] of this.data.entries()">
+      <template v-for="[i, item] of data.entries()">
         <ValueRow
             v-bind:value="item.value"
             v-on:delete="checkRemoveRow(i)"
@@ -108,13 +108,9 @@ import {RowError} from "@/breeding-insight/model/errors/RowError";
   components: {ValueRow, BasicInputField, LabelValueRow, WarningModal, PlusCircleIcon},
   data: () => ({DataType, TraitError, Scale}),
   computed: {
-    categories() {
-          console.log("tester");
-          console.log(this.data.entries());
-          console.log(this.data);
-          console.log(this.data.length)
-          return this.data;
-       }
+    categoryVals: function () {
+      //return this.data;
+    }
   }
 })
 export default class CategoryTraitForm extends Vue {
@@ -135,41 +131,24 @@ export default class CategoryTraitForm extends Vue {
   private activeRemoveRowIndex?: number;
   private deleteModalActive: boolean = false;
 
-  mounted() {
-    console.log("mounted");
-    //console.log(this.data);
-    console.log(this.data.length);
+  @Watch('data', {immediate: true, deep: true})
+  todo() {
+    //it doesn't get here on first try why
+    console.log("here is a watch");
   }
-
-  created(){
-    console.log('created');
-    //console.log(this.data.length);
-  }
-
-  beforeCreate(){
-    console.log('beforecreate');
-  }
-
-  /*@Watch('data', {immediate: true, deep: true})
-  emitData(){
-    this.$emit('update', this.data);
-  }*/ //not good cause not changing prop locally cause anti-pattern
 
   @Watch('type', {immediate: true})
   updateCategories() {
-    //todo swapping
-    let newCategories = this.data.filter((value,index) => {
-      return (value.value !== undefined || value.label !== undefined);
-    });
+    let newCategories = this.data;
 
-    console.log('updatecat');
-    if (newCategories.length === 0) { //ah that is why...when passed in the thingy is set to 1, so it is defined so never hits this block
-      newCategories = this.prepopulateCategories(newCategories);
-    }
+    console.log('updatecat old');
+    console.log(this.data.length);
 
-    this.$emit('update:data', newCategories);
+    this.$emit('update-data', newCategories);
     console.log("post emit");
     console.log(this.data.length);
+
+    //todo might not be needed anymore?
   }
 
   getCategoryErrors(categoryIndex: number): RowError | undefined {
@@ -188,17 +167,6 @@ export default class CategoryTraitForm extends Vue {
         }
       }
     }
-  }
-
-  //todo remove
-  prepopulateCategories(categories) {
-    console.log('prepop');
-    let minCategories = this.type === DataType.Ordinal ? 2 : 1;
-    for (const i of Array(minCategories).keys()) {
-      categories.push(new Category(undefined, undefined));
-    }
-    console.log(categories.length);
-    return categories;
   }
 
   checkRemoveRow(index: number) {
@@ -221,10 +189,11 @@ export default class CategoryTraitForm extends Vue {
   }
 
   removeRow() {
+    let newCategories = this.data;
     if ((this.type === DataType.Ordinal && this.data.length > 2) ||
         (this.type === DataType.Nominal && this.data.length > 1) ||
         (this.type !== DataType.Ordinal && this.type !== DataType.Nominal)) {
-      this.data.splice(this.activeRemoveRowIndex!,1);
+      newCategories.splice(this.activeRemoveRowIndex!,1);
       this.activeRemoveRowIndex = undefined;
       this.deleteModalActive = false;
       return;
@@ -232,13 +201,15 @@ export default class CategoryTraitForm extends Vue {
     this.activeRemoveRowIndex = undefined;
     this.deleteModalActive = false;
 
-    //todo this will have to be synced i guess
+    this.$emit('update-data', newCategories);
     return;
   }
 
   addRow() {
-    this.data.push(new Category());
-    //todo this will have to be synced i guess
+    let newCategories = this.data;
+    newCategories.push(new Category());
+    console.log("add");
+    this.$emit('update-data', newCategories);
   }
 }
 </script>

--- a/src/components/trait/forms/CategoryTraitForm.vue
+++ b/src/components/trait/forms/CategoryTraitForm.vue
@@ -107,11 +107,6 @@ import {RowError} from "@/breeding-insight/model/errors/RowError";
 @Component({
   components: {ValueRow, BasicInputField, LabelValueRow, WarningModal, PlusCircleIcon},
   data: () => ({DataType, TraitError, Scale}),
-  computed: {
-    categoryVals: function () {
-      //return this.data;
-    }
-  }
 })
 export default class CategoryTraitForm extends Vue {
 
@@ -130,26 +125,6 @@ export default class CategoryTraitForm extends Vue {
   private deleteWarningTitle: string = "Remove category?"
   private activeRemoveRowIndex?: number;
   private deleteModalActive: boolean = false;
-
-  @Watch('data', {immediate: true, deep: true})
-  todo() {
-    //it doesn't get here on first try why
-    console.log("here is a watch");
-  }
-
-  @Watch('type', {immediate: true})
-  updateCategories() {
-    let newCategories = this.data;
-
-    console.log('updatecat old');
-    console.log(this.data.length);
-
-    this.$emit('update-data', newCategories);
-    console.log("post emit");
-    console.log(this.data.length);
-
-    //todo might not be needed anymore?
-  }
 
   getCategoryErrors(categoryIndex: number): RowError | undefined {
     if (this.validationHandler) {
@@ -189,11 +164,10 @@ export default class CategoryTraitForm extends Vue {
   }
 
   removeRow() {
-    let newCategories = this.data;
     if ((this.type === DataType.Ordinal && this.data.length > 2) ||
         (this.type === DataType.Nominal && this.data.length > 1) ||
         (this.type !== DataType.Ordinal && this.type !== DataType.Nominal)) {
-      newCategories.splice(this.activeRemoveRowIndex!,1);
+      this.data.splice(this.activeRemoveRowIndex!,1);
       this.activeRemoveRowIndex = undefined;
       this.deleteModalActive = false;
       return;
@@ -201,15 +175,11 @@ export default class CategoryTraitForm extends Vue {
     this.activeRemoveRowIndex = undefined;
     this.deleteModalActive = false;
 
-    this.$emit('update-data', newCategories);
     return;
   }
 
   addRow() {
-    let newCategories = this.data;
-    newCategories.push(new Category());
-    console.log("add");
-    this.$emit('update-data', newCategories);
+    this.data.push(new Category());
   }
 }
 </script>

--- a/src/components/trait/forms/CategoryTraitForm.vue
+++ b/src/components/trait/forms/CategoryTraitForm.vue
@@ -62,7 +62,7 @@
       </template>
     </template>
     <template v-if="Scale.dataTypeEquals(type, DataType.Nominal)">
-      <template v-for="[i, item] of data.entries()">
+      <template v-for="[i, item] of this.data.entries()">
         <ValueRow
             v-bind:value="item.value"
             v-on:delete="checkRemoveRow(i)"
@@ -106,7 +106,16 @@ import {RowError} from "@/breeding-insight/model/errors/RowError";
 
 @Component({
   components: {ValueRow, BasicInputField, LabelValueRow, WarningModal, PlusCircleIcon},
-  data: () => ({DataType, TraitError, Scale})
+  data: () => ({DataType, TraitError, Scale}),
+  computed: {
+    categories() {
+          console.log("tester");
+          console.log(this.data.entries());
+          console.log(this.data);
+          console.log(this.data.length)
+          return this.data;
+       }
+  }
 })
 export default class CategoryTraitForm extends Vue {
 
@@ -126,20 +135,41 @@ export default class CategoryTraitForm extends Vue {
   private activeRemoveRowIndex?: number;
   private deleteModalActive: boolean = false;
 
-  @Watch('data', {immediate: true, deep: true})
+  mounted() {
+    console.log("mounted");
+    //console.log(this.data);
+    console.log(this.data.length);
+  }
+
+  created(){
+    console.log('created');
+    //console.log(this.data.length);
+  }
+
+  beforeCreate(){
+    console.log('beforecreate');
+  }
+
+  /*@Watch('data', {immediate: true, deep: true})
   emitData(){
     this.$emit('update', this.data);
-  }
+  }*/ //not good cause not changing prop locally cause anti-pattern
 
   @Watch('type', {immediate: true})
   updateCategories() {
-    this.data = this.data.filter((value,index) => {
+    //todo swapping
+    let newCategories = this.data.filter((value,index) => {
       return (value.value !== undefined || value.label !== undefined);
     });
-    
-    if (this.data.length === 0) {
-      this.prepopulateCategories();
+
+    console.log('updatecat');
+    if (newCategories.length === 0) { //ah that is why...when passed in the thingy is set to 1, so it is defined so never hits this block
+      newCategories = this.prepopulateCategories(newCategories);
     }
+
+    this.$emit('update:data', newCategories);
+    console.log("post emit");
+    console.log(this.data.length);
   }
 
   getCategoryErrors(categoryIndex: number): RowError | undefined {
@@ -147,7 +177,7 @@ export default class CategoryTraitForm extends Vue {
       const fieldErrors: FieldError[] = this.validationHandler.getValidation(this.validationIndex, TraitError.ScaleCategories);
       if (fieldErrors.length > 0) {
         for (const [index, fieldError] of fieldErrors.entries()) {
-          // Check that it has nested errors for the catogeries
+          // Check that it has nested errors for the categories
           if (fieldError.rowErrors){
             // Get the specific category index requested
             const rowError: RowError[] = fieldError.rowErrors.filter(rowError => rowError.rowIndex === categoryIndex);
@@ -160,11 +190,15 @@ export default class CategoryTraitForm extends Vue {
     }
   }
 
-  prepopulateCategories() {
+  //todo remove
+  prepopulateCategories(categories) {
+    console.log('prepop');
     let minCategories = this.type === DataType.Ordinal ? 2 : 1;
     for (const i of Array(minCategories).keys()) {
-      this.data.push(new Category(undefined, undefined));
+      categories.push(new Category(undefined, undefined));
     }
+    console.log(categories.length);
+    return categories;
   }
 
   checkRemoveRow(index: number) {
@@ -197,11 +231,14 @@ export default class CategoryTraitForm extends Vue {
     }
     this.activeRemoveRowIndex = undefined;
     this.deleteModalActive = false;
+
+    //todo this will have to be synced i guess
     return;
   }
 
   addRow() {
     this.data.push(new Category());
+    //todo this will have to be synced i guess
   }
 }
 </script>

--- a/src/components/trait/forms/CategoryTraitForm.vue
+++ b/src/components/trait/forms/CategoryTraitForm.vue
@@ -64,9 +64,9 @@
     <template v-if="Scale.dataTypeEquals(type, DataType.Nominal)">
       <template v-for="[i, item] of data.entries()">
         <ValueRow
-            v-bind:value="item.value"
+            v-bind:value="item.label"
             v-on:delete="checkRemoveRow(i)"
-            v-on:value-change="item.value = $event"
+            v-on:value-change="item.label = $event"
             v-bind:value-placeholder="nominalPlaceholders[i]"
             v-bind:key="i"
             v-bind:can-be-removed="i > 0"
@@ -106,7 +106,7 @@ import {RowError} from "@/breeding-insight/model/errors/RowError";
 
 @Component({
   components: {ValueRow, BasicInputField, LabelValueRow, WarningModal, PlusCircleIcon},
-  data: () => ({DataType, TraitError, Scale}),
+  data: () => ({DataType, TraitError, Scale})
 })
 export default class CategoryTraitForm extends Vue {
 


### PR DESCRIPTION
# Description
**Story:** [ISSUE: New/Edit Term - Switching between scale classes, specifically ordinal and nominal, not working properly](https://breedinginsight.atlassian.net/browse/BI-1356)

Refactoring of Ordinal/Nominal display to get rid of anti-pattern, fix problem with ordinal/nominal category fields not displaying on first selection, and make code more robust.

- Functionality for modifying category "data" prop was moved from child component CategoryTraitForm.vue to parent component BaseTraitForm in order to avoid anti-pattern problems.
- Categories are now being passed in as categories (which is set to this.trait.scale.categories) due to the nested this.trait.scale.categories prop messing with reactivity
- Switching between ordinal/nominal now effectively hides the "value" fields rather than switching around item.value and item.label when changing scale class and maintaining a history. 
  - The category fields are consistent between ordinal and nominal display, with item.label being passed in as the category for both ValueRow.vue (used for nominal) and LabelValueRow.vue (used for ordinal). item.value is passed in as the value in LabelValueRow.vue, and is effectively "hidden" when switching from ordinal to nominal selection.
  - On save, if the scale class is nominal, the value and label are switched around in order to properly save to the database, and on load they are switched to maintain this more robust display.

# Dependencies
bi-api/release/0.5

# Testing

- Create new ontology term, select nominal, make sure one category displays and categories can be added and removed switch to ordinal and see that there are at minimum two fields and information is preserved
- Create new ontology term, select ordinal, make sure two categories display and categories can be added and removed switch to ordinal and see that there are at minimum two fields and information is preserved
- Save new ordinal term successfully
- Save new nominal term successfully
- Open existing nominal ontology term, check categories display properly, click edit, check display properly, save, check save properly
- Open existing ordinal ontology term, check categories display properly, click edit, check display properly, save, check save properly

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/1959345494)
