### PR TITLE
[BI-1506] Fix date for Germplasm Lists Table

### DIFF
--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -154,7 +154,7 @@ export default class GermplasmListsTable extends Vue {
   }
 
   formatDate(date: Date) {
-    return moment(date).format('YYYY-M-D, h:mm:ss');
+    return moment(date).format('YYYY-MM-DD');
   }
 
   updatePageSize(pageSize: string) {


### PR DESCRIPTION
# Description
**Story:** [BI-1506 - "Created Date" field in the All Germplasm table has the wrong date format.](https://breedinginsight.atlassian.net/browse/BI-1506)

Germplasm Lists Table updated to be in the proper YYYY-MM-DD format.

# Dependencies
bi-api/develop

# Testing

- Open Germplasm Lists table
- Ensure Date Created in YYYY-MM-DD format

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
