### PR TITLE
[BI-1369] enable backend sorting for roles column of program users table

### DIFF
--- a/src/breeding-insight/service/UserService.ts
+++ b/src/breeding-insight/service/UserService.ts
@@ -137,7 +137,6 @@ export class UserService {
 
       UserDAO.getAll(paginationQuery, sort).then((biResponse) => {
 
-        biResponse.result.data = PaginationController.mockSortRecords(biResponse.result.data);
         // Parse our users into the vue users param
         let users = biResponse.result.data.map((user: any) => {
           const role: Role | undefined = this.parseSystemRoles(user.systemRoles);

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -131,7 +131,7 @@
       <b-table-column field="data.email" label="Email" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ props.row.data.email }}
       </b-table-column>
-      <b-table-column :custom-sort="sortRole" label="Role" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="data.roleName" label="Role" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         <template v-if="rolesMap.size > 0">
           {{ getRoleName(props.row.data.roleId) }}
         </template>
@@ -263,7 +263,11 @@ export default class ProgramUsersTable extends Vue {
   }
 
   setSort(field: string, order: string) {
-    const fieldMap: any = {'data.email': UserSortField.Email, 'data.name': UserSortField.Name};
+    const fieldMap: any = {
+      'data.email': UserSortField.Email,
+      'data.name': UserSortField.Name,
+      'data.roleName': UserSortField.Roles
+    };
     if (field in fieldMap) {
       this.updateSort(new UserSort(fieldMap[field], Sort.orderAsBI(order)));
       this.getUsers();
@@ -472,14 +476,6 @@ export default class ProgramUsersTable extends Vue {
 
   getRoleName(id: string): string | undefined {
     return this.rolesMap.get(id)!.name;
-  }
-
-  sortRole(a: any, b: any, isAsc: boolean) {
-    if(isAsc) {
-      return this.getRoleName(a.data.roleId)!.localeCompare(this.getRoleName(b.data.roleId)!);
-    } else {
-      return this.getRoleName(b.data.roleId)!.localeCompare(this.getRoleName(a.data.roleId)!);
-    }
   }
 
 }

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -61,7 +61,11 @@ export const getters: GetterTree<SortState, RootState> = {
         return state.programUserSort;
     },
     programUserSortFieldAsBuefy(state: SortState): string {
-        const fieldMap: any = {[UserSortField.Email]: 'data.email', [UserSortField.Name]: 'data.name'};
+        const fieldMap: any = {
+            [UserSortField.Email]: 'data.email',
+            [UserSortField.Name]: 'data.name',
+            [UserSortField.Roles]: 'data.roleName'
+        };
         return fieldMap[state.programUserSort.field];
     },
     programUserSortOrderAsBuefy(state: SortState): string {


### PR DESCRIPTION
# Description
**Story:** [BI-1369](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1369)

- Backend sorting enabled for roles column of program user's table
- Vuex sort module getter for program users updated to include roles

# Dependencies
release/0.5 bi-api
backend code for sorting on user roles already in place, so only front-end changes

# Testing

1. add several users of different roles and click on roles header to toggle sort order
2. navigate to locations tab and back to users tab and verify that sort state for users table has not changed


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
