### PR TITLE
BI-1653 - Update Experiment Preview to show observations

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -232,9 +232,6 @@ export default class ImportExperiment extends ProgramsBase {
   importFinished(){}
 
   previewDataLoaded(data: any[]) {
-    console.log('PREVIEW DATA LOADED');
-    console.log(data);
-
     if (data.length > 0) {
       const firstRow = data[0];
       if (firstRow.observations && firstRow.observations.length > 0) {
@@ -244,8 +241,6 @@ export default class ImportExperiment extends ProgramsBase {
         });
       }
     }
-
-    console.log(this.phenotypeColumns);
   }
 
   isExisting(rows: any[]) {

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -25,6 +25,7 @@
         v-bind:confirm-import-state="confirmImportState"
         v-on="$listeners"
         v-on:finished="importFinished"
+        v-on:preview-data-loaded="previewDataLoaded"
     >
 
       <template v-slot:importInfoTemplateMessageBox>
@@ -70,6 +71,8 @@
       </template>
 
       <template v-slot:importPreviewTable="previewData">
+
+
         <ExpandableTable
             v-bind:records="previewData.import"
             v-bind:loading="false"
@@ -126,6 +129,10 @@
             {{ getTreatment(props.row.data.observationUnit) }}
           </b-table-column>
 
+          <b-table-column v-for="variable in phenotypeColumns" :key="variable" :label="variable" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+            {{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable)[0].brAPIObject.value }}
+          </b-table-column>
+
           <template v-slot:emptyMessage>
             <p class="has-text-weight-bold">
               No experiment data found in this import file.
@@ -166,7 +173,8 @@ export default class ImportExperiment extends ProgramsBase {
 
   private experimentImportTemplateName = 'ExperimentsTemplateMap';
   private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
-  
+  private phenotypeColumns?: Array<String> = [];
+
   getNumNewExperimentRecords(statistics: any): number | undefined {
     return undefined;
   }
@@ -222,6 +230,23 @@ export default class ImportExperiment extends ProgramsBase {
   }
 
   importFinished(){}
+
+  previewDataLoaded(data: any[]) {
+    console.log('PREVIEW DATA LOADED');
+    console.log(data);
+
+    if (data.length > 0) {
+      const firstRow = data[0];
+      if (firstRow.observations && firstRow.observations.length > 0) {
+        this.phenotypeColumns = firstRow.observations.map((observation: any) =>
+        {
+          return observation.brAPIObject.observationVariableName;
+        });
+      }
+    }
+
+    console.log(this.phenotypeColumns);
+  }
 
   isExisting(rows: any[]) {
     return rows.length && rows[0].trial.state === ImportObjectState.EXISTING;

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -493,6 +493,7 @@ export default class ImportTemplate extends ProgramsBase {
             this.previewTotalRows = previewResponse.preview.rows.length;
             this.previewData = previewResponse.preview.rows as any[];
             this.newObjectCounts = previewResponse.preview.statistics;
+            this.$emit('preview-data-loaded', this.previewData);
             this.importService.send(ImportEvent.IMPORT_SUCCESS);
             // TODO: Temp pagination
             this.pagination.totalCount = previewResponse.preview.rows.length;


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1653?atlOrigin=eyJpIjoiZDc3NjY3ZDkyNzFkNDdkZWIxYjk3ODZkNjI0NmUyNjEiLCJwIjoiaiJ9

- Added displaying phenotype columns to import preview table

# Dependencies
- bi-api feature/BI-1653

# Testing
- Import experiment files with and without phenotype observations and verify preview table matches file

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
