### PR TITLE
[BI-1194] - Upload with timestamps

### DIFF
--- a/src/breeding-insight/model/Observation.ts
+++ b/src/breeding-insight/model/Observation.ts
@@ -30,6 +30,7 @@ export class Observation {
   season?: Season;
   level?: string;
   value?: any;
+  observationTimeStamp?: string;
 
   constructor(id?: string,
               studyId?: string,

--- a/src/breeding-insight/model/import/ImportPreview.ts
+++ b/src/breeding-insight/model/import/ImportPreview.ts
@@ -20,9 +20,12 @@ import {ImportPreviewStatistics} from "@/breeding-insight/model/import/ImportPre
 export class ImportPreview {
   statistics?: {[key: string]: ImportPreviewStatistics};
   rows?: any[];
+  dynamicColumnNames?: string[];
 
-  constructor({statistics, rows}: ImportPreview) {
+  constructor({statistics, rows, dynamicColumnNames}: ImportPreview) {
     this.statistics = statistics;
     this.rows = rows;
+    this.dynamicColumnNames = dynamicColumnNames;
+
   }
 }

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -78,6 +78,7 @@
             v-bind:loading="false"
             v-bind:pagination="previewData.pagination"
             v-on:show-error-notification="$emit('show-error-notification', $event)"
+            scrollable
         >
           <!-- Germplasm Name -->
           <b-table-column field="germplasmName" label="Germplasm Name" v-slot="props" :th-attrs="(column) => ({scope:'col'})"
@@ -130,7 +131,8 @@
           </b-table-column>
 
           <b-table-column v-for="variable in phenotypeColumns" :key="variable" :label="variable" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable)[0].brAPIObject.value }}
+            <p v-if="variable.startsWith('TS: ')">{{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable.replace("TS: ",""))[0].brAPIObject.observationTimeStamp}}</p>
+            <p v-else>{{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable)[0].brAPIObject.value }}</p>
           </b-table-column>
 
           <template v-slot:emptyMessage>
