### PR TITLE
[BI-1146] change ‘Exp Trt Factor Name’ to ‘Treatment Factors’ - failed QA

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -29,7 +29,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Experiments & Observations'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/u0hv5a2664phiswhre64anx1oghvq32s.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/wp6tmlt0585ryid3csccj3q1w2fiyg9d.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>
@@ -133,8 +133,8 @@
           <b-table-column field="column" label="Column" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
             {{ getField(props.row.data.observationUnit, 'observationUnitPosition.positionCoordinateY') }}
           </b-table-column>
-          <!-- Exp Treatment Factor Name -->
-          <b-table-column field="expTreatmentFactorName" label="Exp Treatment Factor Name" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+          <!-- Treatment Factors -->
+          <b-table-column field="expTreatmentFactorName" label="Treatment Factors" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
             {{ getTreatment(props.row.data.observationUnit) }}
           </b-table-column>
 


### PR DESCRIPTION
# Description
**Story:** 
1146 failed QA. The failure was `Acceptance 1. The experiment import template still has a column for “Exp Trt Factor Name” instead of “Treatment Factors”.`

Updated template.  Updated display column name

# Dependencies
bi-api branch bug/BI-1146

# Testing
1.  Download and use new template.
2. Insure that the the column name in the template and READ ME is **Treatment Factors** and not **Exp Trt Factor Name**
3. Insure that the column on the table on the summary screen reads  **Treatment Factors** and not **Exp Trt Factor Name**

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: _[\<link to TAF run>](https://github.com/Breeding-Insight/taf/actions/runs/2676786079)_
