### PR TITLE
BI-1425 - Bad Scaling: Welcome BI Admin

### DIFF
--- a/src/views/program/ProgramSelection.vue
+++ b/src/views/program/ProgramSelection.vue
@@ -22,11 +22,11 @@
     <p>Which program are you working with today?</p>
     <div class="columns">
       <div class="column is-narrow">
-        <div class="buttons">
+        <div class="buttons is-block">
           <template v-if="activeUser && activeUser.hasRole('admin')">
             <router-link
               v-bind:to="{name: 'admin'}"
-              class="button is-primary is-light is-fullwidth is-outlined"
+              class="button is-primary is-light is-block is-outlined mr-0"
             >
               System Administration
             </router-link>
@@ -36,7 +36,7 @@
                 v-for="program in programs"
                 v-bind:key="program.id"
                 v-bind:to="{name: 'program-home', params: {programId: program.id}}"
-                class="button is-primary is-light is-fullwidth is-outlined"
+                class="button is-primary is-light is-block is-outlined mr-0"
             >
               {{program.name}}
             </router-link>


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1425

Updated the styling of the buttons on the program selection page so that the buttons don't use flexbox.  The desired look of the page was to have a button for each program on its own line.  The styling that was implemented accomplished this, but for some reason, caused the buttons to grow exponentially wide as more programs were added to the system.  The fix removes the use of flexbox for how these buttons display, and instead they are now just displayed as `block` elements.



# Dependencies
bi-api: `release/0.5`

# Testing
1. Add 5 or more programs to BI
2. In the browser URL bar, change the URL to the root (ex: `localhost:8080/admin/program-management` should be changed to `localhost:8080`)
3. Verify that the list of program buttons does not extend horizontally to the right off of the screen.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: 
