### PR TITLE
[BI-1634] When filtering the list, set the page to page-1

### DIFF
--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -14,7 +14,7 @@
         backend-sorting
         v-bind:default-sort="[buefyFieldMap[germplasmSort.field], Sort.orderAsBuefy(germplasmSort.order)]"
         v-on:sort="setSort"
-        v-on:search="filters = $event"
+        v-on:search="initSearch"
         v-bind:search-debounce="400"
     >
       <b-table-column field="accessionNumber" label="GID" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
@@ -176,6 +176,10 @@ export default class GermplasmTable extends Vue {
       this.getGermplasm();
     }
   }
-
+  initSearch(filter: any){
+    this.filters = filter;
+    // When filtering the list, set the page to page-1
+    this.paginationController.updatePage(1);
+  }
 }
 </script>

--- a/src/views/germplasm/GermplasmTable.vue
+++ b/src/views/germplasm/GermplasmTable.vue
@@ -178,7 +178,7 @@ export default class GermplasmTable extends Vue {
   }
   initSearch(filter: any){
     this.filters = filter;
-    // When filtering the list, set the page to page-1
+    // When filtering the list, set the page to the first page.
     this.paginationController.updatePage(1);
   }
 }


### PR DESCRIPTION
# Description
[BI-1634 (Germplasm filtering and sorting fails for pages beyond the first)](https://breedinginsight.atlassian.net/browse/BI-1634)

# Dependencies
bi_api: release/0.7

# Testing

1. Go to an All Germplasm table with more than one page.
2. Go to any page other than page-1.
3. Apply a valid filter to any column.

**Expected Result**

1. Valid filtered Germplasm table should displayed
2. The Germplasm table should be on page-1


# Checklist:

- [ ] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [X] I have run [TAF](https://github.com/Breeding-Insight/taf/actions/runs/3395567732)
