### PR TITLE
[BI-1414] - Improve table loading message

### DIFF
--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -407,14 +407,12 @@ export default class OntologyTable extends Vue {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = traits;
         this.traitsPagination = metadata.pagination;
-        this.traitsLoading = false;
       }
     }).catch((error) => {
       // Display error that traits cannot be loaded
       this.$emit('show-error-notification', 'Error while trying to load traits');
-      this.traitsLoading =  false;
       throw error;
-    });
+    }).finally( () => this.traitsLoading =  false );
   }
 
   async editable(trait: Trait) {

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -112,6 +112,7 @@
     <SidePanelTable
       ref="sidePanelTable"
       v-bind:records="traits"
+      v-bind:loading="this.traitsLoading"
       v-bind:pagination="traitsPagination"
       v-bind:auto-handle-close-panel-event="false"
       v-bind:side-panel-state="traitSidePanelState"
@@ -301,6 +302,7 @@ export default class OntologyTable extends Vue {
   private newTrait: Trait = new Trait();
   private currentTraitEditable = false;
   private loadingTraitEditable = true;
+  private traitsLoading: boolean = false;
 
   // table column sorting
   private nameSortLabel: string = OntologySortField.Name;
@@ -399,15 +401,18 @@ export default class OntologyTable extends Vue {
   getTraits() {
     // filter the terms pulled from the back-end
     let filters: TraitFilter[] = [{ field: TraitField.STATUS, value: this.active}];
+    this.traitsLoading = true;
 
     TraitService.getFilteredTraits(this.activeProgram!.id!, this.paginationController.currentCall, true, filters, this.ontologySort).then(([traits, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = traits;
         this.traitsPagination = metadata.pagination;
+        this.traitsLoading = false;
       }
     }).catch((error) => {
       // Display error that traits cannot be loaded
       this.$emit('show-error-notification', 'Error while trying to load traits');
+      this.traitsLoading =  false;
       throw error;
     });
   }

--- a/src/components/tables/SidePanelTable.vue
+++ b/src/components/tables/SidePanelTable.vue
@@ -91,7 +91,7 @@
                           v-on:paginate-page-size="closePanelAndReEmit('paginate-page-size', $event)"/>
 
       <template v-if="records.length === 0">
-        <slot name="emptyMessage" />
+        <slot v-if="this.loading !== true" name="emptyMessage" />
       </template>
     </div>
 
@@ -148,6 +148,8 @@
     autoHandleClosePanelEvent!: boolean;
     @Prop()
     sidePanelState!: SidePanelTableEventBusHandler;
+    @Prop()
+    loading!: boolean;
 
     private BreakpointEvent = BreakpointEvent;
     private state = CollapseColumnsState.NORMAL_PANEL_CLOSED;

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -38,6 +38,7 @@
         v-bind="$attrs"
         :default-sort="defaultSort"
         v-on="$listeners"
+        v-bind:loading="loading"
         :row-class="calculateRowClass"
     >
 
@@ -68,7 +69,7 @@
         </a>
       </b-table-column>
 
-      <template v-slot:empty>
+      <template v-slot:empty v-if="this.loading !== true">
         <slot name="emptyMessage" />
       </template>
 
@@ -125,6 +126,8 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   defaultSort!: String[];
   @Prop()
   rowClasses: any;
+  @Prop()
+  loading!: boolean;
 
   private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
   private openDetail: Array<TableRow<any>> = new Array<TableRow<any>>();


### PR DESCRIPTION
# Description
**Story:** [BI-1414 - Improve table loading message](https://breedinginsight.atlassian.net/browse/BI-1414)

Updated both SidePanelTable.vue and ExpandableTable.vue to take in a loading prop and use it for logic re: displaying a no entries message.

# Dependencies
bi-web/develop

# Testing

- Open Ontology Table with no entries - no entries message displays only after loading complete
- Open Ontology Table with entries - no entries message never displays
- Open Germplasm Table with no entries - no entries message displays only after loading complete
- Open Germplasm Table with entries - no entries message never displays

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [n/a] I have create/modified unit tests to cover this change
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to documentation
- [x] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/1970099521)
