### PR TITLE
[BI-1506] Fix "Created Date" format for Germplasm table

### DIFF
--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -46,7 +46,7 @@
         > </GermplasmLink>
       </b-table-column>
       <b-table-column field="createdDate" label="Created Date" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
-        {{ props.row.data.additionalInfo.createdDate }}
+        {{ GermplasmUtils.getCreatedDate(props.row.data) }}
       </b-table-column>
       <b-table-column field="createdByUserName" label="Created By" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ props.row.data.additionalInfo.createdBy.userName }}


### PR DESCRIPTION
# Description
**Story:** [BI-1506 - "Created Date" field in the All Germplasm table has the wrong date format.](https://breedinginsight.atlassian.net/browse/BI-1506)

Changed Created Date column in Germplasm Table to use GermplasmUtils.getCreatedDate like in the Germplasm Details page so date formatting is consistent.

# Dependencies
bi-api/develop

# Testing
Open germplasm table
Ensure "Created Date" is in YYYY-MM-DD format

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
