### PR TITLE
[BI-1589] - Germplasm pagination doesn't work with page-1 or show-all

### DIFF
--- a/src/breeding-insight/service/BrAPIService.ts
+++ b/src/breeding-insight/service/BrAPIService.ts
@@ -41,7 +41,7 @@ export class BrAPIService {
     if (sort.order) {
       params['sortOrder'] = sort.order;
     }
-    if (pagination.page) {
+    if (pagination.page || pagination.page == 0) { //have to account for 0-index pagination since 0 falsy
       params ['page'] = pagination.page;
     }
     if (pagination.pageSize) {


### PR DESCRIPTION
# Description
**Story:** [BI-1589 - All Germplasm table pagination doesn't work with page-1 or show-all](https://breedinginsight.atlassian.net/browse/BI-1589)

All Germplasm table pagination logic uses 0-indexing to comply with BrAPI, which was leading to some pagination problems due to 0 being treated as falsy in javascript. This added a fix to handle that.

# Dependencies
bi-api/develop

# Testing
- In the "All Germplasm" table, change page size to have multiple pages
- Click on a page that is not page 1
- Click on page 1, pagination and results should return to page 1
- Click on page 2
- Click previous button, pagination and results should return to page 1
- Click on a page that is not page 1
- Click show-all, all entries should appear

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3105690130)
