### PR TITLE
BI-1553 - Pedigree View on Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@casl/ability": "~4.0.0",
     "@casl/vue": "^1.1.1",
-    "@solgenomics/brapi-pedigree-viewer": "git+https://github.com/Breeding-Insight/BrAPI-Pedigree-Viewer#66431da2603e244045c40a71cfccfde5b09ee862",
+    "@solgenomics/brapi-pedigree-viewer": "git+https://github.com/Breeding-Insight/BrAPI-Pedigree-Viewer#v2.0.2",
     "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#v2.0.2",
     "@solgenomics/d3-pedigree-tree": "git+https://github.com/solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c",
     "@types/flat": "^5.0.2",


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1553

Updated BrAPI-Pedigree-Viewer to render multi-line node properly in Firefox



# Dependencies

Indirectly: https://github.com/Breeding-Insight/BrAPI-Pedigree-Viewer/pull/4

# Testing
1. Checkout this branch
2. Run `npm install`
3. Run bi-web
4. In Firefox, navigate to a germplasm record with pedigree
5. Verify that the nodes in the pedigree tree display correctly


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
