### PR TITLE
BI-1189 failed QA - Added Experimental Unit to summary.

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -58,6 +58,7 @@
             <p class="is-size-5 mb-2"><strong>Experiment</strong></p>
             <p>Title: {{ rows[0].trial.brAPIObject.trialName }}</p>
             <p>Description: {{ rows[0].trial.brAPIObject.trialDescription }}</p>
+            <p>Experimental Unit: {{ rows[0].trial.brAPIObject.additionalInfo.defaultObservationLevel }}</p>
             <p>Type: {{ rows[0].trial.brAPIObject.additionalInfo.experimentType }}</p>
             <p>User: </p>
             <p>Creation Date: </p>
@@ -84,22 +85,6 @@
           <!-- Test or Check -->
           <b-table-column field="testOrCheck" label="Test (T) or Check (C)" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
             {{ getField(props.row.data.observationUnit, 'observationUnitPosition.entryType') }}
-          </b-table-column>
-          <!-- Experiment Title -->
-          <b-table-column field="expTitle" label="Experiment Title" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ getField(props.row.data.trial, 'trialName') }}
-          </b-table-column>
-          <!-- Experiment Description -->
-          <b-table-column field="expDescription" label="Experiment Description" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ getField(props.row.data.trial, 'trialDescription') }}
-          </b-table-column>
-          <!-- Exp Unit -->
-          <b-table-column field="expUnit" label="Experiment Unit" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ getField(props.row.data.observationUnit, 'observationUnitPosition.observationLevel.levelName') }}
-          </b-table-column>
-          <!-- Exp Type -->
-          <b-table-column field="expType" label="Experiment Type" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ getField(props.row.data.study, 'studyType') }}
           </b-table-column>
           <!-- Env -->
           <b-table-column field="env" label="Env" v-slot="props" :th-attrs="(column) => ({scope:'col'})">


### PR DESCRIPTION
added Experimental Unit to summary.  Hide redundant Experiment details in the Table

# Description
[BI-1189](https://breedinginsight.atlassian.net/browse/BI-1189) failed QA.  _Experimental Unit_ data needs to be added to the summary on  the confirmation page for Experiment Import(above the table).

Also the redundant experiment details needs to be removed from the table.  The columns to be removed are:
- Experiment Title
- Experiment Description
- Experiment Unit
- Experiment Type

# Dependencies
bi-api branch develop

# Testing

1. Import _Experiments and Observations_ data from a flat file (you should now be on the confirmation page).
2. The _Experimental Unit_ should appear in the summary section (under **Experiment**)
3. In the table below, you should not see the columns "Experiment Title", "Experiment Description", Experiment Unit", or "Experiment Type"

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/2818522499)
