### PR TITLE
[BI-1613] - Add Term Type to Ontology Term Import

### DIFF
--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -88,6 +88,7 @@ export class Trait {
     }
     this.fullName = fullName;
     this.isDup = isDup;
+    this.termType = termType;
   }
 
   static assign(trait: Trait): Trait {

--- a/src/breeding-insight/model/Trait.ts
+++ b/src/breeding-insight/model/Trait.ts
@@ -36,7 +36,7 @@ export class Trait {
   tags?: string[] = [];
   fullName?: string;
   isDup?: boolean;
-  termType?: TermType;
+  termType: TermType =  TermType.PHENOTYPE; //Phenotype is default
 
   constructor(id?: string,
               traitName?: string,
@@ -88,7 +88,9 @@ export class Trait {
     }
     this.fullName = fullName;
     this.isDup = isDup;
-    this.termType = termType;
+    if (termType) {
+      this.termType = termType;
+    }
   }
 
   static assign(trait: Trait): Trait {

--- a/src/breeding-insight/model/TraitSelector.ts
+++ b/src/breeding-insight/model/TraitSelector.ts
@@ -23,9 +23,9 @@ export enum TraitField {
 }
 
 export enum TermType {
-  PHENOTYPE = 'PHENOTYPE',
-  GERM_ATTRIBUTE = 'GERM_ATTRIBUTE',
-  GERM_PASSPORT = 'GERM_PASSPORT'
+  PHENOTYPE = 'Phenotype',
+  GERM_ATTRIBUTE = 'Germplasm Attribute',
+  GERM_PASSPORT = 'Germplasm Passport'
 }
 
 export class TraitFilter {

--- a/src/breeding-insight/model/TraitSelector.ts
+++ b/src/breeding-insight/model/TraitSelector.ts
@@ -18,13 +18,14 @@ export enum TraitField {
   CREATED_BY_USER_ID = 'createdByUserId',
   CREATED_BY_USER_NAME = 'createdByUserName',
   UPDATED_BY_USER_ID = 'updatedByUserId',
-  UPDATED_BY_USER_NAME = 'updatedByUserName'
+  UPDATED_BY_USER_NAME = 'updatedByUserName',
+  TERM_TYPE = 'termType'
 }
 
 export enum TermType {
-  PHENOTYPE = 'Phenotype',
-  GERM_ATTRIBUTE = 'Germplasm Attribute',
-  GERM_PASSPORT = 'Germplasm Passport'
+  PHENOTYPE = 'PHENOTYPE',
+  GERM_ATTRIBUTE = 'GERM_ATTRIBUTE',
+  GERM_PASSPORT = 'GERM_PASSPORT'
 }
 
 export class TraitFilter {

--- a/src/breeding-insight/utils/EnumUtils.ts
+++ b/src/breeding-insight/utils/EnumUtils.ts
@@ -1,0 +1,28 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class EnumUtils {
+    static enumKeyToValue(enumKey: string, enumType: Object){
+        let index = Object.keys(enumType).indexOf(enumKey);
+        return Object.values(enumType)[index];
+    }
+
+    static enumValueToKey(enumVal: string, enumType: Object){
+        let index = Object.values(enumType).indexOf(enumVal);
+        return Object.keys(enumType)[index];
+    }
+}

--- a/src/breeding-insight/utils/TraitStringFormatters.ts
+++ b/src/breeding-insight/utils/TraitStringFormatters.ts
@@ -17,6 +17,7 @@
 
 import {Scale, DataType} from "@/breeding-insight/model/Scale";
 import {StringFormatters} from "@/breeding-insight/utils/StringFormatters";
+import {TermType} from "@/breeding-insight/model/TraitSelector";
 
 export class TraitStringFormatters {
   
@@ -31,5 +32,10 @@ export class TraitStringFormatters {
     }
     return undefined;
   }
+
+  static getTermTypeString(termType: TermType): string | undefined {
+    return StringFormatters.toStartCase(termType);
+    //todo see if can be used to convert to more readable form
+    }
 
 }

--- a/src/breeding-insight/utils/TraitStringFormatters.ts
+++ b/src/breeding-insight/utils/TraitStringFormatters.ts
@@ -18,6 +18,7 @@
 import {Scale, DataType} from "@/breeding-insight/model/Scale";
 import {StringFormatters} from "@/breeding-insight/utils/StringFormatters";
 import {TermType} from "@/breeding-insight/model/TraitSelector";
+import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
 
 export class TraitStringFormatters {
   
@@ -34,8 +35,7 @@ export class TraitStringFormatters {
   }
 
   static getTermTypeString(termType: TermType): string | undefined {
-    return StringFormatters.toStartCase(termType);
-    //todo see if can be used to convert to more readable form
+    return EnumUtils.enumKeyToValue(termType,TermType);
     }
 
 }

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -275,6 +275,7 @@ import {TermType, TraitField, TraitFilter} from "@/breeding-insight/model/TraitS
 import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
 import {BackendPaginationController} from "@/breeding-insight/model/view_models/BackendPaginationController";
 import {Category} from "@/breeding-insight/model/Category";
+import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
 
 @Component({
   mixins: [validationMixin],
@@ -623,7 +624,6 @@ export default class OntologyTable extends Vue {
   }
 
   prepareScaleCategoriesForSave(inputTrait: Trait){
-    //todo investigate means to convert term type
     let traitToSave = JSON.parse(JSON.stringify(inputTrait));
     if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
       traitToSave.scale.categories.forEach((category: Category) => {
@@ -631,6 +631,8 @@ export default class OntologyTable extends Vue {
         category.label = undefined;
       });
     }
+    //Translate TermType from user readable to backend storage format
+    traitToSave.termType = EnumUtils.enumValueToKey(inputTrait.termType, TermType);
     return traitToSave;
   }
 

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -132,7 +132,7 @@
             v-on:newSortColumn="$emit('newSortColumn', $event)"
             v-on:toggleSortOrder="$emit('toggleSortOrder')"
         >
-          {{ data.termType }}
+          {{ TraitStringFormatters.getTermTypeString(data.termType) }}
         </TableColumn>
         <TableColumn
           name="trait"
@@ -250,7 +250,7 @@ import WarningModal from '@/components/modals/WarningModal.vue'
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate';
 import {Trait} from '@/breeding-insight/model/Trait'
-import {mapGetters, mapActions} from 'vuex'
+import {mapActions, mapGetters} from 'vuex'
 import {Program} from "@/breeding-insight/model/Program";
 import NewDataForm from '@/components/forms/NewDataForm.vue'
 import BasicInputField from "@/components/forms/BasicInputField.vue";
@@ -271,8 +271,8 @@ import {DataType, Scale} from "@/breeding-insight/model/Scale";
 import {SidePanelTableEventBusHandler} from "@/components/tables/SidePanelTableEventBus";
 import {DataFormEventBusHandler} from '@/components/forms/DataFormEventBusHandler';
 import {integer, maxLength} from "vuelidate/lib/validators";
-import {TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
-import {OntologySort, OntologySortField, SortOrder, TraitSortField} from "@/breeding-insight/model/Sort";
+import {TermType, TraitField, TraitFilter} from "@/breeding-insight/model/TraitSelector";
+import {OntologySort, OntologySortField} from "@/breeding-insight/model/Sort";
 import {BackendPaginationController} from "@/breeding-insight/model/view_models/BackendPaginationController";
 import {Category} from "@/breeding-insight/model/Category";
 
@@ -623,6 +623,7 @@ export default class OntologyTable extends Vue {
   }
 
   prepareScaleCategoriesForSave(inputTrait: Trait){
+    //todo investigate means to convert term type
     let traitToSave = JSON.parse(JSON.stringify(inputTrait));
     if ((traitToSave) && (traitToSave.scale) && (traitToSave.scale.dataType) && (Scale.dataTypeEquals(traitToSave.scale.dataType, DataType.Nominal)) && (traitToSave.scale.categories)) {
       traitToSave.scale.categories.forEach((category: Category) => {

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -37,7 +37,7 @@
           <span class="has-text-weight-bold">Term Type</span>
         </div>
         <div class="column pt-0 pb-0">
-          <span class="is-size-7 mb-0">{{data.termType}}</span>
+          <span class="is-size-7 mb-0">{{TraitStringFormatters.getTermTypeString(data.termType)}}</span>
         </div>
       </div>
 
@@ -262,6 +262,7 @@
   import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
   import { HelpCircleIcon } from 'vue-feather-icons'
   import ProgressBar from '@/components/forms/ProgressBar.vue'
+  import {TraitStringFormatters} from '@/breeding-insight/utils/TraitStringFormatters';
 
   @Component({
     components: {EditDataForm, SidePanel, BaseTraitForm, HelpCircleIcon, ProgressBar},
@@ -270,7 +271,7 @@
         'isSubscribed'
       ])
     },
-    data: () => ({DataType, MethodClass, Scale, Method, StringFormatters}),
+    data: () => ({DataType, MethodClass, Scale, Method, StringFormatters, TraitStringFormatters}),
     filters: {
       capitalize: function(value: string | undefined) : string | undefined {
         if (value === undefined) value = '';

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -55,6 +55,19 @@
           {{ data.observationVariableName }}
         </TableColumn>
         <TableColumn
+            name="termType"
+            v-bind:label="'Term Type'"
+            v-bind:visible="!collapseColumns"
+            v-bind:sortField="importPreviewOntologySort.field"
+            v-bind:sortFieldLabel="termTypeSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="importPreviewOntologySort.order"
+            v-on:newSortColumn="newSortColumn"
+            v-on:toggleSortOrder="toggleSortOrder"
+        >
+          {{ TraitStringFormatters.getTermTypeString(data.termType) }}
+        </TableColumn>
+        <TableColumn
             name="trait"
             v-bind:label="'Trait'"
             v-bind:visible="!collapseColumns"
@@ -220,6 +233,7 @@ export default class TraitsImportTable extends Vue {
   private scaleClassSortLabel: string = OntologySortField.ScaleClass;
   private unitSortLabel: string = OntologySortField.ScaleName;
   private entityAttributeSortLabel: string = OntologySortField.entityAttributeSortLabel;
+  private termTypeSortLabel: string = OntologySortField.TermType;
 
   mounted() {
     this.updatePagination();

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -20,6 +20,7 @@
   </div>
   <div class="column new-term is-10">
     <BasicSelectField
+        id="termTypeField"
         class="pb-2"
         v-bind:selected-id="trait.termType"
         v-bind:options="termTypes"
@@ -165,6 +166,7 @@
     </div>
     <div class="column new-term is-10">
       <BasicSelectField
+          id="methodClass"
           class="pb-2"
           v-bind:selected-id="trait.method.methodClass"
           v-bind:options="methodOptions"
@@ -186,6 +188,7 @@
     </div>
     <div class="column new-term is-10">
       <BasicSelectField
+          id="scaleClass"
           v-bind:selected-id="StringFormatters.toStartCase(trait.scale.dataType)"
           v-bind:options="getScaleOptions()"
           v-bind:field-name="'Scale Class'"

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -296,6 +296,7 @@ import {Category} from "@/breeding-insight/model/Category";
 import TagField from "@/components/forms/TagField.vue";
 import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
 import {TermType} from "@/breeding-insight/model/TraitSelector";
+import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
 
 @Component({
   components: {
@@ -379,8 +380,9 @@ export default class BaseTraitForm extends Vue {
     if ((this.trait.scale) && (this.trait.scale.categories)) {
       this.categories = this.trait.scale.categories;
     }
-    if (!this.trait.termType) {
-      this.trait.termType = TermType.PHENOTYPE;
+    //If termType pulled from backend (rather than the default for new terms), set to display friendly version
+    if (this.trait.termType != TermType.PHENOTYPE) {
+      this.trait.termType = EnumUtils.enumKeyToValue(this.trait.termType, TermType);
     }
   }
 

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -178,7 +178,7 @@ export default class TraitsImport extends ProgramsBase {
   private showAbortModal = false;
 
   private yesAbortId: string = "traitsimport-yes-abort";
-  private templateUrl: string = "https://cornell.box.com/shared/static/8mp6ex7c07mregc84pcb81u3fcpjje69.xls";
+  private templateUrl: string = "https://cornell.box.com/shared/static/7vtd4vkzc2efrdlion74miql9surugqd.xls";
 
   private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
 


### PR DESCRIPTION
# Description
**Story:** [BI-1613 - Add Term Type to Ontology Term Import](https://breedinginsight.atlassian.net/browse/BI-1613)

Updated Ontology Import Preview table to include Term Type column
Updated Ontology Import Template button to download updated template version

Note: This is branched off of BI-1615, so until that is merged the changelist will include changes from that branch

# Dependencies
[bi-api/BI-1613](https://github.com/Breeding-Insight/bi-api/pull/233)

# Testing
- Open Ontology Batch Import
- Click download template - ensure template downloaded is v13 and has term type column
- Create ontology import using download template with blank and filled values for term type with different casing
- Upload created file
- Check import preview table displays correct term types for user inputted rows
- Check import preview table displays "Phenotype" for rows where the user did not input a term type
- Confirm import
- Check that import works successfully and new ontology terms are displayed in table with correct term types

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/3662068500)
