### PR TITLE
BI-1585 - TAF - Set proper id for "Choose ontology to subscribe to:" drop-down

### DIFF
--- a/src/components/forms/BasicInputField.vue
+++ b/src/components/forms/BasicInputField.vue
@@ -24,7 +24,7 @@
     v-bind:server-validations="serverValidations"
   >
     <input
-        v-bind:id="inputId ? inputId : fieldName.split(' ').join('-')"
+        v-bind:id="inputId ? inputId : fieldName.split(' ').join('-').replace(/[^a-zA-Z0-9\-]/gm, '')"
         v-bind:value="value"
         @input="$emit('input', $event.target.value)"
         class="input"

--- a/src/components/forms/BasicSelectField.vue
+++ b/src/components/forms/BasicSelectField.vue
@@ -25,7 +25,7 @@
   >
     <div class="select is-fullwidth">
       <select
-          v-bind:id="fieldName.replace(' ', '-')"
+          v-bind:id="fieldName.split(' ').join('-').replace(/[^a-zA-Z0-9\-]/gm, '')"
           v-on:change="$emit('input', $event.target.value)"
           class="select is-fullwidth"
           v-bind:disabled="isDisabled"


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1585

Updated `BasicSelectField` to replace all occurances of a space with a dash.  Bug was that only the first instance of a space was being replaced.  Also updated both `BasicSelectField` and `BasicInputField` to strip out non-alphanumeric and dash characters from the `id` field.


# Testing
1. Share a program's ontology with another program
2. Navigate to the program that an ontology was shared with
3. Navigate to the program configuration page
4. Inspect the `select` input's ID, and verify that it is "Choose-ontology-to-subscribe-to"


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] ~I have run TAF:~ NA: this bug fix is to fix a TAF scenario that's in progress
