### PR TITLE
[BI-1202] Germplasm Table: Add sorting to all columns

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -25,12 +25,20 @@ export class Sort {
     'asc': SortOrder.Ascending,
     'desc': SortOrder.Descending
   };
+  static buefySortOrder: any = {
+    [SortOrder.Ascending]: 'asc',
+    [SortOrder.Descending]: 'desc'
+  }
 
   static orderAsBI(order: string) {
     if (order in this.orderMap) {
       return this.orderMap[order];
     }
     return SortOrder.Ascending;
+  }
+
+  static orderAsBuefy(order: SortOrder) {
+    return this.buefySortOrder[order];
   }
 }
 
@@ -113,6 +121,28 @@ export class ProgramSort {
   order: SortOrder;
 
   constructor(field: ProgramSortField, order: SortOrder) {
+    this.field = field;
+    this.order = order;
+  }
+}
+
+// germplasm
+export enum GermplasmSortField {
+  AccessionNumber = "accessionNumber",
+  DefaultDisplayName = "defaultDisplayName",
+  BreedingMethod = "additionalInfo.breedingMethod",
+  SeedSource = "seedSource",
+  FemaleParent = "femaleParent",
+  MaleParent = "maleParent",
+  CreatedDate = "additionalInfo.createdDate",
+  UserName = "additionalInfo.createdBy.userName"
+}
+
+export class GermplasmSort {
+  field: GermplasmSortField;
+  order: SortOrder;
+
+  constructor(field: GermplasmSortField, order: SortOrder) {
     this.field = field;
     this.order = order;
   }

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -159,13 +159,18 @@
               </router-link>
               <ul v-show="importFileActive">
                 <li>
-                  <router-link v-bind:to="{name: 'ontology', params: {programId: activeProgram.id}}">
+                  <router-link v-bind:to="{name: 'import-ontology', params: {programId: activeProgram.id}}">
                     Ontology
                   </router-link>
                 </li>
                 <li>
                   <router-link v-bind:to="{name: 'germplasm-import', params: {programId: activeProgram.id}}">
                     Germplasm
+                  </router-link>
+                </li>
+                <li>
+                  <router-link v-bind:to="{name: 'experiment-import', params: {programId: activeProgram.id}}">
+                    Experiments & Observations
                   </router-link>
                 </li>
                 <li>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -67,6 +67,7 @@ import OntologyArchivedTable from "@/components/ontology/OntologyArchivedTable.v
 import PageNotFound from "@/views/PageNotFound.vue";
 import Germplasm from "@/views/germplasm/Germplasm.vue";
 import GermplasmLists from "@/views/germplasm/GermplasmLists.vue";
+import ImportExperiment from "@/views/import/ImportExperiment.vue";
 
 Vue.use(VueRouter);
 
@@ -370,6 +371,15 @@ const routes = [
           layout: layouts.userSideBar
         },
         component: ImportGermplasm
+      },
+      {
+        path: 'experiment',
+        name: 'experiment-import',
+        meta: {
+          title: 'Experiments & Observations',
+          layout: layouts.userSideBar
+        },
+        component: ImportExperiment
       },
       {
         path: 'brapi-import',

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -19,6 +19,7 @@ import {GetterTree} from 'vuex';
 import {RootState} from "@/store/types";
 import {SortState} from "@/store/sorting/types";
 import {
+    GermplasmSort,
     LocationSort, OntologySort,
     ProgramSort,
     ProgramSortField,
@@ -107,5 +108,10 @@ export const getters: GetterTree<SortState, RootState> = {
     },
     programSortOrderAsBuefy(state: SortState): string {
         return orderMap[state.programSort.order];
+    },
+
+    // germplasm
+    germplasmSort(state: SortState): GermplasmSort {
+        return state.germplasmSort;
     }
 };

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -20,6 +20,8 @@ import {getters} from '@/store/sorting/getters';
 import {mutations} from '@/store/sorting/mutations';
 import {RootState} from '@/store/types';
 import {
+    GermplasmSort,
+    GermplasmSortField,
     LocationSort,
     LocationSortField,
     OntologySort,
@@ -53,7 +55,10 @@ state = {
     systemUserSort: new UserSort(UserSortField.Name, SortOrder.Ascending),
 
     // program table
-    programSort: new ProgramSort(ProgramSortField.Name, SortOrder.Ascending)
+    programSort: new ProgramSort(ProgramSortField.Name, SortOrder.Ascending),
+
+    // program table
+    germplasmSort: new GermplasmSort(GermplasmSortField.AccessionNumber, SortOrder.Ascending)
 };
 
 const namespaced: boolean = true

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -38,4 +38,7 @@ export const UPDATE_LOCATION_SORT = 'updateLocationSort';
 export const UPDATE_SYSTEM_USER_SORT = 'updateSystemUserSort';
 
 // program table
-export const UPDATE_PROGRAM_SORT = 'updateProgramSort'
+export const UPDATE_PROGRAM_SORT = 'updateProgramSort';
+
+// germplasm tbale
+export const UPDATE_GERMPLASM_SORT = 'updateGermplasmSort';

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -26,10 +26,11 @@ import {
     ACTIVE_ONT_TOGGLE_SORT_ORDER,
     ARCHIVED_ONT_TOGGLE_SORT_ORDER,
     IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER,
-    IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN
+    IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN, UPDATE_GERMPLASM_SORT
 } from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
 import {
+    GermplasmSort,
     LocationSort, OntologySort, OntologySortField,
     ProgramSort, SortOrder,
     TraitSortField,
@@ -83,5 +84,11 @@ export const mutations: MutationTree<SortState> = {
     [UPDATE_PROGRAM_SORT](state: SortState, sort: ProgramSort) {
         state.programSort.field = sort.field;
         state.programSort.order = sort.order;
+    },
+
+    //program table
+    [UPDATE_GERMPLASM_SORT](state: SortState, sort: GermplasmSort) {
+        state.germplasmSort.field = sort.field;
+        state.germplasmSort.order = sort.order;
     }
 };

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -1,4 +1,5 @@
 import {
+    GermplasmSort,
     LocationSort,
     OntologySort,
     ProgramSort, Sort, SortOrder,
@@ -27,5 +28,8 @@ export interface SortState {
     systemUserSort: UserSort,
 
     // program table
-    programSort: ProgramSort
+    programSort: ProgramSort,
+
+    // germplasm table
+    germplasmSort: GermplasmSort
 }

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -1,0 +1,100 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div id="import-experiment">
+    <ImportTemplate
+        v-bind:abort-msg="'No records will be added, and the import in progress will be completely removed.'"
+        v-bind:system-import-template-name="experimentImportTemplateName"
+        v-bind:confirm-msg="'Confirm New Experiments & Observations Records'"
+        v-bind:import-type-name="'Experiments & Observations'"
+        v-bind:confirm-import-state="confirmImportState"
+        v-on="$listeners"
+        v-on:finished="importFinished"
+    >
+
+      <template v-slot:importInfoTemplateMessageBox>
+        <ImportInfoTemplateMessageBox v-bind:import-type-name="'Experiments & Observations'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/ecmwixiwp5wl3cjq493hvhi4agq03cyh.xls'"
+                                      class="mb-5">
+          <strong>Before You Import...</strong>
+          <br/>
+          Experimental germplasm and ontology terms must be created in the system before experiments can be created via import.
+          See the import template for more information about data requirements. Importing phenotypic
+          observations into existing experiments requires only Observation Unit IDs
+          to match with the experimental design.
+        </ImportInfoTemplateMessageBox>
+      </template>
+
+      <template v-slot:confirmImportMessageBox="{ statistics, abort, confirm, rows }">
+        <ConfirmImportMessageBox v-bind:num-records="getNumNewExperimentRecords(statistics)"
+                                 v-bind:import-type-name="'Experiments & Observations'"
+                                 v-bind:confirm-import-state="confirmImportState"
+                                 v-on:abort="abort"
+                                 v-on:confirm="confirm"
+                                 class="mb-4">
+          <div>
+            <p class="is-size-5 mb-2"><strong>Import Summary</strong></p>
+            <p>Total number of entries: {{ rows.length }}</p>
+          </div>
+        </ConfirmImportMessageBox>
+      </template>
+
+      <template v-slot:importPreviewTable="previewData">
+      </template>
+
+    </ImportTemplate>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component } from 'vue-property-decorator'
+import ProgramsBase from "@/components/program/ProgramsBase.vue";
+import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTemplateMessageBox.vue";
+import ConfirmImportMessageBox from "@/components/trait/ConfirmImportMessageBox.vue";
+import ImportTemplate from "@/views/import/ImportTemplate.vue";
+import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
+import ReportTable from "@/components/report/ReportTable.vue";
+import {ImportFormatter} from "@/breeding-insight/model/report/ImportFormatter";
+import {ReportStruct} from "@/breeding-insight/model/report/ReportStruct";
+import defaultRenames from '@/config/report/ReportRenames';
+import { AlertTriangleIcon } from 'vue-feather-icons';
+import {GermplasmList} from "@/breeding-insight/model/GermplasmList";
+import BasicInputField from "@/components/forms/BasicInputField.vue";
+
+@Component({
+  components: {
+    ImportInfoTemplateMessageBox, ConfirmImportMessageBox, ImportTemplate, AlertTriangleIcon, BasicInputField
+  },
+  data: () => ({ImportFormatter})
+})
+export default class ImportExperiment extends ProgramsBase {
+
+  private experimentImportTemplateName = 'ExperimentsTemplateMap';
+  private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
+
+  private germplasmList: GermplasmList = new GermplasmList();
+
+
+  getNumNewExperimentRecords(statistics: any): number | undefined {
+    return undefined;
+  }
+
+  importFinished(){}
+
+}
+</script>

--- a/src/views/import/ImportFile.vue
+++ b/src/views/import/ImportFile.vue
@@ -35,6 +35,11 @@
             <a>Germplasm</a>
           </router-link>
           <router-link
+              v-bind:to="{name: 'experiment-import', params: {programId: activeProgram.id}}"
+              tag="li" active-class="is-active">
+            <a>Experiments & Observations</a>
+          </router-link>
+          <router-link
               v-bind:to="{name: 'brapi-import', params: {programId: activeProgram.id}}"
               tag="li" active-class="is-active">
             <a>BrAPI Import<span class="ml-2 tag is-warning">Beta</span></a>


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1202

Made all germplasm table columns sortable and hooked them up to the backend sorting. Test was added on backend. 



# Dependencies
biapi: BI-1202

# Testing
See bi-api PR for testing details.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
