### PR TITLE
[BI-1224] - Show list creator in Germplasm lists table

### DIFF
--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -37,6 +37,9 @@
       <b-table-column field="data.dateCreated" label="Date Created" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ formatDate(props.row.data.dateCreated) }}
       </b-table-column>
+      <b-table-column field="data.listOwnerName" label="Creator" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        {{ props.row.data.listOwnerName }}
+      </b-table-column>
       <b-table-column  field="data.listDbId" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         <a href="#" v-on:click="downloadList(props.row.data.listDbId)">
           Download

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -34,10 +34,10 @@
       <b-table-column field="data.listSize" label="Total Entries" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ props.row.data.listSize }}
       </b-table-column>
-      <b-table-column field="data.dateCreated" label="Date Created" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="data.dateCreated" label="Created Date" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ formatDate(props.row.data.dateCreated) }}
       </b-table-column>
-      <b-table-column field="data.listOwnerName" label="Creator" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="data.listOwnerName" label="Created By" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ props.row.data.listOwnerName }}
       </b-table-column>
       <b-table-column  field="data.listDbId" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">


### PR DESCRIPTION
# Description
**Story:** [BI-1224 - Show list creator in Germplasm lists table](https://breedinginsight.atlassian.net/browse/BI-1224)

Retrieves list creator and displays for germplasm lists.

Added Created By column in Germplasm Lists table that takes in listOwnerName
Changed Date Created to Created Date to be more consistent with other tables

# Dependencies
[bi-api/BI-1224](https://github.com/Breeding-Insight/bi-api/pull/194)

# Testing
For breedbase and brapi test server:
- Import germplasm under two different users
- Go to germplasm list table
- Created By column should exist
- Column should display name of correct user that imported germplasm list

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/2572017460)