@@ -231,16 +233,17 @@ export default class ImportExperiment extends ProgramsBase {
 
   importFinished(){}
 
-  previewDataLoaded(data: any[]) {
+  //todo may streamline
+  previewDataLoaded(data: any[], dynamicColumns: String[]) {
     if (data.length > 0) {
       const firstRow = data[0];
       if (firstRow.observations && firstRow.observations.length > 0) {
-        this.phenotypeColumns = firstRow.observations.map((observation: any) =>
-        {
+        this.phenotypeColumns = firstRow.observations.map((observation: any) => {
           return observation.brAPIObject.observationVariableName;
         });
       }
     }
+    this.phenotypeColumns = dynamicColumns;
   }
 
   isExisting(rows: any[]) {

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -233,16 +233,7 @@ export default class ImportExperiment extends ProgramsBase {
 
   importFinished(){}
 
-  //todo may streamline
-  previewDataLoaded(data: any[], dynamicColumns: String[]) {
-    if (data.length > 0) {
-      const firstRow = data[0];
-      if (firstRow.observations && firstRow.observations.length > 0) {
-        this.phenotypeColumns = firstRow.observations.map((observation: any) => {
-          return observation.brAPIObject.observationVariableName;
-        });
-      }
-    }
+  previewDataLoaded(dynamicColumns: String[]) {
     this.phenotypeColumns = dynamicColumns;
   }
 

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -131,7 +131,7 @@
           </b-table-column>
 
           <b-table-column v-for="variable in phenotypeColumns" :key="variable" :label="variable" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            <p v-if="variable.startsWith('TS: ')">{{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable.replace("TS: ",""))[0].brAPIObject.observationTimeStamp}}</p>
+            <p v-if="variable.startsWith('TS:')">{{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable.replace(/TS:\s*/,""))[0].brAPIObject.observationTimeStamp}}</p>
             <p v-else>{{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable)[0].brAPIObject.value }}</p>
           </b-table-column>
 

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -129,10 +129,9 @@
           <b-table-column field="expTreatmentFactorName" label="Treatment Factors" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
             {{ getTreatment(props.row.data.observationUnit) }}
           </b-table-column>
-
+          <!-- Dynamic Phenotype and Timestamp Columns -->
           <b-table-column v-for="variable in phenotypeColumns" :key="variable" :label="variable" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            <p v-if="variable.startsWith('TS:')">{{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable.replace(/TS:\s*/,""))[0].brAPIObject.observationTimeStamp}}</p>
-            <p v-else>{{ props.row.data.observations.filter(observation => observation.brAPIObject.observationVariableName === variable)[0].brAPIObject.value }}</p>
+            <p> {{ retrieveDynamicColVal(props.row.data.observations, variable) }}</p>
           </b-table-column>
 
           <template v-slot:emptyMessage>
@@ -241,5 +240,14 @@ export default class ImportExperiment extends ProgramsBase {
     return rows.length && rows[0].trial.state === ImportObjectState.EXISTING;
   }
 
+  retrieveDynamicColVal(importReturnObject: any, column: string){
+    if (column.startsWith('TS:')) {
+      //Is timestamp
+      return importReturnObject.filter((observation: { brAPIObject: { observationVariableName: string; }; }) => observation.brAPIObject.observationVariableName === column.replace(/TS:\s*/,""))[0].brAPIObject.observationTimeStamp;
+    } else {
+      //Is phenotype observation
+      return importReturnObject.filter((observation: { brAPIObject: { observationVariableName: string; }; }) => observation.brAPIObject.observationVariableName === column)[0].brAPIObject.value
+    }
+  }
 }
 </script>

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -192,6 +192,7 @@ export default class ImportTemplate extends ProgramsBase {
   private previewData: any[] = [];
   private previewTotalRows: number = 0;
   private newObjectCounts: any = [];
+  private dynamicColumns: string[] | undefined = [];
 
   private file : File | null = null;
   private import_errors: ValidationError | String | null = null;
@@ -493,7 +494,8 @@ export default class ImportTemplate extends ProgramsBase {
             this.previewTotalRows = previewResponse.preview.rows.length;
             this.previewData = previewResponse.preview.rows as any[];
             this.newObjectCounts = previewResponse.preview.statistics;
-            this.$emit('preview-data-loaded', this.previewData);
+            this.dynamicColumns = previewResponse.preview.dynamicColumnNames;
+            this.$emit('preview-data-loaded', this.previewData, this.dynamicColumns);
             this.importService.send(ImportEvent.IMPORT_SUCCESS);
             // TODO: Temp pagination
             this.pagination.totalCount = previewResponse.preview.rows.length;

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -495,7 +495,7 @@ export default class ImportTemplate extends ProgramsBase {
             this.previewData = previewResponse.preview.rows as any[];
             this.newObjectCounts = previewResponse.preview.statistics;
             this.dynamicColumns = previewResponse.preview.dynamicColumnNames;
-            this.$emit('preview-data-loaded', this.previewData, this.dynamicColumns);
+            this.$emit('preview-data-loaded', this.dynamicColumns);
             this.importService.send(ImportEvent.IMPORT_SUCCESS);
             // TODO: Temp pagination
             this.pagination.totalCount = previewResponse.preview.rows.length;


### PR DESCRIPTION
# Description
**Story:** [BI-1194 - Upload with timestamps](https://breedinginsight.atlassian.net/browse/BI-1194)

Updates to enable display of timestamp values in experiment import preview and to ensure that dynamic columns (phenotypes and timestamps) are displayed in the same order as in the import file.

# Dependencies
[bi-api/BI-1194](https://github.com/Breeding-Insight/bi-api/pull/225)

# Testing
- Import experiment file with phenotypes and timestamps of both date and date/time values (the latter indicated by TS: ontology term name)
- Ensure preview screen displays phenotype and timestamp columns and values in same order as file
- Ensure timestamp columns with date only in file also have time of midnight associated in preview

- Import experiment file with incorrect timestamp format - error should display

- Import experiment file with timestamp that doesn't correspond to a phenotype column in the file - error should display

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3492308685)
