### PR TITLE
[BI-1614] - Add Term Type to Ontology Term display and form

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -55,7 +55,8 @@ export enum OntologySortField {
   MethodDescription = 'methodDescription',
   ScaleClass = 'scaleClass',
   ScaleName = 'scaleName',
-  entityAttributeSortLabel = 'entityAttribute'
+  entityAttributeSortLabel = 'entityAttribute',
+  TermType = 'termType'
 }
 
 export class OntologySort {

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -24,7 +24,6 @@ export class Trait {
   id?: string;
   traitName?: string;
   observationVariableName?: string;
-  termType?: TermType;
   programObservationLevel?: ProgramObservationLevel;
   entity?: string;
   attribute?: string;
@@ -37,11 +36,11 @@ export class Trait {
   tags?: string[] = [];
   fullName?: string;
   isDup?: boolean;
+  termType?: TermType;
 
   constructor(id?: string,
               traitName?: string,
               observationVariableName?: string,
-              termType?: TermType,
               programObservationLevel?: ProgramObservationLevel,
               entity?: string,
               attribute?: string,
@@ -52,7 +51,8 @@ export class Trait {
               active?: boolean,
               tags?: string[],
               fullName?: string,
-              isDup?: boolean
+              isDup?: boolean,
+              termType?: TermType
               ) {
     this.id = id;
     this.traitName = traitName;

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -18,11 +18,13 @@
 import {ProgramObservationLevel} from "@/breeding-insight/model/ProgramObservationLevel";
 import {Method} from "@/breeding-insight/model/Method";
 import {Scale} from "@/breeding-insight/model/Scale";
+import {TermType} from "@/breeding-insight/model/TraitSelector";
 
 export class Trait {
   id?: string;
   traitName?: string;
   observationVariableName?: string;
+  termType?: TermType;
   programObservationLevel?: ProgramObservationLevel;
   entity?: string;
   attribute?: string;
@@ -39,6 +41,7 @@ export class Trait {
   constructor(id?: string,
               traitName?: string,
               observationVariableName?: string,
+              termType?: TermType,
               programObservationLevel?: ProgramObservationLevel,
               entity?: string,
               attribute?: string,
@@ -49,7 +52,7 @@ export class Trait {
               active?: boolean,
               tags?: string[],
               fullName?: string,
-              isDup?: boolean,
+              isDup?: boolean
               ) {
     this.id = id;
     this.traitName = traitName;
@@ -89,7 +92,7 @@ export class Trait {
 
   static assign(trait: Trait): Trait {
     return new Trait(trait.id, trait.traitName, trait.observationVariableName, trait.programObservationLevel, trait.entity, trait.attribute,
-        trait.traitDescription, trait.method, trait.scale, trait.synonyms, trait.active, trait.tags, trait.fullName, trait.isDup);
+        trait.traitDescription, trait.method, trait.scale, trait.synonyms, trait.active, trait.tags, trait.fullName, trait.isDup, trait.termType);
   }
 
   checkStringListEquals(list: string[] | undefined, otherList: string[] | undefined): boolean {
@@ -111,6 +114,7 @@ export class Trait {
       (this.traitName === trait.traitName) &&
       (this.observationVariableName === trait.observationVariableName) &&
       (this.fullName === trait.fullName) &&
+      (this.termType === trait.termType) &&
       (this.checkStringListEquals(this.synonyms, trait.synonyms)) &&
       (this.mainAbbreviation === trait.mainAbbreviation) &&
         (this.entity === trait.entity) &&

--- a/src/breeding-insight/model/TraitSelector.ts
+++ b/src/breeding-insight/model/TraitSelector.ts
@@ -21,6 +21,12 @@ export enum TraitField {
   UPDATED_BY_USER_NAME = 'updatedByUserName'
 }
 
+export enum TermType {
+  PHENOTYPE = 'Phenotype',
+  GERM_ATTRIBUTE = 'Germplasm Attribute',
+  GERM_PASSPORT = 'Germplasm Passport'
+}
+
 export class TraitFilter {
   field?: TraitField;
   value?: string | number | boolean;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -123,6 +123,18 @@
           {{ data.observationVariableName }}
         </TableColumn>
         <TableColumn
+            name="termType"
+            v-bind:label="'Term Type'"
+            v-bind:sortField="ontologySort.field"
+            v-bind:sortFieldLabel="termTypeSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="ontologySort.order"
+            v-on:newSortColumn="$emit('newSortColumn', $event)"
+            v-on:toggleSortOrder="$emit('toggleSortOrder')"
+        >
+          {{ data.termType }}
+        </TableColumn>
+        <TableColumn
           name="trait"
           v-bind:label="'Trait'"
           v-bind:visible="!traitSidePanelState.collapseColumns"
@@ -314,6 +326,7 @@ export default class OntologyTable extends Vue {
   private scaleClassSortLabel: string = OntologySortField.ScaleClass;
   private unitSortLabel: string = OntologySortField.ScaleName;
   private entityAttributeSortLabel: string = OntologySortField.entityAttributeSortLabel;
+  private termTypeSortLabel: string = OntologySortField.TermType;
 
   // New trait form
   private newTraitActive: boolean = false;

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -31,6 +31,16 @@
           <span class="is-size-7 mb-0">{{data.traitDescription}}</span>
         </div>
       </div>
+
+      <div v-if="data.termType" class="columns is-desktop pt-1 pl-3">
+        <div class="column is-one-third pt-0 pb-0 has-text-right-desktop">
+          <span class="has-text-weight-bold">Term Type</span>
+        </div>
+        <div class="column pt-0 pb-0">
+          <span class="is-size-7 mb-0">{{data.termType}}</span>
+        </div>
+      </div>
+
       <!-- just shows first abbreviation AKA main abbreviation and first synonym -->
       <template v-if="abbreviationsSynonymsString">
         <div class="columns is-desktop pt-1 pl-3">

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -14,6 +14,21 @@
       <label for="newTermActiveToggle" class="is-pulled-right">{{trait.active ? 'Active' : 'Archived'}}</label>
     </div>
 
+<!-- term type -->
+  <div class="column is-2">
+    <span class="is-pulled-right required new-term pb-2 pr-3">Term Type</span>
+  </div>
+  <div class="column new-term is-10">
+    <BasicSelectField
+        class="pb-2"
+        v-bind:selected-id="trait.termType"
+        v-bind:options="termTypes"
+        v-bind:field-name="'Term Type'"
+        v-bind:show-label="false"
+        v-on:input="setTermType($event)"
+    />
+  </div>
+
 <!--    term name-->
     <div class="column is-2">
       <span class="is-pulled-right required new-term pb-2 pr-3">Name</span>
@@ -265,22 +280,22 @@ import BasicInputField from "@/components/forms/BasicInputField.vue";
 import BasicSelectField from "@/components/forms/BasicSelectField.vue";
 import {Trait} from "@/breeding-insight/model/Trait";
 import {Method, MethodClass} from "@/breeding-insight/model/Method";
-import { Scale, DataType } from '@/breeding-insight/model/Scale';
-import { ProgramObservationLevel } from '@/breeding-insight/model/ProgramObservationLevel';
+import {DataType, Scale} from '@/breeding-insight/model/Scale';
+import {ProgramObservationLevel} from '@/breeding-insight/model/ProgramObservationLevel';
 import OrdinalTraitForm from "@/components/trait/forms/CategoryTraitForm.vue";
+import CategoryTraitForm from "@/components/trait/forms/CategoryTraitForm.vue";
 import TextTraitForm from "@/components/trait/forms/TextTraitForm.vue";
 import DateTraitForm from "@/components/trait/forms/DateTraitForm.vue";
 import DurationTraitForm from "@/components/trait/forms/DurationTraitForm.vue";
 import NumericalTraitForm from "@/components/trait/forms/NumericalTraitForm.vue";
-import CategoryTraitForm from "@/components/trait/forms/CategoryTraitForm.vue";
 import {TraitError} from "@/breeding-insight/model/errors/TraitError";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 import AutoCompleteField from "@/components/forms/AutoCompleteField.vue";
-import { StringFormatters } from '@/breeding-insight/utils/StringFormatters';
+import {StringFormatters} from '@/breeding-insight/utils/StringFormatters';
 import {Category} from "@/breeding-insight/model/Category";
-import {integer} from "vuelidate/lib/validators";
 import TagField from "@/components/forms/TagField.vue";
 import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
+import {TermType} from "@/breeding-insight/model/TraitSelector";
 
 @Component({
   components: {
@@ -323,6 +338,8 @@ export default class BaseTraitForm extends Vue {
   @Prop()
   tags?: string[];
 
+  private termTypes: TermType[] = Object.values(TermType);
+
   private methodHistory: {[key: string]: Method} = {};
   private scaleHistory: {[key: string]: Scale} = {};
   private lastCategoryType: string = '';
@@ -361,6 +378,9 @@ export default class BaseTraitForm extends Vue {
     }
     if ((this.trait.scale) && (this.trait.scale.categories)) {
       this.categories = this.trait.scale.categories;
+    }
+    if (!this.trait.termType) {
+      this.trait.termType = TermType.PHENOTYPE;
     }
   }
 
@@ -527,6 +547,10 @@ export default class BaseTraitForm extends Vue {
     } else {
       this.trait.synonyms[0] = value;
     }
+  }
+
+  setTermType(value: TermType) {
+    this.trait.termType = value;
   }
 
   setFullName(value: string) {


### PR DESCRIPTION
# Description
**Story:** [BI-1614 - Add Term Type to Ontology Term display and form creation/modification](https://breedinginsight.atlassian.net/browse/BI-1614)

Added TermType enum and added dropdown to select Term Type in ontology term form.
Added display of term type in ontology side panel and ontology table

# Dependencies
bi-api/develop

# Testing
NOTE: As Term Type is not yet stored in backend, table/side panel display will need to be tested in [BI-1615](https://github.com/Breeding-Insight/bi-web/pull/285)

- Navigate to ontology table
- Should see empty Term Type column
- Select new term
- New input Term Type should be present at top of form, with a dropdown and "Phenotype" selected as default.
- Dropdown should list the options "Phenotype", "Germplasm Attribute", and "Germplasm Passport"
- User should be able to select aforementioned options
- Click edit on existing ontology term, Term Type should be present at top of form with same dropdown

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3586137883)
