### PR TITLE
[BI-1339] Germplasm Details page

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -13,3 +13,5 @@ VUE_APP_BI_API_ROOT=${API_BASE_URL}
 # The level of logging for our logger
 VUE_APP_LOG_LEVEL=${WEB_LOG_LEVEL}
 
+# The reference source
+VUE_APP_BI_REFERENCE_SOURCE=breeding-insight.org

--- a/.env.development
+++ b/.env.development
@@ -14,4 +14,4 @@ VUE_APP_BI_API_ROOT=${API_BASE_URL}
 VUE_APP_LOG_LEVEL=${WEB_LOG_LEVEL}
 
 # The reference source
-VUE_APP_BI_REFERENCE_SOURCE=breeding-insight.org
+VUE_APP_BI_REFERENCE_SOURCE=breedinginsight.org

--- a/src/breeding-insight/dao/GermplasmDAO.ts
+++ b/src/breeding-insight/dao/GermplasmDAO.ts
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
-import {BiResponse} from "@/breeding-insight/model/BiResponse";
+import {BiResponse, Response} from "@/breeding-insight/model/BiResponse";
 import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
+import {Result, ResultGenerator} from "@/breeding-insight/model/Result";
+import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
 
 export class GermplasmDAO {
 
@@ -42,21 +44,20 @@ export class GermplasmDAO {
         }))
     }
 
-    static getSingleGermplasm(programId: string, germplasmId: string): Promise<BiResponse> {
+    static async getSingleGermplasm(programId: string, germplasmId: string): Promise<Result<Error, Germplasm>> {
         const config: any = {};
         config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/brapi/v2/germplasm/${germplasmId}`;
         config.method = 'get';
         config.programId = programId;
         config.germplasmId = germplasmId;
-        config.params = {}; //todo check if needed
+        config.params = {};
 
-        return new Promise<any>(((resolve, reject) => {
-            api.call(config)
-                .then((response: any) => {
-                    resolve(response);
-                }).catch((error) => {
-                reject(error);
-            })
-        }))
+        try {
+            const res = await api.call(config) as Response;
+            let { result } = res.data;
+            return ResultGenerator.success(result);
+        } catch (error) {
+            return ResultGenerator.err(error);
+        }
     }
 }

--- a/src/breeding-insight/dao/GermplasmDAO.ts
+++ b/src/breeding-insight/dao/GermplasmDAO.ts
@@ -41,4 +41,22 @@ export class GermplasmDAO {
             })
         }))
     }
+
+    static getSingleGermplasm(programId: string, germplasmId: string): Promise<BiResponse> {
+        const config: any = {};
+        config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/brapi/v2/germplasm/${germplasmId}`;
+        config.method = 'get';
+        config.programId = programId;
+        config.germplasmId = germplasmId;
+        config.params = {}; //todo check if needed
+
+        return new Promise<any>(((resolve, reject) => {
+            api.call(config)
+                .then((response: any) => {
+                    resolve(response);
+                }).catch((error) => {
+                reject(error);
+            })
+        }))
+    }
 }

--- a/src/breeding-insight/service/GermplasmService.ts
+++ b/src/breeding-insight/service/GermplasmService.ts
@@ -21,6 +21,7 @@ import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {GermplasmDAO} from "@/breeding-insight/dao/GermplasmDAO";
 import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
+import {Result, ResultGenerator} from "@/breeding-insight/model/Result";
 
 export class GermplasmService {
 
@@ -49,25 +50,14 @@ export class GermplasmService {
         }));
     }
 
-    static getSingleGermplasm(programId: string, germplasmId: string): Promise<Germplasm> {
-        return new Promise<Germplasm>(((resolve, reject) => {
-
-            let germplasm: Germplasm;
-
-            if (programId) {
-                GermplasmDAO.getSingleGermplasm(programId, germplasmId).then((response: any) => {
-                    if (response.data) {
-                        germplasm = response.data as Germplasm;
-                    }
-
-                    resolve(germplasm);
-                }).catch((error) => {
-                    reject(error);
-                })
-            } else {
-                reject();
-            }
-        }));
+    static async getSingleGermplasm(programId: string, germplasmId: string): Promise<Result<Error, Germplasm>> {
+        try {
+              if (!programId) throw new Error('Missing or invalid program id');
+              let response: Result<Error, Germplasm> = await GermplasmDAO.getSingleGermplasm(programId, germplasmId);
+              return response;
+          } catch(error) {
+              return ResultGenerator.err(error);
+          }
     }
 
 }

