### PR TITLE
[BI-1363] Disable cancel button on share ontology save

### DIFF
--- a/src/components/program/SharedOntologyConfiguration.vue
+++ b/src/components/program/SharedOntologyConfiguration.vue
@@ -111,6 +111,7 @@
                     class="button"
                     v-on:click="showShareModal = false"
                     id="cancelSharedOntology"
+                    v-bind:disabled="shareProgramProcessing"
                 >
                   Cancel
                 </button>


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1363

For the share ontology modal, the 'Save' button was disabled while saving, but not the 'Cancel' button. I add the disable logic to the 'Cancel' button as well. 

NOTE: Based off `bug/BI-1366` so includes some of those changes. 

# Dependencies
biapi: develop

# Testing
1. Set a debug point in biapi inside the `/programs/{programId}/ontology/shared/programs` endpoint. 
2. Share ontology with another program
3. The debug point will pause the backend so you can see the button state. 
4. Check that the save button has a loading wheel and that both the save and cancel buttons are disabled. 


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
