### PR TITLE
[BI-1494] - Fixing pedigree navigation due to merge

### DIFF
--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -130,7 +130,7 @@ import {BrAPIService, BrAPIType} from "@/breeding-insight/service/BrAPIService";
     // Find the id for that gid
     const gid = germplasmId.split('-')[1];
     const programId = to.params.programId;
-    BrAPIService.get(BrAPIType.GERMPLASM, {accessionNumber: gid}, programId, 1, 0).then((germplasmResult) => {
+    BrAPIService.get(BrAPIType.GERMPLASM, programId, 0, 1, {accessionNumber: gid}).then((germplasmResult) => {
       // Parse out the germplasm id
       const germplasm = germplasmResult.result.data[0];
       const germplasmUUID = GermplasmUtils.getGermplasmUUID(germplasm.externalReferences);


### PR DESCRIPTION
# Description
**Story:** [BI-1494 - Improve Pedigree View Display](https://breedinginsight.atlassian.net/browse/BI-1494)

Merging of -- changed order of parameters in BrAPIService.ts:get, which in turn resulted in an invalid GET url -- and being redirected to a blank page with a console error. This change fixes the parameters in the -- call to BrAPIService.ts:get.

# Dependencies
bi-api/develop

# Testing
In a Breedbase program, open germplasm details page for a germplasm with parents and children
Click on different nodes in the pedigree viewer, they should redirect to the correct germplasm details pages

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