--- a/src/breeding-insight/service/GermplasmService.ts
+++ b/src/breeding-insight/service/GermplasmService.ts
@@ -20,6 +20,7 @@ import {BiResponse, Metadata} from "@/breeding-insight/model/BiResponse";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {GermplasmDAO} from "@/breeding-insight/dao/GermplasmDAO";
+import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
 
 export class GermplasmService {
 
@@ -39,6 +40,27 @@ export class GermplasmService {
                     }
 
                     resolve([germplasmLists, biResponse.metadata]);
+                }).catch((error) => {
+                    reject(error);
+                })
+            } else {
+                reject();
+            }
+        }));
+    }
+
+    static getSingleGermplasm(programId: string, germplasmId: string): Promise<Germplasm> {
+        return new Promise<Germplasm>(((resolve, reject) => {
+
+            let germplasm: Germplasm;
+
+            if (programId) {
+                GermplasmDAO.getSingleGermplasm(programId, germplasmId).then((response: any) => {
+                    if (response.data) {
+                        germplasm = response.data as Germplasm;
+                    }
+
+                    resolve(germplasm);
                 }).catch((error) => {
                     reject(error);
                 })

--- a/src/breeding-insight/utils/GermplasmUtils.ts
+++ b/src/breeding-insight/utils/GermplasmUtils.ts
@@ -1,0 +1,46 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import moment from "moment";
+import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
+import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferences";
+
+export class GermplasmUtils {
+    static getExternalUID(germplasm: Germplasm): string | undefined {
+        let val;
+        if (germplasm.externalReferences && germplasm.seedSource) {
+            val = germplasm.externalReferences!.filter(ref => ref.referenceSource == germplasm.seedSource!)
+                .map(ref => ref.referenceID);
+            return val ? val[0]: "";
+        }
+        return "";
+    }
+
+    static getCreatedDate(germplasm: Germplasm): string | undefined {
+        if (germplasm.additionalInfo && germplasm.additionalInfo.createdDate) {
+            let dateTime = moment(germplasm.additionalInfo!.createdDate!, "DD/MM/YYYY h:mm:ss");
+            return dateTime.format("DD/MM/YYYY");
+        }
+        return "";
+    }
+
+    static getGermplasmUUID(references: ExternalReferences): string | undefined {
+        let val = references.find(ref => ref.referenceSource === process.env.VUE_APP_BI_REFERENCE_SOURCE);
+        return val ? val.referenceID : "";
+    }
+
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -66,6 +66,7 @@ import OntologyArchivedTable from "@/components/ontology/OntologyArchivedTable.v
 import PageNotFound from "@/views/PageNotFound.vue";
 import Germplasm from "@/views/germplasm/Germplasm.vue";
 import GermplasmLists from "@/views/germplasm/GermplasmLists.vue";
+import GermplasmDetails from "@/views/germplasm/GermplasmDetails.vue";
 
 Vue.use(VueRouter);
 
@@ -292,6 +293,16 @@ const routes = [
         component: GermplasmLists
       }
     ]
+  },
+  {
+    path: '/programs/:programId/germplasm/:germplasmId',
+    name: 'germplasm-details',
+    component: GermplasmDetails,
+    meta: {
+      title: 'Germplasm Details',
+      layout: layouts.userSideBar
+    },
+    beforeEnter: processProgramNavigation
   },
   {
     path: '/programs/:programId/traits',

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -89,7 +89,7 @@ import moment from "moment";
 export default class GermplasmDetails extends GermplasmBase {
 
   private activeProgram?: Program;
-  private germplasm?: Germplasm;
+  private germplasm: Germplasm;
   private germplasmLoading: boolean = true;
   private germplasmUUID: string = this.$route.params.germplasmId;
 
@@ -120,7 +120,8 @@ export default class GermplasmDetails extends GermplasmBase {
 
   getCreatedDate(){
     if (this.germplasm!.additionalInfo && this.germplasm!.additionalInfo.createdDate) {
-      let dateTime = moment(this.germplasm.additionalInfo.createdDate!, "DD/MM/YYYY h:mm:ss");
+      let createdDate = this.germplasm.additionalInfo.createdDate;
+      let dateTime = moment(createdDate, "DD/MM/YYYY h:mm:ss");
       return dateTime.format("DD/MM/YYYY");
     }
     return "";

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -110,7 +110,7 @@ export default class GermplasmDetails extends GermplasmBase {
 
   getExternalUID() {
     let val = "";
-    if (this.germplasm.externalReferences && this.germplasm.seedSource) {
+    if (this.germplasm!.externalReferences && this.germplasm!.seedSource) {
       val = this.germplasm.externalReferences.filter(ref => ref.referenceSource == this.germplasm.seedSource)
           .map(ref => ref.referenceID);
     }
@@ -118,7 +118,7 @@ export default class GermplasmDetails extends GermplasmBase {
   }
 
   getCreatedDate(){
-    if (this.germplasm.additionalInfo && this.germplasm.additionalInfo.createdDate) {
+    if (this.germplasm!.additionalInfo && this.germplasm!.additionalInfo.createdDate) {
       let dateTime = moment(this.germplasm.additionalInfo.createdDate, "DD/MM/YYYY h:mm:ss");
       return dateTime.format("DD/MM/YYYY");
     }

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -75,10 +75,8 @@ import {mapGetters} from "vuex";
 import {Program} from "@/breeding-insight/model/Program";
 import GermplasmBase from "@/components/germplasm/GermplasmBase.vue";
 import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
-import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
-import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {GermplasmService} from "@/breeding-insight/service/GermplasmService";
-import {Pagination} from "@/breeding-insight/model/BiResponse";
+import moment from "moment";
 
 @Component({
   components: {},
@@ -91,12 +89,9 @@ import {Pagination} from "@/breeding-insight/model/BiResponse";
 export default class GermplasmDetails extends GermplasmBase {
 
   private activeProgram?: Program;
-  private germplasm: Germplasm;
+  private germplasm?: Germplasm;
   private germplasmLoading: boolean = true;
   private germplasmUUID: string = this.$route.params.germplasmId;
-  //private femaleParent: string = "";
-  //todo create empty obj then as germplasm
-  //todo take away time in datetime
 
   mounted() {
     this.getGermplasm();
@@ -114,14 +109,20 @@ export default class GermplasmDetails extends GermplasmBase {
   }
 
   getExternalUID() {
-    let val = this.germplasm.externalReferences.filter(ref => ref.referenceSource == this.germplasm.seedSource)
-        .map(ref => ref.referenceID);
+    let val = "";
+    if (this.germplasm.externalReferences && this.germplasm.seedSource) {
+      val = this.germplasm.externalReferences.filter(ref => ref.referenceSource == this.germplasm.seedSource)
+          .map(ref => ref.referenceID);
+    }
     return val ? val[0]: "";
   }
 
   getCreatedDate(){
-    let dateTime = new Date(this.germplasm.additionalInfo.createdDate);
-    return dateTime.toLocaleDateString();
+    if (this.germplasm.additionalInfo && this.germplasm.additionalInfo.createdDate) {
+      let dateTime = moment(this.germplasm.additionalInfo.createdDate, "DD/MM/YYYY h:mm:ss");
+      return dateTime.format("DD/MM/YYYY");
+    }
+    return "";
   }
 
 }

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -111,7 +111,7 @@ export default class GermplasmDetails extends GermplasmBase {
   getExternalUID() {
     let val;
     if (this.germplasm!.externalReferences && this.germplasm!.seedSource) {
-      val = this.germplasm.externalReferences.filter(ref => ref.referenceSource == this.germplasm.seedSource!)
+      val = this.germplasm!.externalReferences!.filter(ref => ref.referenceSource == this.germplasm!.seedSource!)
           .map(ref => ref.referenceID);
       return val ? val[0]: "";
     }
@@ -120,8 +120,7 @@ export default class GermplasmDetails extends GermplasmBase {
 
   getCreatedDate(){
     if (this.germplasm!.additionalInfo && this.germplasm!.additionalInfo.createdDate) {
-      let createdDate = this.germplasm.additionalInfo.createdDate;
-      let dateTime = moment(createdDate, "DD/MM/YYYY h:mm:ss");
+      let dateTime = moment(this.germplasm!.additionalInfo!.createdDate!, "DD/MM/YYYY h:mm:ss");
       return dateTime.format("DD/MM/YYYY");
     }
     return "";

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -109,17 +109,18 @@ export default class GermplasmDetails extends GermplasmBase {
   }
 
   getExternalUID() {
-    let val = "";
+    let val;
     if (this.germplasm!.externalReferences && this.germplasm!.seedSource) {
-      val = this.germplasm.externalReferences.filter(ref => ref.referenceSource == this.germplasm.seedSource)
+      val = this.germplasm.externalReferences.filter(ref => ref.referenceSource == this.germplasm.seedSource!)
           .map(ref => ref.referenceID);
+      return val ? val[0]: "";
     }
-    return val ? val[0]: "";
+    return "";
   }
 
   getCreatedDate(){
     if (this.germplasm!.additionalInfo && this.germplasm!.additionalInfo.createdDate) {
-      let dateTime = moment(this.germplasm.additionalInfo.createdDate, "DD/MM/YYYY h:mm:ss");
+      let dateTime = moment(this.germplasm.additionalInfo.createdDate!, "DD/MM/YYYY h:mm:ss");
       return dateTime.format("DD/MM/YYYY");
     }
     return "";

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -89,7 +89,7 @@ import moment from "moment";
 export default class GermplasmDetails extends GermplasmBase {
 
   private activeProgram?: Program;
-  private germplasm: Germplasm;
+  private germplasm?: Germplasm;
   private germplasmLoading: boolean = true;
   private germplasmUUID: string = this.$route.params.germplasmId;
 

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="germplasm">
+    <h1 class="title">
+      Germplasm Details
+    </h1>
+
+    <div class="columns is-multiline is-align-items-stretch mt-4">
+    <article class="column ">
+    <section>
+      <ul style="list-style-type: none;">
+      <li><b>Preferred Name: </b> {{ }}</li>
+      <li><b>GID: </b> {{ }}</li>
+      <li><b>Breeding Method: </b> {{ }}</li>
+      <li><b>Source: </b> {{ }}</li>
+      <li><b>Synonyms: </b> {{ }}</li>
+      <li><b>External UID: </b> {{ }}</li>
+      <li><b>User: </b> {{ }}</li>
+      <li><b>Creation Date: </b> {{ }}</li>
+      </ul>
+    </section>
+    </article>
+    <article class="column px-2">
+      <section>
+        <ul style="list-style-type: none;">
+        <li><b>Female Parent: </b> {{ }}</li>
+        <li><b>Female Parent GID: </b> {{ }}</li>
+        <li><b>Male Parent: </b> {{ }}</li>
+        <li><b>Male Parent GID: </b> {{ }}</li>
+        <li><b>Cross: </b> {{ }}</li>
+        <li><b>Cross GID(s): </b> {{ }}</li>
+        </ul>
+      </section>
+    </article>
+      </div>
+
+    <section>
+      <nav class="tabs is-boxed">
+        <ul>
+            <router-link
+                v-bind:to="{name: '', params: {programId: activeProgram.id}}"
+                tag="li"
+            >
+              <a>Images</a>
+            </router-link>
+            <router-link
+                v-bind:to="{name: '', params: {programId: activeProgram.id}}"
+                tag="li"
+            >
+              <a>Pedigrees</a>
+            </router-link>
+              <router-link
+                  v-bind:to="{name: '', params: {programId: activeProgram.id}}"
+                  tag="li"
+              >
+                <a>Attributes</a>
+              </router-link>
+        </ul>
+      </nav>
+    </section>
+
+    <div class="tab-content">
+      <router-view
+          @show-success-notification="$emit('show-success-notification', $event)"
+          @show-info-notification="$emit('show-info-notification', $event)"
+          @show-error-notification="$emit('show-error-notification', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component } from 'vue-property-decorator'
+import {mapGetters} from "vuex";
+import {Program} from "@/breeding-insight/model/Program";
+import GermplasmBase from "@/components/germplasm/GermplasmBase.vue";
+import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
+
+@Component({
+  components: {},
+  computed: {
+    ...mapGetters([
+      'activeProgram'
+    ])
+  },
+  data: () => ({})
+})
+export default class GermplasmDetails extends GermplasmBase {
+
+  private activeProgram?: Program;
+  private data!: Germplasm;
+
+  //when page loads get details for uuid, create service, axios, api, call reference dao components in frontend re pathing
+
+}
+</script>

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -1,3 +1,20 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
 <template>
   <div class="germplasm">
     <router-link v-bind:to="{name: 'germplasm-all', params: {programId: activeProgram.id}}">

--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -118,7 +118,7 @@ export default class GermplasmTable extends Vue {
 
   getGermplasmUUID(references: ExternalReferences){
     let val = references.find(ref => ref.referenceSource === process.env.VUE_APP_BI_REFERENCE_SOURCE);
-    return val ? val.referenceID : ""; //todo error handling
+    return val ? val.referenceID : "";
   }
 
 

--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -38,7 +38,7 @@
         {{ props.row.data.additionalInfo.createdBy.userName }}
       </b-table-column>
       <b-table-column field="germplasmId" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-        <router-link v-bind:to="{name: 'germplasm-details', params: {programId: activeProgram.id, germplasmId: getGermplasmUUID(props.row.data.externalReferences)}}">
+        <router-link v-bind:to="{name: 'germplasm-details', params: {programId: activeProgram.id, germplasmId: GermplasmUtils.getGermplasmUUID(props.row.data.externalReferences)}}">
           Show Details
         </router-link>
       </b-table-column>
@@ -68,7 +68,7 @@ import {Pagination} from "@/breeding-insight/model/BiResponse";
 import ExpandableTable from "@/components/tables/expandableTable/ExpandableTable.vue";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {Pedigree} from "@/breeding-insight/model/import/germplasm/Pedigree";
-import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferences";
+import {GermplasmUtils} from '@/breeding-insight/utils/GermplasmUtils';
 
 @Component({
   mixins: [validationMixin],
@@ -78,7 +78,7 @@ import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferen
       'activeProgram'
     ])
   },
-  data: () => ({Trait, StringFormatters, TraitStringFormatters, Pedigree})
+  data: () => ({Trait, StringFormatters, TraitStringFormatters, Pedigree, GermplasmUtils})
 })
 export default class GermplasmTable extends Vue {
 
@@ -115,12 +115,5 @@ export default class GermplasmTable extends Vue {
     }
 
   }
-
-  getGermplasmUUID(references: ExternalReferences){
-    let val = references.find(ref => ref.referenceSource === process.env.VUE_APP_BI_REFERENCE_SOURCE);
-    return val ? val.referenceID : "";
-  }
-
-
 }
 </script>

--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -37,6 +37,11 @@
       <b-table-column field="createdBy.userName" label="Created By" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ props.row.data.additionalInfo.createdBy.userName }}
       </b-table-column>
+      <b-table-column field="germplasmId" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        <router-link v-bind:to="{name: 'germplasm-details', params: {programId: activeProgram.id, germplasmId: getGermplasmUUID(props.row.data.externalReferences)}}">
+          Show Details
+        </router-link>
+      </b-table-column>
 
       <template v-slot:emptyMessage>
         <p class="has-text-weight-bold">
@@ -63,6 +68,7 @@ import {Pagination} from "@/breeding-insight/model/BiResponse";
 import ExpandableTable from "@/components/tables/expandableTable/ExpandableTable.vue";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {Pedigree} from "@/breeding-insight/model/import/germplasm/Pedigree";
+import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferences";
 
 @Component({
   mixins: [validationMixin],
@@ -109,6 +115,12 @@ export default class GermplasmTable extends Vue {
     }
 
   }
+
+  getGermplasmUUID(references: ExternalReferences){
+    let val = references.find(ref => ref.referenceSource === process.env.VUE_APP_BI_REFERENCE_SOURCE);
+    return val ? val.referenceID : ""; //todo error handling
+  }
+
 
 }
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-1339 - Germplasm Details page](https://breedinginsight.atlassian.net/browse/BI-1339)

Updates to enable display of individual germplasm details

- Added GermplasmDetails.vue to display individual germplasm information
- Updated GermplasmTable.vue to include a column with links to germplasm details for each germplasm and to retrieve the germplasm UUID for use in said link
- Added reference source to .env.development to aid in retrieval of germplasm UUID from external references on front end
- Added api call to new /programs/${programId}/brapi/v2/germplasm/${germplasmId} endpoint to retrieve individual germplasm information
- Updated router to include navigation to germplasm details page

# Dependencies
[bi-api/feature/BI-1339](https://github.com/Breeding-Insight/bi-api/pull/176)

# Testing

1. Import germplasm list with entries with pedigrees, partial pedigrees, and no pedigrees
2. Go to germplasm table - each row should have show details link
3. Click on show details link
4. Should navigate to germplasm details page
5. Germplasm info displayed should correspond to selected germplasm

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/2110874250)