### PR TITLE
[BI-1615] - Add termType to Trait DB Table

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -55,7 +55,8 @@ export enum OntologySortField {
   MethodDescription = 'methodDescription',
   ScaleClass = 'scaleClass',
   ScaleName = 'scaleName',
-  entityAttributeSortLabel = 'entityAttribute'
+  entityAttributeSortLabel = 'entityAttribute',
+  TermType = 'termType'
 }
 
 export class OntologySort {

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -88,6 +88,7 @@ export class Trait {
     }
     this.fullName = fullName;
     this.isDup = isDup;
+    this.termType = termType;
   }
 
   static assign(trait: Trait): Trait {

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -24,7 +24,6 @@ export class Trait {
   id?: string;
   traitName?: string;
   observationVariableName?: string;
-  termType?: TermType;
   programObservationLevel?: ProgramObservationLevel;
   entity?: string;
   attribute?: string;
@@ -37,11 +36,11 @@ export class Trait {
   tags?: string[] = [];
   fullName?: string;
   isDup?: boolean;
+  termType?: TermType;
 
   constructor(id?: string,
               traitName?: string,
               observationVariableName?: string,
-              termType?: TermType,
               programObservationLevel?: ProgramObservationLevel,
               entity?: string,
               attribute?: string,
@@ -52,7 +51,8 @@ export class Trait {
               active?: boolean,
               tags?: string[],
               fullName?: string,
-              isDup?: boolean
+              isDup?: boolean,
+              termType?: TermType
               ) {
     this.id = id;
     this.traitName = traitName;

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -18,11 +18,13 @@
 import {ProgramObservationLevel} from "@/breeding-insight/model/ProgramObservationLevel";
 import {Method} from "@/breeding-insight/model/Method";
 import {Scale} from "@/breeding-insight/model/Scale";
+import {TermType} from "@/breeding-insight/model/TraitSelector";
 
 export class Trait {
   id?: string;
   traitName?: string;
   observationVariableName?: string;
+  termType?: TermType;
   programObservationLevel?: ProgramObservationLevel;
   entity?: string;
   attribute?: string;
@@ -39,6 +41,7 @@ export class Trait {
   constructor(id?: string,
               traitName?: string,
               observationVariableName?: string,
+              termType?: TermType,
               programObservationLevel?: ProgramObservationLevel,
               entity?: string,
               attribute?: string,
@@ -49,7 +52,7 @@ export class Trait {
               active?: boolean,
               tags?: string[],
               fullName?: string,
-              isDup?: boolean,
+              isDup?: boolean
               ) {
     this.id = id;
     this.traitName = traitName;
@@ -89,7 +92,7 @@ export class Trait {
 
   static assign(trait: Trait): Trait {
     return new Trait(trait.id, trait.traitName, trait.observationVariableName, trait.programObservationLevel, trait.entity, trait.attribute,
-        trait.traitDescription, trait.method, trait.scale, trait.synonyms, trait.active, trait.tags, trait.fullName, trait.isDup);
+        trait.traitDescription, trait.method, trait.scale, trait.synonyms, trait.active, trait.tags, trait.fullName, trait.isDup, trait.termType);
   }
 
   checkStringListEquals(list: string[] | undefined, otherList: string[] | undefined): boolean {
@@ -111,6 +114,7 @@ export class Trait {
       (this.traitName === trait.traitName) &&
       (this.observationVariableName === trait.observationVariableName) &&
       (this.fullName === trait.fullName) &&
+      (this.termType === trait.termType) &&
       (this.checkStringListEquals(this.synonyms, trait.synonyms)) &&
       (this.mainAbbreviation === trait.mainAbbreviation) &&
         (this.entity === trait.entity) &&

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -36,7 +36,7 @@ export class Trait {
   tags?: string[] = [];
   fullName?: string;
   isDup?: boolean;
-  termType?: TermType;
+  termType: TermType =  TermType.PHENOTYPE; //Phenotype is default
 
   constructor(id?: string,
               traitName?: string,
@@ -88,7 +88,9 @@ export class Trait {
     }
     this.fullName = fullName;
     this.isDup = isDup;
-    this.termType = termType;
+    if (termType) {
+      this.termType = termType;
+    }
   }
 
   static assign(trait: Trait): Trait {

--- a/src/breeding-insight/model/TraitSelector.ts
+++ b/src/breeding-insight/model/TraitSelector.ts
@@ -21,6 +21,12 @@ export enum TraitField {
   UPDATED_BY_USER_NAME = 'updatedByUserName'
 }
 
+export enum TermType {
+  PHENOTYPE = 'Phenotype',
+  GERM_ATTRIBUTE = 'Germplasm Attribute',
+  GERM_PASSPORT = 'Germplasm Passport'
+}
+
 export class TraitFilter {
   field?: TraitField;
   value?: string | number | boolean;

--- a/src/breeding-insight/model/TraitSelector.ts
+++ b/src/breeding-insight/model/TraitSelector.ts
@@ -23,9 +23,9 @@ export enum TraitField {
 }
 
 export enum TermType {
-  PHENOTYPE = 'PHENOTYPE',
-  GERM_ATTRIBUTE = 'GERM_ATTRIBUTE',
-  GERM_PASSPORT = 'GERM_PASSPORT'
+  PHENOTYPE = 'Phenotype',
+  GERM_ATTRIBUTE = 'Germplasm Attribute',
+  GERM_PASSPORT = 'Germplasm Passport'
 }
 
 export class TraitFilter {

--- a/src/breeding-insight/model/TraitSelector.ts
+++ b/src/breeding-insight/model/TraitSelector.ts
@@ -18,13 +18,14 @@ export enum TraitField {
   CREATED_BY_USER_ID = 'createdByUserId',
   CREATED_BY_USER_NAME = 'createdByUserName',
   UPDATED_BY_USER_ID = 'updatedByUserId',
-  UPDATED_BY_USER_NAME = 'updatedByUserName'
+  UPDATED_BY_USER_NAME = 'updatedByUserName',
+  TERM_TYPE = 'termType'
 }
 
 export enum TermType {
-  PHENOTYPE = 'Phenotype',
-  GERM_ATTRIBUTE = 'Germplasm Attribute',
-  GERM_PASSPORT = 'Germplasm Passport'
+  PHENOTYPE = 'PHENOTYPE',
+  GERM_ATTRIBUTE = 'GERM_ATTRIBUTE',
+  GERM_PASSPORT = 'GERM_PASSPORT'
 }
 
 export class TraitFilter {

--- a/src/breeding-insight/utils/EnumUtils.ts
+++ b/src/breeding-insight/utils/EnumUtils.ts
@@ -1,0 +1,28 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class EnumUtils {
+    static enumKeyToValue(enumKey: string, enumType: Object){
+        let index = Object.keys(enumType).indexOf(enumKey);
+        return Object.values(enumType)[index];
+    }
+
+    static enumValueToKey(enumVal: string, enumType: Object){
+        let index = Object.values(enumType).indexOf(enumVal);
+        return Object.keys(enumType)[index];
+    }
+}

--- a/src/breeding-insight/utils/TraitStringFormatters.ts
+++ b/src/breeding-insight/utils/TraitStringFormatters.ts
@@ -17,6 +17,7 @@
 
 import {Scale, DataType} from "@/breeding-insight/model/Scale";
 import {StringFormatters} from "@/breeding-insight/utils/StringFormatters";
+import {TermType} from "@/breeding-insight/model/TraitSelector";
 
 export class TraitStringFormatters {
   
@@ -31,5 +32,10 @@ export class TraitStringFormatters {
     }
     return undefined;
   }
+
+  static getTermTypeString(termType: TermType): string | undefined {
+    return StringFormatters.toStartCase(termType);
+    //todo see if can be used to convert to more readable form
+    }
 
 }

--- a/src/breeding-insight/utils/TraitStringFormatters.ts
+++ b/src/breeding-insight/utils/TraitStringFormatters.ts
@@ -18,6 +18,7 @@
 import {Scale, DataType} from "@/breeding-insight/model/Scale";
 import {StringFormatters} from "@/breeding-insight/utils/StringFormatters";
 import {TermType} from "@/breeding-insight/model/TraitSelector";
+import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
 
 export class TraitStringFormatters {
   
@@ -34,8 +35,7 @@ export class TraitStringFormatters {
   }
 
   static getTermTypeString(termType: TermType): string | undefined {
-    return StringFormatters.toStartCase(termType);
-    //todo see if can be used to convert to more readable form
+    return EnumUtils.enumKeyToValue(termType,TermType);
     }
 
 }

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -275,6 +275,7 @@ import {TermType, TraitField, TraitFilter} from "@/breeding-insight/model/TraitS
 import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
 import {BackendPaginationController} from "@/breeding-insight/model/view_models/BackendPaginationController";
 import {Category} from "@/breeding-insight/model/Category";
+import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
 
 @Component({
   mixins: [validationMixin],
@@ -623,7 +624,6 @@ export default class OntologyTable extends Vue {
   }
 
   prepareScaleCategoriesForSave(inputTrait: Trait){
-    //todo investigate means to convert term type
     let traitToSave = JSON.parse(JSON.stringify(inputTrait));
     if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
       traitToSave.scale.categories.forEach((category: Category) => {
@@ -631,6 +631,8 @@ export default class OntologyTable extends Vue {
         category.label = undefined;
       });
     }
+    //Translate TermType from user readable to backend storage format
+    traitToSave.termType = EnumUtils.enumValueToKey(inputTrait.termType, TermType);
     return traitToSave;
   }
 

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -123,6 +123,18 @@
           {{ data.observationVariableName }}
         </TableColumn>
         <TableColumn
+            name="termType"
+            v-bind:label="'Term Type'"
+            v-bind:sortField="ontologySort.field"
+            v-bind:sortFieldLabel="termTypeSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="ontologySort.order"
+            v-on:newSortColumn="$emit('newSortColumn', $event)"
+            v-on:toggleSortOrder="$emit('toggleSortOrder')"
+        >
+          {{ data.termType }}
+        </TableColumn>
+        <TableColumn
           name="trait"
           v-bind:label="'Trait'"
           v-bind:visible="!traitSidePanelState.collapseColumns"
@@ -314,6 +326,7 @@ export default class OntologyTable extends Vue {
   private scaleClassSortLabel: string = OntologySortField.ScaleClass;
   private unitSortLabel: string = OntologySortField.ScaleName;
   private entityAttributeSortLabel: string = OntologySortField.entityAttributeSortLabel;
+  private termTypeSortLabel: string = OntologySortField.TermType;
 
   // New trait form
   private newTraitActive: boolean = false;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -132,7 +132,7 @@
             v-on:newSortColumn="$emit('newSortColumn', $event)"
             v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
-          {{ data.termType }}
+          {{ TraitStringFormatters.getTermTypeString(data.termType) }}
         </TableColumn>
         <TableColumn
           name="trait"
@@ -250,7 +250,7 @@ import WarningModal from '@/components/modals/WarningModal.vue'
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate';
 import {Trait} from '@/breeding-insight/model/Trait'
-import {mapGetters, mapActions} from 'vuex'
+import {mapActions, mapGetters} from 'vuex'
 import {Program} from "@/breeding-insight/model/Program";
 import NewDataForm from '@/components/forms/NewDataForm.vue'
 import BasicInputField from "@/components/forms/BasicInputField.vue";
@@ -271,8 +271,8 @@ import {DataType, Scale} from "@/breeding-insight/model/Scale";
 import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableEventBus";
 import {DataFormEventBusHandler} from '@/components/forms/DataFormEventBusHandler';
 import {integer, maxLength} from "vuelidate/lib/validators";
-import {TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
-import {OntologySort, OntologySortField, SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
+import {TermType, TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
+import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
 import {BackendPaginationController} from "@/breeding-insight/model/view_models/BackendPaginationController";
 import {Category} from "@/breeding-insight/model/Category";
 
@@ -623,6 +623,7 @@ export default class OntologyTable extends Vue {
   }
 
   prepareScaleCategoriesForSave(inputTrait: Trait){
+    //todo investigate means to convert term type
     let traitToSave = JSON.parse(JSON.stringify(inputTrait));
     if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
       traitToSave.scale.categories.forEach((category: Category) => {

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -31,6 +31,16 @@
           <span class="is-size-7 mb-0">{{data.traitDescription}}</span>
         </div>
       </div>
+
+      <div v-if="data.termType" class="columns is-desktop pt-1 pl-3">
+        <div class="column is-one-third pt-0 pb-0 has-text-right-desktop">
+          <span class="has-text-weight-bold">Term Type</span>
+        </div>
+        <div class="column pt-0 pb-0">
+          <span class="is-size-7 mb-0">{{data.termType}}</span>
+        </div>
+      </div>
+
       <!-- just shows first abbreviation AKA main abbreviation and first synonym -->
       <template v-if="abbreviationsSynonymsString">
         <div class="columns is-desktop pt-1 pl-3">

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -37,7 +37,7 @@
           <span class="has-text-weight-bold">Term Type</span>
         </div>
         <div class="column pt-0 pb-0">
-          <span class="is-size-7 mb-0">{{data.termType}}</span>
+          <span class="is-size-7 mb-0">{{TraitStringFormatters.getTermTypeString(data.termType)}}</span>
         </div>
       </div>
 
@@ -262,6 +262,7 @@
   import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
   import { HelpCircleIcon } from 'vue-feather-icons'
   import ProgressBar from '@/components/forms/ProgressBar.vue'
+  import {TraitStringFormatters} from '@/breeding-insight/utils/TraitStringFormatters';
 
   @Component({
     components: {EditDataForm, SidePanel, BaseTraitForm, HelpCircleIcon, ProgressBar},
@@ -270,7 +271,7 @@
         'isSubscribed'
       ])
     },
-    data: () => ({DataType, MethodClass, Scale, Method, StringFormatters}),
+    data: () => ({DataType, MethodClass, Scale, Method, StringFormatters, TraitStringFormatters}),
     filters: {
       capitalize: function(value: string | undefined) : string | undefined {
         if (value === undefined) value = '';

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -14,6 +14,21 @@
       <label for="newTermActiveToggle" class="is-pulled-right">{{trait.active ? 'Active' : 'Archived'}}</label>
     </div>
 
+<!-- term type -->
+  <div class="column is-2">
+    <span class="is-pulled-right required new-term pb-2 pr-3">Term Type</span>
+  </div>
+  <div class="column new-term is-10">
+    <BasicSelectField
+        class="pb-2"
+        v-bind:selected-id="trait.termType"
+        v-bind:options="termTypes"
+        v-bind:field-name="'Term Type'"
+        v-bind:show-label="false"
+        v-on:input="setTermType($event)"
+    />
+  </div>
+
 <!--    term name-->
     <div class="column is-2">
       <span class="is-pulled-right required new-term pb-2 pr-3">Name</span>
@@ -265,22 +280,22 @@ import BasicInputField from "@/components/forms/BasicInputField.vue";
 import BasicSelectField from "@/components/forms/BasicSelectField.vue";
 import {Trait} from "@/breeding-insight/model/Trait";
 import {Method, MethodClass} from "@/breeding-insight/model/Method";
-import { Scale, DataType } from '@/breeding-insight/model/Scale';
-import { ProgramObservationLevel } from '@/breeding-insight/model/ProgramObservationLevel';
+import {DataType, Scale} from '@/breeding-insight/model/Scale';
+import {ProgramObservationLevel} from '@/breeding-insight/model/ProgramObservationLevel';
 import OrdinalTraitForm from "@/components/trait/forms/CategoryTraitForm.vue";
+import CategoryTraitForm from "@/components/trait/forms/CategoryTraitForm.vue";
 import TextTraitForm from "@/components/trait/forms/TextTraitForm.vue";
 import DateTraitForm from "@/components/trait/forms/DateTraitForm.vue";
 import DurationTraitForm from "@/components/trait/forms/DurationTraitForm.vue";
 import NumericalTraitForm from "@/components/trait/forms/NumericalTraitForm.vue";
-import CategoryTraitForm from "@/components/trait/forms/CategoryTraitForm.vue";
 import {TraitError} from "@/breeding-insight/model/errors/TraitError";
 import {ValidationError} from "@/breeding-insight/model/errors/ValidationError";
 import AutoCompleteField from "@/components/forms/AutoCompleteField.vue";
-import { StringFormatters } from '@/breeding-insight/utils/StringFormatters';
+import {StringFormatters} from '@/breeding-insight/utils/StringFormatters';
 import {Category} from "@/breeding-insight/model/Category";
-import {integer} from "vuelidate/lib/validators";
 import TagField from "@/components/forms/TagField.vue";
 import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
+import {TermType} from "@/breeding-insight/model/TraitSelector";
 
 @Component({
   components: {
@@ -323,6 +338,8 @@ export default class BaseTraitForm extends Vue {
   @Prop()
   tags?: string[];
 
+  private termTypes: TermType[] = Object.values(TermType);
+
   private methodHistory: {[key: string]: Method} = {};
   private scaleHistory: {[key: string]: Scale} = {};
   private lastCategoryType: string = '';
@@ -361,6 +378,9 @@ export default class BaseTraitForm extends Vue {
     }
     if ((this.trait.scale) && (this.trait.scale.categories)) {
       this.categories = this.trait.scale.categories;
+    }
+    if (!this.trait.termType) {
+      this.trait.termType = TermType.PHENOTYPE;
     }
   }
 
@@ -527,6 +547,10 @@ export default class BaseTraitForm extends Vue {
     } else {
       this.trait.synonyms[0] = value;
     }
+  }
+
+  setTermType(value: TermType) {
+    this.trait.termType = value;
   }
 
   setFullName(value: string) {

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -296,6 +296,7 @@ import {Category} from "@/breeding-insight/model/Category";
 import TagField from "@/components/forms/TagField.vue";
 import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
 import {TermType} from "@/breeding-insight/model/TraitSelector";
+import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
 
 @Component({
   components: {
@@ -379,8 +380,9 @@ export default class BaseTraitForm extends Vue {
     if ((this.trait.scale) && (this.trait.scale.categories)) {
       this.categories = this.trait.scale.categories;
     }
-    if (!this.trait.termType) {
-      this.trait.termType = TermType.PHENOTYPE;
+    //If termType pulled from backend (rather than the default for new terms), set to display friendly version
+    if (this.trait.termType != TermType.PHENOTYPE) {
+      this.trait.termType = EnumUtils.enumKeyToValue(this.trait.termType, TermType);
     }
   }
 


### PR DESCRIPTION
# Description
**Story:** [BI-1615 - Add termType to Trait DB Table](https://breedinginsight.atlassian.net/browse/BI-1615)

NOTE: This is forked from BI-1614, so changelist will include changes from there until BI-1614 is merged into develop

Small improvements off BI-1614 to ensure term types actually display
Created EnumUtils to handle methods for converting between enum key and value for ease of converting between the user-friendly display value and the backend storage value, and utilized them for term types

NOTE: Sorting could get weird if the alphabetical order differs between the user friendly display (ie Germplasm Passport) and backend storage value (GERM_PASSPORT). Not a problem here, but something to keep in mind. Also the difference between display and backend and the fact that there are a few distinct types means that if filtering was to be implemented for term types in the future it should probably be via drop down rather than text box.

# Dependencies
[bi-api/BI-1615](https://github.com/Breeding-Insight/bi-api/pull/231)

# Testing

- Open ontology table
- Check that Term Type column exists and is populated with values
- Check that Term Type column can be sorted
- Click new term, check that there is now a Term Type dropdown with "Phenotype" as default and a dropdown that lists "Phenotype", "Germplasm Attribute", and "Germplasm Passport"
- Select term type and save, check that new ontology term displayed in table with correct term type 
- Click 'Show Details' for one germplasm, check side panel display includes Term Type and Term Type is correct value
- Click edit term, check that Term Type dropdown value matches the Term Type in table
- Change Term Type and check that new value is saved and displayed correctly in table
- Check that Term Type column also exists in Archived Ontology table and not just Active

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3624530763)
