### PR TITLE
BI-1404 - No loading wheel ontology page

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -395,6 +395,26 @@ table tr.is-edited + .detail {
   }
 }
 
+// adapted from https://github.com/jgthms/bulma/issues/847
+.loading-indicator {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.5;
+  &:after {
+    @include loader;
+    position: absolute;
+    top: calc(50% - 2.5em);
+    left: calc(50% - 2.5em);
+    width: 5em;
+    height: 5em;
+    border-width: 0.25em;
+  }
+}
+
+.table-min-height {
+  min-height: 100px;
+}
+
 .menu-scroll {
   position: absolute;
   height: 100%;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -112,7 +112,6 @@
     <SidePanelTable
       ref="sidePanelTable"
       v-bind:records="traits"
-      v-bind:loading="this.traitsLoading"
       v-bind:pagination="traitsPagination"
       v-bind:auto-handle-close-panel-event="false"
       v-bind:side-panel-state="traitSidePanelState"

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -115,6 +115,7 @@
       v-bind:pagination="traitsPagination"
       v-bind:auto-handle-close-panel-event="false"
       v-bind:side-panel-state="traitSidePanelState"
+      v-bind:loading="traitsLoading"
       v-on:paginate="paginationController.updatePage($event)"
       v-on:paginate-toggle-all="paginationController.toggleShowAll(traitsPagination.totalCount.valueOf())"
       v-on:paginate-page-size="paginationController.updatePageSize(parseInt($event,10))"
@@ -301,6 +302,7 @@ export default class OntologyTable extends Vue {
   private newTrait: Trait = new Trait();
   private currentTraitEditable = false;
   private loadingTraitEditable = true;
+  private traitsLoading = true;
 
   // table column sorting
   private nameSortLabel: string = OntologySortField.Name;
@@ -399,15 +401,18 @@ export default class OntologyTable extends Vue {
   getTraits() {
     // filter the terms pulled from the back-end
     let filters: TraitFilter[] = [{ field: TraitField.STATUS, value: this.active}];
+    this.traitsLoading = true;
 
     TraitService.getFilteredTraits(this.activeProgram!.id!, this.paginationController.currentCall, true, filters, this.ontologySort).then(([traits, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = traits;
         this.traitsPagination = metadata.pagination;
+        this.traitsLoading = false;
       }
     }).catch((error) => {
       // Display error that traits cannot be loaded
       this.$emit('show-error-notification', 'Error while trying to load traits');
+      this.traitsLoading = false;
       throw error;
     });
   }

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -407,14 +407,12 @@ export default class OntologyTable extends Vue {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = traits;
         this.traitsPagination = metadata.pagination;
-        this.traitsLoading = false;
       }
     }).catch((error) => {
       // Display error that traits cannot be loaded
       this.$emit('show-error-notification', 'Error while trying to load traits');
-      this.traitsLoading = false;
       throw error;
-    });
+    }).finally(() => this.traitsLoading = false );
   }
 
   async editable(trait: Trait) {

--- a/src/components/tables/SidePanelTable.vue
+++ b/src/components/tables/SidePanelTable.vue
@@ -30,7 +30,7 @@
       </div>
     </WarningModal>
 
-    <div class="side-panel-table">
+    <div class="side-panel-table table-min-height" v-bind:class="{'loading-indicator': loading}">
       <div class="columns is-mobile">
         <div class="column pr-0">
           <BaseTable
@@ -91,7 +91,7 @@
                           v-on:paginate-page-size="closePanelAndReEmit('paginate-page-size', $event)"/>
 
       <template v-if="records.length === 0">
-        <slot name="emptyMessage" />
+        <slot v-if="this.loading !== true" name="emptyMessage" />
       </template>
     </div>
 
@@ -148,6 +148,8 @@
     autoHandleClosePanelEvent!: boolean;
     @Prop()
     sidePanelState!: SidePanelTableEventBusHandler;
+    @Prop()
+    loading!: boolean;
 
     private BreakpointEvent = BreakpointEvent;
     private state = CollapseColumnsState.NORMAL_PANEL_CLOSED;


### PR DESCRIPTION
# Description
**Story:** [BI-1404](https://breedinginsight.atlassian.net/browse/BI-1404?atlOrigin=eyJpIjoiNjdlZjFhNjU0M2UwNDZkNWEyM2M0MzZhOTRiMmRhNzYiLCJwIjoiaiJ9)

- Added loading indicator to sidepanel table
- Set loading prop in ontology table

# Dependencies
- develop on bi-api

# Testing
- Test loading with breedbase which is slower and verify indicator shows


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
