### PR TITLE
[BI-1199] - Choose file format for germplasm export

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -678,3 +678,8 @@ th.activesort.sortcolumn, th.sortcolumn:hover {
     }
   }
 }
+
+.modal-radio {
+  display:block;
+  vertical-align: middle;
+}

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -678,8 +678,3 @@ th.activesort.sortcolumn, th.sortcolumn:hover {
     }
   }
 }
-
-.modal-radio {
-  display:block;
-  vertical-align: middle;
-}

--- a/src/breeding-insight/model/FileType.ts
+++ b/src/breeding-insight/model/FileType.ts
@@ -17,17 +17,19 @@
 
 export class FileType {
     //todo check if all properties needed
-    static xls = new FileType("xls", ".xls", "application/vnd.ms-excel");
-    static xlsx = new FileType("xlsx", ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-    static csv = new FileType("csv", ".csv", "text/csv");
+    static xls = new FileType("xls", ".xls", "application/vnd.ms-excel", "XLS");
+    static xlsx = new FileType("xlsx", ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "XLSX");
+    static csv = new FileType("csv", ".csv", "text/csv", "CSV");
 
     name: string;
     extension: string;
     mimeType: string;
+    id: string;
 
-    constructor(name: string, extension: string, mimeType: string) {
+    constructor(name: string, extension: string, mimeType: string, id: string) {
         this.name = name;
         this.extension = extension;
         this.mimeType = mimeType;
+        this.id = id;
     }
 }

--- a/src/breeding-insight/model/FileType.ts
+++ b/src/breeding-insight/model/FileType.ts
@@ -16,20 +16,15 @@
  */
 
 export class FileType {
-    //todo check if all properties needed
-    static xls = new FileType("xls", ".xls", "application/vnd.ms-excel", "XLS");
-    static xlsx = new FileType("xlsx", ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "XLSX");
-    static csv = new FileType("csv", ".csv", "text/csv", "CSV");
+    static xls = new FileType(".xls", "XLS");
+    static xlsx = new FileType(".xlsx", "XLSX");
+    static csv = new FileType(".csv", "CSV");
 
     name: string;
-    extension: string;
-    mimeType: string;
     id: string;
 
-    constructor(name: string, extension: string, mimeType: string, id: string) {
+    constructor(name: string, id: string) {
         this.name = name;
-        this.extension = extension;
-        this.mimeType = mimeType;
         this.id = id;
     }
 }

--- a/src/breeding-insight/model/FileType.ts
+++ b/src/breeding-insight/model/FileType.ts
@@ -1,0 +1,33 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class FileType {
+    //todo check if all properties needed
+    static xls = new FileType("xls", ".xls", "application/vnd.ms-excel");
+    static xlsx = new FileType("xlsx", ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    static csv = new FileType("csv", ".csv", "text/csv");
+
+    name: string;
+    extension: string;
+    mimeType: string;
+
+    constructor(name: string, extension: string, mimeType: string) {
+        this.name = name;
+        this.extension = extension;
+        this.mimeType = mimeType;
+    }
+}

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -25,6 +25,7 @@
         v-on:deactivate="modalActive = false"
         @select-change="setFileExtension"
     >
+      <template #buttons>
       <div class="columns">
         <div class="column is-whole has-text-centered buttons">
           <button
@@ -41,6 +42,7 @@
           </button>
         </div>
       </div>
+      </template>
     </SelectModal>
 
 

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -170,7 +170,6 @@ export default class GermplasmListsTable extends Vue {
     this.modalActive = false;
     if (this.activeProgram) {
       window.open(process.env.VUE_APP_BI_API_ROOT + '/v1/programs/' + this.activeProgram.id + '/germplasm/lists/' + this.selectedListDbId + '/export/' + this.fileExtension, '_blank');
-      window.fileExtension = this.fileExtension; //todo see if this works, else use hash
     }
   }
 

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -171,7 +171,7 @@ export default class GermplasmListsTable extends Vue {
   downloadList() {
     this.modalActive = false;
     if (this.activeProgram) {
-      window.open(process.env.VUE_APP_BI_API_ROOT + '/v1/programs/' + this.activeProgram.id + '/germplasm/lists/' + this.selectedListDbId + '/export/' + this.fileExtension, '_blank');
+      window.open(process.env.VUE_APP_BI_API_ROOT + '/v1/programs/' + this.activeProgram.id + '/germplasm/lists/' + this.selectedListDbId + '/export?fileExtension=' + this.fileExtension, '_blank');
     }
   }
 

--- a/src/components/modals/SelectModal.vue
+++ b/src/components/modals/SelectModal.vue
@@ -55,7 +55,7 @@
             </div>
           </template>
         </div>
-        <slot></slot>
+        <slot name="buttons"></slot>
       </div>
     </div>
   </BaseModal>
@@ -74,7 +74,7 @@ export default class SelectModal extends Vue {
   @Prop()
   title! : string;
   @Prop()
-  subtitle!: string;
+  subtitle: string;
   @Prop()
   options:string;
 

--- a/src/components/modals/SelectModal.vue
+++ b/src/components/modals/SelectModal.vue
@@ -1,0 +1,92 @@
+<!--
+- See the NOTICE file distributed with this work for additional information
+        - regarding copyright ownership.
+-
+- Licensed under the Apache License, Version 2.0 (the "License");
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+        - limitations under the License.
+-->
+
+<template>
+  <BaseModal
+      v-bind:active.sync="active"
+      v-on:deactivate="$emit('deactivate')"
+  >
+    <div>
+      <div>
+        <article class="media">
+          <div class="media-content">
+            <div class="content">
+              <h3 class="is-5 title" :class="modalHeaderClass">
+                {{title}}
+              </h3>
+            </div>
+          </div>
+        </article>
+        <section>
+          <p class="has-text-dark has-text-weight-bold" :class="this.$modalTextClass">
+            {{ subtitle }}
+          </p>
+        </section>
+        <div class="control">
+          <template v-for="option in options">
+            <label
+                v-bind:key="option.name"
+                class="radio modal-radio"
+            >
+              <input
+                  type="radio"
+                  v-bind:name="optionType"
+                  v-bind:value="option.name"
+                  v-model="checked"
+                  v-on:change="$emit('select-change', checked)"
+              >
+              {{option.name}}
+            </label>
+          </template>
+        </div>
+        <slot></slot>
+      </div>
+    </div>
+  </BaseModal>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import BaseModal from '@/components/modals/BaseModal.vue';
+
+@Component({
+  components: {BaseModal}
+})
+export default class SelectModal extends Vue {
+  @Prop()
+  active!: boolean;
+  @Prop()
+  title! : string;
+  @Prop()
+  subtitle!: string;
+  @Prop()
+  options:string;
+
+  private checked: string = "";
+
+  private optionType = "optionType";
+  private modalHeaderClass: string = "modal-header";
+
+  mounted(){
+    this.checked = this.options[0].name;
+    this.$emit('select-change', this.checked);
+  }
+
+  //TODO utilize id instead of name in places?
+}
+
+</script>

--- a/src/components/modals/SelectModal.vue
+++ b/src/components/modals/SelectModal.vue
@@ -38,19 +38,21 @@
         </section>
         <div class="control">
           <template v-for="option in options">
-            <label
+            <div v-bind:key="option.name">
+              <label
                 v-bind:key="option.name"
-                class="radio modal-radio"
-            >
-              <input
+                class="radio"
+              >
+                <input
                   type="radio"
                   v-bind:name="optionType"
                   v-bind:value="option.name"
                   v-model="checked"
                   v-on:change="$emit('select-change', checked)"
-              >
-              {{option.name}}
-            </label>
+                >
+                {{option.name}}
+              </label>
+            </div>
           </template>
         </div>
         <slot></slot>

--- a/src/components/modals/SelectModal.vue
+++ b/src/components/modals/SelectModal.vue
@@ -38,15 +38,15 @@
         </section>
         <div class="control">
           <template v-for="option in options">
-            <div v-bind:key="option.name">
+            <div v-bind:key="option.id">
               <label
-                v-bind:key="option.name"
+                v-bind:key="option.id"
                 class="radio"
               >
                 <input
                   type="radio"
                   v-bind:name="optionType"
-                  v-bind:value="option.name"
+                  v-bind:value="option.id"
                   v-model="checked"
                   v-on:change="$emit('select-change', checked)"
                 >
@@ -84,11 +84,9 @@ export default class SelectModal extends Vue {
   private modalHeaderClass: string = "modal-header";
 
   mounted(){
-    this.checked = this.options[0].name;
+    this.checked = this.options[0].id;
     this.$emit('select-change', this.checked);
   }
-
-  //TODO utilize id instead of name in places?
 }
 
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-1199 - Choose file format for germplasm export](https://breedinginsight.atlassian.net/browse/BI-1199)

Changes to frontend to enable modal selection of file type when downloading germplasm list and passing of user selection to backend.

Added new reusable modal component SelectModal that takes in title and a list of options to display, and utilized it to display file types upon user clicking download and pass that information on click.

# Dependencies
[bi-api/BI-1199](https://github.com/Breeding-Insight/bi-api/pull/193)

# Testing
- Open Germplasm List
- Click Download
- Verify modal pops up and shows
- Verify each file type can be selected
- Verify when cancel clicked the modal closes and nothing is downloaded
- Verify for each file type (csv, xls, xlsx) that when it is selected and download is clicked the file is downloaded with the proper extension and the correct data

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/2545220951)
