### PR TITLE
[BI-1230] Truly Unknown Germplasm

### DIFF
--- a/src/breeding-insight/model/import/germplasm/Pedigree.ts
+++ b/src/breeding-insight/model/import/germplasm/Pedigree.ts
@@ -51,10 +51,10 @@ export class Pedigree {
    * @param femaleParentUnknown
    * @param maleParentUnknown
    */
-  public static parsePedigreeStringWithUnknowns(pedigreeString: string, femaleParentUnknown: string, maleParentUnknown: string) : Pedigree {
+  public static parsePedigreeStringWithUnknowns(pedigreeString: string, femaleParentUnknown: string, maleParentUnknown: string, gid: string) : Pedigree {
     let parsedPedigree = this.parsePedigreeString(pedigreeString);
-    if (femaleParentUnknown) parsedPedigree.femaleParent = "0";
-    if (maleParentUnknown) parsedPedigree.maleParent = "0";
+    if (femaleParentUnknown) parsedPedigree.femaleParent = "Unknown";
+    if (maleParentUnknown) parsedPedigree.maleParent = "Unknown";
     return parsedPedigree;
   }
 

--- a/src/breeding-insight/model/import/germplasm/Pedigree.ts
+++ b/src/breeding-insight/model/import/germplasm/Pedigree.ts
@@ -44,4 +44,18 @@ export class Pedigree {
     }
   }
 
+  /**
+   * Wrapper of parsePedigreeString that handles female/male parent unknown cases.
+   *
+   * @param pedigreeString
+   * @param femaleParentUnknown
+   * @param maleParentUnknown
+   */
+  public static parsePedigreeStringWithUnknowns(pedigreeString: string, femaleParentUnknown: string, maleParentUnknown: string) : Pedigree {
+    let parsedPedigree = this.parsePedigreeString(pedigreeString);
+    if (femaleParentUnknown) parsedPedigree.femaleParent = "0";
+    if (maleParentUnknown) parsedPedigree.maleParent = "0";
+    return parsedPedigree;
+  }
+
 }

