### PR TITLE
[BI-1499] - Improve Presentation of Buttons

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -656,6 +656,12 @@ th.activesort.sortcolumn, th.sortcolumn:hover {
   transform: rotate(180deg);
 }
 
+.above-tabs-button {
+  margin-bottom: 15px;
+  position: absolute;
+  right: 35px;
+}
+
 .trait-detail {
   .scale-info {
     border-left: 1px solid $info;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -49,22 +49,6 @@
       <div class="column">
         <button
             v-if="$ability.can('create', 'Trait') && !isSubscribed"
-            v-show="!newTraitActive && traits.length > 0"
-            class="button is-primary is-pulled-right has-text-weight-bold"
-            v-on:click="$router.push({name: 'import-ontology', params: {programId: activeProgram.id}})"
-        >
-        <span class="icon is-small">
-          <PlusCircleIcon
-              size="1.5x"
-              aria-hidden="true"
-          />
-        </span>
-        <span>
-          Import Batch File
-        </span>
-        </button>
-        <button
-            v-if="$ability.can('create', 'Trait') && !isSubscribed"
             data-testid="newDataForm"
             v-show="!newTraitActive && traits.length > 0"
             class="button mx-2 is-primary is-pulled-right is-light has-text-weight-bold"

--- a/src/views/germplasm/Germplasm.vue
+++ b/src/views/germplasm/Germplasm.vue
@@ -38,6 +38,21 @@
           >
             <a>Germplasm Lists</a>
           </router-link>
+          <button
+              v-if="$ability.can('create', 'Import')"
+              class="button is-primary is-pulled-right has-text-weight-bold above-tabs-button"
+              v-on:click="$router.push({name: 'germplasm-import', params: {programId: activeProgram.id}})"
+          >
+        <span class="icon is-small">
+          <PlusCircleIcon
+              size="1.5x"
+              aria-hidden="true"
+          />
+        </span>
+            <span>
+          Import Batch File
+        </span>
+          </button>
         </ul>
       </nav>
     </section>
@@ -57,9 +72,10 @@ import { Component } from 'vue-property-decorator'
 import {mapGetters} from "vuex";
 import {Program} from "@/breeding-insight/model/Program";
 import GermplasmBase from "@/components/germplasm/GermplasmBase.vue";
+import {PlusCircleIcon} from 'vue-feather-icons'
 
 @Component({
-  components: {},
+  components: { PlusCircleIcon },
   computed: {
     ...mapGetters([
       'activeProgram'

--- a/src/views/ontology/Ontology.vue
+++ b/src/views/ontology/Ontology.vue
@@ -41,6 +41,21 @@
           >
             <a>Archived</a>
           </router-link>
+          <button
+              v-if="$ability.can('create', 'Trait') && !isSubscribed"
+              class="button is-primary is-pulled-right has-text-weight-bold above-tabs-button"
+              v-on:click="$router.push({name: 'import-ontology', params: {programId: activeProgram.id}})"
+          >
+        <span class="icon is-small">
+          <PlusCircleIcon
+              size="1.5x"
+              aria-hidden="true"
+          />
+        </span>
+            <span>
+          Import Batch File
+        </span>
+          </button>
         </ul>
       </nav>
     </section>
@@ -63,10 +78,11 @@
   import OntologyActiveTable from "@/components/ontology/OntologyActiveTable.vue";
   import OntologyArchivedTable from "@/components/ontology/OntologyArchivedTable.vue";
   import {SubscribedOntology} from "@/breeding-insight/model/SubscribedOntology";
+  import {PlusCircleIcon} from 'vue-feather-icons'
 
   @Component({
     components: {
-      OntologyArchivedTable, OntologyActiveTable
+      OntologyArchivedTable, OntologyActiveTable, PlusCircleIcon
     },
     computed: {
       ...mapGetters([


### PR DESCRIPTION
# Description
**Story:** [BI-1499 - Improve Presentation of Buttons](https://breedinginsight.atlassian.net/browse/BI-1499)

Added Batch Import button to Germplasm page above tabs.
Moved Batch Import button to Ontology page above tabs

# Dependencies
bi-api/develop

# Testing
For Germplasm Page
- Import Batch File button should be present above the tabs
- Clicking said button should lead to Germplasm Import page

For Ontology Page
- Import Batch File button should be present above the tabs
- New Term should still be below tabs as before
- Clicking Import Batch File should lead to Ontology Import page

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/2652088975)
