### PR TITLE
[BI-1147] ﻿﻿2.0 Experimental Data Preview Universal Elements

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -218,7 +218,7 @@ img {
   min-height:100vh;
   flex-direction: column;
   &.has-navbar-fixed-top-touch {
-    @extend body.has-navbar-fixed-top-touch;
+    @extend body, .has-navbar-fixed-top-touch;
   }
 }
 
@@ -776,4 +776,11 @@ div.b-table.loading-active tbody {
 
 .right-confirm-column {
   float: left;
+}
+
+tr:nth-child(even) td.db-filled {
+  background-color: mix($primary-light, $dark, 92%);
+}
+tr:nth-child(odd) td.db-filled {
+  background-color: $primary-light;
 }

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -60,8 +60,8 @@
             <p>Description: {{ rows[0].trial.brAPIObject.trialDescription }}</p>
             <p>Experimental Unit: {{ rows[0].trial.brAPIObject.additionalInfo.defaultObservationLevel }}</p>
             <p>Type: {{ rows[0].trial.brAPIObject.additionalInfo.experimentType }}</p>
-            <p>User: </p>
-            <p>Creation Date: </p>
+            <p v-if="isExisting(rows[0].trial.state)">User: </p>
+            <p v-if="isExisting(rows[0].trial.state)">Creation Date: </p>
           </div>
           </div>
         </ConfirmImportMessageBox>
@@ -137,17 +137,17 @@
 </template>
 
 <script lang="ts">
-import { Component } from 'vue-property-decorator'
+import {Component} from 'vue-property-decorator'
 import ProgramsBase from "@/components/program/ProgramsBase.vue";
 import ImportInfoTemplateMessageBox from "@/components/file-import/ImportInfoTemplateMessageBox.vue";
 import ConfirmImportMessageBox from "@/components/trait/ConfirmImportMessageBox.vue";
 import ImportTemplate from "@/views/import/ImportTemplate.vue";
 import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
 import {ImportFormatter} from "@/breeding-insight/model/report/ImportFormatter";
-import { AlertTriangleIcon } from 'vue-feather-icons';
-import {GermplasmList} from "@/breeding-insight/model/GermplasmList";
+import {AlertTriangleIcon} from 'vue-feather-icons';
 import BasicInputField from "@/components/forms/BasicInputField.vue";
 import ExpandableTable from "@/components/tables/expandableTable/ExpandableTable.vue";
+import {ImportObjectState} from "@/breeding-insight/model/import/ImportObjectState";
 
 @Component({
   components: {
@@ -215,6 +215,10 @@ export default class ImportExperiment extends ProgramsBase {
   }
 
   importFinished(){}
+
+  isExisting(state: ImportObjectState) {
+    return state === ImportObjectState.EXISTING;
+  }
 
 }
 </script>

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -60,8 +60,9 @@
             <p>Description: {{ rows[0].trial.brAPIObject.trialDescription }}</p>
             <p>Experimental Unit: {{ rows[0].trial.brAPIObject.additionalInfo.defaultObservationLevel }}</p>
             <p>Type: {{ rows[0].trial.brAPIObject.additionalInfo.experimentType }}</p>
-            <p v-if="isExisting(rows[0].trial.state)">User: </p>
-            <p v-if="isExisting(rows[0].trial.state)">Creation Date: </p>
+            <p>Experimental Design: Externally generated</p>
+            <p v-if="isExisting(rows)">User: </p>
+            <p v-if="isExisting(rows)">Creation Date: </p>
           </div>
           </div>
         </ConfirmImportMessageBox>
@@ -216,8 +217,8 @@ export default class ImportExperiment extends ProgramsBase {
 
   importFinished(){}
 
-  isExisting(state: ImportObjectState) {
-    return state === ImportObjectState.EXISTING;
+  isExisting(rows: any[]) {
+    return rows.length && rows[0].trial.state === ImportObjectState.EXISTING && rows[0].observationUnit.state === ImportObjectState.EXISTING;
   }
 
 }

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -75,7 +75,8 @@
             v-on:show-error-notification="$emit('show-error-notification', $event)"
         >
           <!-- Germplasm Name -->
-          <b-table-column field="germplasmName" label="Germplasm Name" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+          <b-table-column field="germplasmName" label="Germplasm Name" v-slot="props" :th-attrs="(column) => ({scope:'col'})"
+          :td-attrs="(row, column) => ({class: 'db-filled'})">
             {{ getField(props.row.data.germplasm, 'germplasmName') }}
           </b-table-column>
           <!-- Germplasm GID -->

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -20,7 +20,7 @@
     <ImportTemplate
         v-bind:abort-msg="'No records will be added, and the import in progress will be completely removed.'"
         v-bind:system-import-template-name="experimentImportTemplateName"
-        v-bind:confirm-msg="'Confirm New Experiments & Observations Records'"
+        v-bind:confirm-msg="'Preview Experimental Upload'"
         v-bind:import-type-name="'Experiments & Observations'"
         v-bind:confirm-import-state="confirmImportState"
         v-on="$listeners"
@@ -48,6 +48,7 @@
                                  v-on:confirm="confirm"
                                  class="mb-4">
           <div>
+            <p>Review your experimental data import before committing to the database.</p>
           <div class = "left-confirm-column">
             <p class="is-size-5 mb-2"><strong>Import Summary</strong></p>
             <p>Environments: {{ statistics.Environments.newObjectCount }}</p>

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -62,8 +62,8 @@
             <p>Experimental Unit: {{ rows[0].trial.brAPIObject.additionalInfo.defaultObservationLevel }}</p>
             <p>Type: {{ rows[0].trial.brAPIObject.additionalInfo.experimentType }}</p>
             <p>Experimental Design: Externally generated</p>
-            <p v-if="isExisting(rows)">User: </p>
-            <p v-if="isExisting(rows)">Creation Date: </p>
+            <p v-if="isExisting(rows)">User: {{ rows[0].trial.brAPIObject.additionalInfo.createdBy.userName }}</p>
+            <p v-if="isExisting(rows)">Creation Date: {{ rows[0].trial.brAPIObject.additionalInfo.createdDate | dmy}}</p>
           </div>
           </div>
         </ConfirmImportMessageBox>
@@ -155,6 +155,11 @@ import {ImportObjectState} from "@/breeding-insight/model/import/ImportObjectSta
   components: {
     ImportInfoTemplateMessageBox, ConfirmImportMessageBox, ImportTemplate, AlertTriangleIcon, BasicInputField, ExpandableTable
   },
+  filters: {
+    dmy: function(dateTime: String): String {
+      return dateTime.split(' ')[0];
+    }
+  },
   data: () => ({ImportFormatter})
 })
 export default class ImportExperiment extends ProgramsBase {
@@ -219,7 +224,7 @@ export default class ImportExperiment extends ProgramsBase {
   importFinished(){}
 
   isExisting(rows: any[]) {
-    return rows.length && rows[0].trial.state === ImportObjectState.EXISTING && rows[0].observationUnit.state === ImportObjectState.EXISTING;
+    return rows.length && rows[0].trial.state === ImportObjectState.EXISTING;
   }
 
 }


### PR DESCRIPTION
# Description
**Story:** [BI-1147](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1147)

a class was added to the germplasm names in new experiment import preview so that it can be styled light purple.
created by/date fields in experiment details of the preview are only displayed if importing into an existing experiment.

# Dependencies
bi-api BI-1147 branch

# Testing

create a new experiment and verify preview summary and table match the wireframe.
import the same data with a different environment and verify that createdBy and createdDate fields are diplayed in preview summary.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
