### PR TITLE
[BI-1478] - Add Pedigree to All Germplasm Table

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -151,6 +151,7 @@ export enum GermplasmSortField {
   DefaultDisplayName = "defaultDisplayName",
   BreedingMethod = "breedingMethod",
   SeedSource = "seedSource",
+  Pedigree = "pedigree",
   FemaleParent = "femaleParentGID",
   MaleParent = "maleParentGID",
   CreatedDate = "createdDate",

--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -33,6 +33,9 @@
       <b-table-column field="seedSource" label="Source" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ props.row.data.seedSource }}
       </b-table-column>
+      <b-table-column field="pedigree" label="Pedigree" v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
+        {{ props.row.data.additionalInfo.pedigreeByName }}
+      </b-table-column>
       <b-table-column field="femaleParentGID" label="Female Parent GID" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         <GermplasmLink
             v-bind:germplasmUUID="Pedigree.parsePedigreeString(props.row.data.additionalInfo.pedigreeByUUID).femaleParent"


### PR DESCRIPTION
# Description
**Story:**  [BI-1478 - Add Pedigree to All Germplasm Table](https://breedinginsight.atlassian.net/browse/BI-1478)

Added pedigree column to All Germplasm table that displays the parent names with searching (but NOT sorting) enabled.

# Dependencies
[bi-api/feature/BI-1478](https://github.com/Breeding-Insight/bi-api/pull/213)

# Testing

- Open All Germplasm Table
- Check that Pedigree column exists
- Check that entries with parent GIDs have pedigree with corresponding parents in Pedigree Column
- Check that Pedigree column not sortable
- Try searching in Pedigree column for several different search terms

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3107562107)