--- a/src/components/germplasm/GermplasmPedigreesView.vue
+++ b/src/components/germplasm/GermplasmPedigreesView.vue
@@ -126,6 +126,9 @@ export default class GermplasmPedigreesView extends GermplasmBase {
         let pedigree = PedigreeViewer(`${process.env.VUE_APP_BI_API_V1_PATH}/programs/${this.activeProgram!.id}/brapi/v2`, undefined, 'v2.0',
             function (dbId: any, germplasm: any) {
               const parsedName = parseGermplasmName(germplasm.value.name);
+              if (parsedName.gid === "0") {
+                return null;
+              }
               return `${germplasmDetailsUrl}/gid-${parsedName.gid}`;
             },
             {

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -39,12 +39,12 @@
           <GermplasmLink
             v-if="germplasm.pedigree"
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(germplasm.additionalInfo.pedigreeByUUID).femaleParent"
-            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(germplasm.pedigree,germplasm.additionalInfo.femaleParentUnknown,germplasm.additionalInfo.maleParentUnknown).femaleParent"
+            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(germplasm.pedigree,germplasm.additionalInfo.femaleParentUnknown,germplasm.additionalInfo.maleParentUnknown, germplasm.germplasmDbId).femaleParent"
         > </GermplasmLink>
           <template v-if="Pedigree.parsePedigreeString(germplasm.pedigree).maleParent">
           / <GermplasmLink
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(germplasm.additionalInfo.pedigreeByUUID).maleParent"
-            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(germplasm.pedigree,germplasm.additionalInfo.femaleParentUnknown,germplasm.additionalInfo.maleParentUnknown).maleParent"
+            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(germplasm.pedigree,germplasm.additionalInfo.femaleParentUnknown,germplasm.additionalInfo.maleParentUnknown, germplasm.germplasmDbId).maleParent"
           > </GermplasmLink></template>
         </li>
         <li><b>Synonyms: </b> {{ GermplasmUtils.formatSynonyms(germplasm.synonyms) }}</li>

--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -39,12 +39,12 @@
           <GermplasmLink
             v-if="germplasm.pedigree"
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(germplasm.additionalInfo.pedigreeByUUID).femaleParent"
-            v-bind:germplasmGID="Pedigree.parsePedigreeString(germplasm.pedigree).femaleParent"
+            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(germplasm.pedigree,germplasm.additionalInfo.femaleParentUnknown,germplasm.additionalInfo.maleParentUnknown).femaleParent"
         > </GermplasmLink>
           <template v-if="Pedigree.parsePedigreeString(germplasm.pedigree).maleParent">
           / <GermplasmLink
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(germplasm.additionalInfo.pedigreeByUUID).maleParent"
-            v-bind:germplasmGID="Pedigree.parsePedigreeString(germplasm.pedigree).maleParent"
+            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(germplasm.pedigree,germplasm.additionalInfo.femaleParentUnknown,germplasm.additionalInfo.maleParentUnknown).maleParent"
           > </GermplasmLink></template>
         </li>
         <li><b>Synonyms: </b> {{ GermplasmUtils.formatSynonyms(germplasm.synonyms) }}</li>

--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -36,13 +36,13 @@
       <b-table-column field="femaleParentGID" label="Female Parent GID" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         <GermplasmLink
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(props.row.data.additionalInfo.pedigreeByUUID).femaleParent"
-            v-bind:germplasmGID="Pedigree.parsePedigreeString(props.row.data.pedigree).femaleParent"
+            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(props.row.data.pedigree, props.row.data.additionalInfo.femaleParentUnknown, props.row.data.additionalInfo.maleParentUnknown).femaleParent"
         > </GermplasmLink>
       </b-table-column>
       <b-table-column field="maleParentGID" label="Male Parent GID" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         <GermplasmLink
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(props.row.data.additionalInfo.pedigreeByUUID).maleParent"
-            v-bind:germplasmGID="Pedigree.parsePedigreeString(props.row.data.pedigree).maleParent"
+            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(props.row.data.pedigree,props.row.data.additionalInfo.femaleParentUnknown,props.row.data.additionalInfo.maleParentUnknown).maleParent"
         > </GermplasmLink>
       </b-table-column>
       <b-table-column field="createdDate" label="Created Date" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>

--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -36,13 +36,13 @@
       <b-table-column field="femaleParentGID" label="Female Parent GID" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         <GermplasmLink
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(props.row.data.additionalInfo.pedigreeByUUID).femaleParent"
-            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(props.row.data.pedigree, props.row.data.additionalInfo.femaleParentUnknown, props.row.data.additionalInfo.maleParentUnknown).femaleParent"
+            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(props.row.data.pedigree, props.row.data.additionalInfo.femaleParentUnknown, props.row.data.additionalInfo.maleParentUnknown, props.row.data.accessionNumber).femaleParent"
         > </GermplasmLink>
       </b-table-column>
       <b-table-column field="maleParentGID" label="Male Parent GID" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         <GermplasmLink
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(props.row.data.additionalInfo.pedigreeByUUID).maleParent"
-            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(props.row.data.pedigree,props.row.data.additionalInfo.femaleParentUnknown,props.row.data.additionalInfo.maleParentUnknown).maleParent"
+            v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(props.row.data.pedigree,props.row.data.additionalInfo.femaleParentUnknown,props.row.data.additionalInfo.maleParentUnknown, props.row.data.accessionNumber).maleParent"
         > </GermplasmLink>
       </b-table-column>
       <b-table-column field="createdDate" label="Created Date" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -221,27 +221,21 @@ export default class ImportGermplasm extends ProgramsBase {
 
   getPedigree(germplasm: Germplasm) {
     //return germplasm.pedigree;
-    console.log(germplasm);
-    console.log(germplasm.additionalInfo.femaleParentUnknown);
     let originalPedigree = germplasm.pedigree ? germplasm.pedigree.split('/') : [""];
     let displayPedigree = "";
-    if (germplasm.additionalInfo.femaleParentUnknown){
+    if (germplasm.additionalInfo && germplasm.additionalInfo.femaleParentUnknown){
       displayPedigree = "Unknown";
     } else {
       displayPedigree = originalPedigree[0];
     }
-    if (germplasm.additionalInfo.maleParentUnknown){
+    if (germplasm.additionalInfo && germplasm.additionalInfo.maleParentUnknown){
       displayPedigree += "/Unknown";
     } else if (originalPedigree.length == 2) {
       displayPedigree +=`/${originalPedigree[1]}`;
     }
-    /*else if (germplasm.additionalInfo.femaleParentUnknown && something) {
-      //Handle case with unknown female, known male, which currently has a null pedigree posted
+    //todo future card, handle case of unknown female/known male, which currently has null pedigree posted
 
-    }
-     */
     return displayPedigree;
-    //todo handle unknown f, known male
 
   }
 

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -112,7 +112,7 @@
             {{ props.row.data.brAPIObject.seedSource }}
           </b-table-column>
           <b-table-column field="pedigree" label="Pedigree" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ props.row.data.brAPIObject.pedigree }}
+            {{ getPedigree(props.row.data.brAPIObject) }}
           </b-table-column>
           <b-table-column field="femaleParentGid" label="Female Parent GID" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
             {{ props.row.data.brAPIObject.additionalInfo.femaleParentGid }}
@@ -162,6 +162,7 @@ import ExpandableTable from "@/components/tables/expandableTable/ExpandableTable
 import {ImportObjectState} from "@/breeding-insight/model/import/ImportObjectState";
 import {ExternalUID} from "@/breeding-insight/model/import/germplasm/ExternalUID";
 import {GermplasmUtils} from "@/breeding-insight/utils/GermplasmUtils";
+import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
 
 @Component({
   components: {
@@ -217,5 +218,32 @@ export default class ImportGermplasm extends ProgramsBase {
   importFinished() {
     this.germplasmList = new GermplasmList();
   }
+
+  getPedigree(germplasm: Germplasm) {
+    //return germplasm.pedigree;
+    console.log(germplasm);
+    console.log(germplasm.additionalInfo.femaleParentUnknown);
+    let originalPedigree = germplasm.pedigree ? germplasm.pedigree.split('/') : [""];
+    let displayPedigree = "";
+    if (germplasm.additionalInfo.femaleParentUnknown){
+      displayPedigree = "Unknown";
+    } else {
+      displayPedigree = originalPedigree[0];
+    }
+    if (germplasm.additionalInfo.maleParentUnknown){
+      displayPedigree += "/Unknown";
+    } else if (originalPedigree.length == 2) {
+      displayPedigree +=`/${originalPedigree[1]}`;
+    }
+    /*else if (germplasm.additionalInfo.femaleParentUnknown && something) {
+      //Handle case with unknown female, known male, which currently has a null pedigree posted
+
+    }
+     */
+    return displayPedigree;
+    //todo handle unknown f, known male
+
+  }
+
 }
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-1230 - Truly Unknown Germplasm](https://breedinginsight.atlassian.net/browse/BI-1230)

Updates to support importing germplasm with truly unknown parents without using a dummy parent. This development also ensures that unrelated germplasm with unknown parents are not falsely attributed as siblings in the pedigree view display.

To import a file with unknown parents, a GID or entry number of 0 must be used. Presently only both parents unknown or female parent known and male parent unknown are supported. 

Unknown parents will be displayed as "Unknown" in the parent GID columns in the All Germplasm table and in the pedigree in Germplasm Details page.

Due to Breedbase limitations, parents with more than 10 progeny will cause the pedigree viewer to error (to be fixed in BI-1579.

# Dependencies
[bi-api/BI-1230](https://github.com/Breeding-Insight/bi-api/pull/205)

# Testing
For both import with parent entry numbers and import with germplasm gids, import germplasm file with:

- Germplasm with no parents (should not be labeled unknown)
- Germplasm with unknown female parent
- Germplasm with known female parent and unknown male parent
- Germplasm with unknown female parent and unknown male parent 

Check import occurs successfully
Check that Unknown is displayed in GID column for All Germplasm Table for germplasm with Unknown parent
Check that Unknown displayed in pedigree on Germplasm Details page for germplasm with Unknown parent

Look at pedigree viewer and expand generations, unknown parents should be displayed and be separate nodes from each other

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3009574983)
