### PR TITLE
BI-1651 - Allow programs to choose/create breeding methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "bi-web",
-  "version": "v0.8.0+441",
+  "version": "v0.8.0+469",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "bi-web",
-      "version": "v0.8.0+441",
+      "version": "v0.8.0+469",
       "hasInstallScript": true,
       "dependencies": {
         "@casl/ability": "~4.0.0",
@@ -65,7 +64,7 @@
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^24.9.0",
         "babel-preset-env": "^1.7.0",
-        "buefy": "^0.9.8",
+        "buefy": "^0.9.22",
         "bulma": "^0.9.1",
         "bulma-divider": "^0.2.0",
         "bulma-switch": "^2.0.0",
@@ -5950,12 +5949,12 @@
       }
     },
     "node_modules/buefy": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.8.tgz",
-      "integrity": "sha512-VBGAD6WtmgpPdiRnBXaTleS3ifpNu9rbInAr54YL8KJw1RhCb8JtGYYYVRjllnDQmN0jQjC5lYoPR9KpfTe+Cw==",
+      "version": "0.9.22",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.22.tgz",
+      "integrity": "sha512-rA9Bf7+2lZupL1PlQU60o7cc0Og4MRz9it5LZlKOIwPENM1uEOjH48EFnNFniLyxIcz6vln0EicS96GsVCFx1Q==",
       "dev": true,
       "dependencies": {
-        "bulma": "0.9.3"
+        "bulma": "0.9.4"
       },
       "engines": {
         "node": ">= 4.0.0",
@@ -6025,9 +6024,9 @@
       "dev": true
     },
     "node_modules/bulma": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.3.tgz",
-      "integrity": "sha512-0d7GNW1PY4ud8TWxdNcP6Cc8Bu7MxcntD/RRLGWuiw/s0a9P+XlH/6QoOIrmbj6o8WWJzJYhytiu9nFjTszk1g==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.4.tgz",
+      "integrity": "sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ==",
       "dev": true
     },
     "node_modules/bulma-divider": {
@@ -26913,7 +26912,6 @@
       "dev": true,
       "requires": {
         "@ant-design-vue/babel-plugin-jsx": "^1.0.0-0",
-        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -26925,7 +26923,6 @@
         "@babel/runtime": "^7.11.0",
         "@vue/babel-preset-jsx": "^1.1.2",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }
@@ -29364,12 +29361,12 @@
       }
     },
     "buefy": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.8.tgz",
-      "integrity": "sha512-VBGAD6WtmgpPdiRnBXaTleS3ifpNu9rbInAr54YL8KJw1RhCb8JtGYYYVRjllnDQmN0jQjC5lYoPR9KpfTe+Cw==",
+      "version": "0.9.22",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.22.tgz",
+      "integrity": "sha512-rA9Bf7+2lZupL1PlQU60o7cc0Og4MRz9it5LZlKOIwPENM1uEOjH48EFnNFniLyxIcz6vln0EicS96GsVCFx1Q==",
       "dev": true,
       "requires": {
-        "bulma": "0.9.3"
+        "bulma": "0.9.4"
       }
     },
     "buffer": {
@@ -29426,9 +29423,9 @@
       "dev": true
     },
     "bulma": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.3.tgz",
-      "integrity": "sha512-0d7GNW1PY4ud8TWxdNcP6Cc8Bu7MxcntD/RRLGWuiw/s0a9P+XlH/6QoOIrmbj6o8WWJzJYhytiu9nFjTszk1g==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.4.tgz",
+      "integrity": "sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ==",
       "dev": true
     },
     "bulma-divider": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.9.0",
     "babel-preset-env": "^1.7.0",
-    "buefy": "^0.9.8",
+    "buefy": "^0.9.22",
     "bulma": "^0.9.1",
     "bulma-divider": "^0.2.0",
     "bulma-switch": "^2.0.0",

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -222,6 +222,12 @@ img {
   }
 }
 
+.program-management {
+  .tab-content {
+    margin-left: 1em;
+  }
+}
+
 #program-menu {
   .dropdown-content {
     max-height: 50vh;
@@ -267,6 +273,18 @@ nav.tabs li.is-active {
   }
 }
 
+.expandable-card {
+  .is-button-transparent {
+    background: transparent;
+    border: none;
+  }
+
+  header {
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}
 .table.is-narrow {
   border-collapse: collapse;
 }
@@ -798,4 +816,22 @@ tr:nth-child(odd) td.db-filled {
   @extend .is-11;
   @extend .pl-1;
   @extend .py-1;
+}
+
+.breeding-methods {
+  .enable-system-methods {
+    .modal-card {
+      width: 90%;
+    }
+  }
+}
+
+.content {
+  .pagination-list {
+    margin-top: 0;
+
+    li + li {
+      margin-top: 0;
+    }
+  }
 }

--- a/src/breeding-insight/dao/BreedingMethodDAO.ts
+++ b/src/breeding-insight/dao/BreedingMethodDAO.ts
@@ -68,4 +68,8 @@ export class BreedingMethodDAO {
 
     return new BiResponse(data);
   }
+
+  static delete (programId: string, breedingMethodId: string) {
+    return api.call({ url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/breeding-methods/${breedingMethodId}`, method: 'delete'});
+  }
 }

--- a/src/breeding-insight/dao/BreedingMethodDAO.ts
+++ b/src/breeding-insight/dao/BreedingMethodDAO.ts
@@ -21,10 +21,12 @@ import { BreedingMethod } from '@/breeding-insight/model/BreedingMethod';
 
 export class BreedingMethodDAO {
 
-  static async getProgramBreedingMethods(programId: string) {
+  static async getProgramBreedingMethods(programId: string, inUse?: boolean) {
+    const params = inUse !== undefined ? {'inUse': inUse} : undefined;
     const {data} = await api.call({
       url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/breeding-methods`,
-      method: 'get'
+      method: 'get',
+      params: params
     }) as Response;
 
     return new BiResponse(data);

--- a/src/breeding-insight/dao/BreedingMethodDAO.ts
+++ b/src/breeding-insight/dao/BreedingMethodDAO.ts
@@ -1,0 +1,69 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as api from '@/util/api';
+import { BiResponse, Response } from '@/breeding-insight/model/BiResponse';
+import { BreedingMethod } from '@/breeding-insight/model/BreedingMethod';
+
+export class BreedingMethodDAO {
+
+  static async getProgramBreedingMethods(programId: string) {
+    const {data} = await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/breeding-methods`,
+      method: 'get'
+    }) as Response;
+
+    return new BiResponse(data);
+  }
+
+  static async getSystemBreedingMethods() {
+    const {data} = await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/breeding-methods`,
+      method: 'get'
+    }) as Response;
+
+    return new BiResponse(data);
+  }
+
+  static async enableSystemBreedingMethods(programId: string, ids: string[]) {
+    await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/breeding-methods/enable`,
+      method: 'put',
+      data: ids
+    });
+  }
+
+  static async createProgramBreedingMethod(programId: string, method: BreedingMethod) {
+    const {data} = await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/breeding-methods`,
+      method: 'post',
+      data: method
+    }) as Response;
+
+    return new BiResponse(data);
+  }
+
+  static async updateProgramBreedingMethod(programId: string, method: BreedingMethod) {
+    const {data} = await api.call({
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/breeding-methods/${method.id}`,
+      method: 'put',
+      data: method
+    }) as Response;
+
+    return new BiResponse(data);
+  }
+}

--- a/src/breeding-insight/model/BreedingMethod.ts
+++ b/src/breeding-insight/model/BreedingMethod.ts
@@ -1,0 +1,36 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class BreedingMethod {
+  id?: string;
+  name?: string;
+  abbreviation?: string;
+  description?: string;
+  category?: string;
+  geneticDiversity?: string;
+  programId?: string;
+
+  constructor({id, name, abbreviation, description, category, geneticDiversity, programId}: BreedingMethod) {
+    this.id = id;
+    this.name = name;
+    this.abbreviation = abbreviation;
+    this.description = description;
+    this.category = category;
+    this.geneticDiversity = geneticDiversity;
+    this.programId = programId;
+  }
+}

--- a/src/breeding-insight/service/BreedingMethodService.ts
+++ b/src/breeding-insight/service/BreedingMethodService.ts
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-import { BiResponse, Metadata } from '@/breeding-insight/model/BiResponse';
+import { BiResponse } from '@/breeding-insight/model/BiResponse';
 import { BreedingMethod } from '@/breeding-insight/model/BreedingMethod';
 import { BreedingMethodDAO } from '@/breeding-insight/dao/BreedingMethodDAO';
-import { ValidationErrorService } from '@/breeding-insight/service/ValidationErrorService';
 
 export class BreedingMethodService {
   private static getBreedingMethodUnknown: string = 'An unknown error occurred while retrieving breeding methods';
@@ -133,5 +132,19 @@ export class BreedingMethodService {
     }
 
     throw this.unableToUpdateMethod;
+  }
+
+  static delete (programId: string, breedingMethodId: string) {
+    return new Promise<any>(((resolve, reject) => {
+
+      if (programId && breedingMethodId){
+        return BreedingMethodDAO.delete(programId, breedingMethodId)
+          .then(() => resolve())
+          .catch((error) => reject(error));
+      } else {
+        reject();
+      }
+
+    }));
   }
 }

--- a/src/breeding-insight/service/BreedingMethodService.ts
+++ b/src/breeding-insight/service/BreedingMethodService.ts
@@ -29,13 +29,13 @@ export class BreedingMethodService {
   private static errorUpdatingMethod: string = 'Error updating program breeding method';
   private static unableToUpdateMethod: string = 'Unable to update program breeding method';
 
-  static async getProgramBreedingMethods(programId: string): Promise<BreedingMethod[]> {
+  static async getProgramBreedingMethods(programId: string, inUse?: boolean): Promise<BreedingMethod[]> {
     if (!programId) {
       throw 'Program ID not provided';
     }
 
     try {
-      const response: BiResponse = await BreedingMethodDAO.getProgramBreedingMethods(programId);
+      const response: BiResponse = await BreedingMethodDAO.getProgramBreedingMethods(programId, inUse);
       const data: any = response.result.data;
       if(data) {
         return data.map((response: BreedingMethod) => new BreedingMethod(response));

--- a/src/breeding-insight/service/BreedingMethodService.ts
+++ b/src/breeding-insight/service/BreedingMethodService.ts
@@ -1,0 +1,137 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BiResponse, Metadata } from '@/breeding-insight/model/BiResponse';
+import { BreedingMethod } from '@/breeding-insight/model/BreedingMethod';
+import { BreedingMethodDAO } from '@/breeding-insight/dao/BreedingMethodDAO';
+import { ValidationErrorService } from '@/breeding-insight/service/ValidationErrorService';
+
+export class BreedingMethodService {
+  private static getBreedingMethodUnknown: string = 'An unknown error occurred while retrieving breeding methods';
+  private static errorEnablingMethods: string = 'Error enabling system breeding methods';
+  private static unableToEnableMethods: string = 'Unable to enable system breeding methods';
+  private static errorCreatingMethod: string = 'Error creating program breeding method';
+  private static unableToCreateMethod: string = 'Unable to create program breeding method';
+  private static errorUpdatingMethod: string = 'Error updating program breeding method';
+  private static unableToUpdateMethod: string = 'Unable to update program breeding method';
+
+  static async getProgramBreedingMethods(programId: string): Promise<BreedingMethod[]> {
+    if (!programId) {
+      throw 'Program ID not provided';
+    }
+
+    try {
+      const response: BiResponse = await BreedingMethodDAO.getProgramBreedingMethods(programId);
+      const data: any = response.result.data;
+      if(data) {
+        return data.map((response: BreedingMethod) => new BreedingMethod(response));
+      } else {
+        return [];
+      }
+    } catch (e) {
+      if (e.response && e.response.statusText) {
+        e.errorMessage = e.response.statusText;
+      } else {
+        e.errorMessage = this.getBreedingMethodUnknown;
+      }
+      throw e;
+    }
+  }
+
+  static async getSystemBreedingMethods(): Promise<BreedingMethod[]> {
+    try {
+      const response: BiResponse = await BreedingMethodDAO.getSystemBreedingMethods();
+      const data: any = response.result.data;
+      if(data) {
+        return data.map((response: BreedingMethod) => new BreedingMethod(response));
+      } else {
+        return [];
+      }
+    } catch (e) {
+      if (e.response && e.response.statusText) {
+        e.errorMessage = e.response.statusText;
+      } else {
+        e.errorMessage = this.getBreedingMethodUnknown;
+      }
+      throw e;
+    }
+  }
+
+  static async enableSystemMethods(programId: string, systemMethods: BreedingMethod[]): Promise<any> {
+    if (programId && systemMethods) {
+      // Check that they all have a breeding method id
+      if (systemMethods.filter(method => method.id).length !== systemMethods.length) {
+        throw this.unableToEnableMethods;
+      }
+
+      try {
+        let ids: string[] = systemMethods.map(value => value.id!);
+        await BreedingMethodDAO.enableSystemBreedingMethods(programId, ids);
+      } catch (e) {
+        if (e.response && e.response.statusText) {
+          e.errorMessage = e.response.statusText;
+        } else {
+          e.errorMessage = this.errorEnablingMethods;
+        }
+        throw e;
+      }
+    }
+    else throw this.unableToEnableMethods;
+  }
+
+  static async createProgramBreedingMethod(programId: string, method: BreedingMethod): Promise<BreedingMethod> {
+    if (programId && method) {
+      try {
+        const response: BiResponse = await BreedingMethodDAO.createProgramBreedingMethod(programId, method);
+        const data: any = response.result;
+        if(data) {
+          return new BreedingMethod(data);
+        }
+      } catch (e) {
+        if (e.response && e.response.statusText) {
+          e.errorMessage = e.response.statusText;
+        } else {
+          e.errorMessage = this.errorCreatingMethod;
+        }
+        throw e;
+      }
+    }
+
+    throw this.unableToCreateMethod;
+  }
+
+  static async updateProgramBreedingMethod(programId: string, method: BreedingMethod): Promise<BreedingMethod> {
+    if (programId && method) {
+      try {
+        const response: BiResponse = await BreedingMethodDAO.updateProgramBreedingMethod(programId, method);
+        const data: any = response.result;
+        if(data) {
+          return new BreedingMethod(data);
+        }
+      } catch (e) {
+        if (e.response && e.response.statusText) {
+          e.errorMessage = e.response.statusText;
+        } else {
+          e.errorMessage = this.errorUpdatingMethod;
+        }
+        throw e;
+      }
+    }
+
+    throw this.unableToUpdateMethod;
+  }
+}

--- a/src/components/layouts/ExpandableCard.vue
+++ b/src/components/layouts/ExpandableCard.vue
@@ -1,0 +1,62 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div class="card mb-5 expandable-card">
+    <header class="card-header" v-on:click="expanded = !expanded">
+      <h2 class="card-header-title mb-0">
+        {{title}}
+      </h2>
+      <button class="card-header-icon is-button-transparent is-pulled-right" aria-label="expand" v-on:click="expanded = !expanded">
+          <span class="icon">
+            <PlusIcon v-if="!expanded" size="1x" aria-hidden="true"></PlusIcon>
+            <MinusIcon v-if="expanded" size="1x" aria-hidden="true"></MinusIcon>
+          </span>
+      </button>
+    </header>
+    <div class="card-content" v-if="expanded">
+      <div class="content">
+        <slot></slot>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+
+  import {Component, Prop, Vue} from 'vue-property-decorator'
+  import {PlusIcon, MinusIcon} from 'vue-feather-icons';
+
+  @Component({
+    components: {PlusIcon, MinusIcon}
+  })
+  export default class ExpandableCard extends Vue {
+    @Prop()
+    title!: string;
+    @Prop({default: true})
+    show?: boolean;
+
+    private expanded = true;
+
+    mounted() {
+      if(this.show !== undefined) {
+        this.expanded = this.show;
+      }
+    }
+  }
+
+</script>

--- a/src/components/modals/BaseModal.vue
+++ b/src/components/modals/BaseModal.vue
@@ -26,7 +26,7 @@
   >
     <div
         class="modal"
-        v-bind:class="{ 'is-active': active }"
+        v-bind:class="[{ 'is-active': active }, modalClass]"
         tabindex="-1"
     >
         <div class="modal-background" v-on:click="() => $refs.focusTrap.deactivate()"/>
@@ -45,7 +45,9 @@
           >
             <slot></slot>
           </section>
-          <footer class="modal-card-foot"/>
+          <footer class="modal-card-foot">
+            <slot name="footer"></slot>
+          </footer>
         </div>
       </div>
     </focus-trap>
@@ -64,6 +66,8 @@
     active!: boolean;
     @Prop()
     bodyClass!: Object;
+    @Prop()
+    modalClass!: Object;
 
     mounted() {
     }

--- a/src/components/modals/GenericModal.vue
+++ b/src/components/modals/GenericModal.vue
@@ -19,11 +19,15 @@
   <BaseModal
       v-bind:active.sync="active"
       v-on:deactivate="$emit('deactivate')"
+      v-bind="$attrs"
   >
     <h3 class="is-5 title has-text-info">
       {{msgTitle}}
     </h3>
     <slot></slot>
+    <template v-slot:footer>
+      <slot name="footer"></slot>
+    </template>
   </BaseModal>
 </template>
 
@@ -38,8 +42,6 @@ import { AlertCircleIcon } from 'vue-feather-icons'
 export default class GenericModal extends Vue {
   @Prop()
   active!: boolean;
-  @Prop()
-  bodyClass!: Object;
   @Prop()
   msgTitle!: string;
 }

--- a/src/components/program/SharedOntologyConfiguration.vue
+++ b/src/components/program/SharedOntologyConfiguration.vue
@@ -170,9 +170,9 @@ export default class SharedOntologyConfiguration extends ProgramsBase {
   private editableMatchedPrograms: SharedOntology[] = [];
   private subscribedOntology?: SubscribedOntology;
 
-  async mounted() {
+  mounted() {
     // Get shared ontologies
-    await this.getSharedOntologyData();
+    this.getSharedOntologyData();
   }
 
   @Watch('subscriptionChange', {immediate: false})

--- a/src/components/program/SubscribeOntologyConfiguration.vue
+++ b/src/components/program/SubscribeOntologyConfiguration.vue
@@ -135,7 +135,9 @@ export default class SubscribeOntologyConfiguration extends ProgramsBase {
   async subscribeOntology() {
 
     try {
-      if (!this.selectedOntology.id) throw 'Please select an ontology to subscibe to.';
+      if (!this.selectedOntology.id) {
+        throw 'Please select an ontology to subscribe to.';
+      }
       // Loading wheel show
       this.subscribeProcessing = true;
       await SharedOntologyService.subscribeOntology(this.activeProgram!.id!, this.selectedOntology.id);

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -46,7 +46,7 @@
     >
 
       <slot></slot>
-      <b-table-column v-if="editable || details || archivable" v-slot="props" cell-class="has-text-right is-narrow" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column v-if="editable || details || archivable" v-slot="props" cell-class="has-text-left is-narrow" :th-attrs="(column) => ({scope:'col'})">
         <a
             v-if="isRowEditable(props.row) || details"
             data-testid="edit"
@@ -65,12 +65,12 @@
           </span>
         </a>
         <a
-            v-if="archivable"
+            v-if="isRowArchivable(props.row)"
             v-on:click="$emit('remove', props.row.data)"
             v-on:keypress.enter.space="$emit('remove', props.row.data)"
             tabindex="0"
         >
-          Deactivate
+          {{ deactivateLinkText }}
         </a>
       </b-table-column>
 
@@ -131,6 +131,8 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   @Prop()
   rowEditable!: Function;
   @Prop()
+  rowArchivable!: Function;
+  @Prop()
   archivable!: boolean;
   @Prop()
   pagination!: Pagination;
@@ -146,6 +148,8 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   details!: boolean;
   @Prop()
   searchDebounce!: number;
+  @Prop({default: "Deactivate"})
+  deactivateLinkText?: string;
 
   private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
   private openDetail: Array<TableRow<any>> = new Array<TableRow<any>>();
@@ -235,6 +239,10 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
 
   isRowEditable(row: any) {
     return ((typeof this.rowEditable === "function") ? this.rowEditable(row) : true) && this.editable;
+  }
+
+  isRowArchivable(row: any) {
+    return ((typeof this.rowArchivable === "function") ? this.rowArchivable(row) : true) && this.archivable;
   }
 }
 </script>

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -41,7 +41,6 @@
         v-on="$listeners"
         v-bind:loading="loading"
         :row-class="calculateRowClass"
-        backend-filtering
         v-bind:debounce-search="searchDebounce"
         v-on:filters-change="cloneFilters"
     >
@@ -49,19 +48,19 @@
       <slot></slot>
       <b-table-column v-if="editable || details || archivable" v-slot="props" cell-class="has-text-right is-narrow" :th-attrs="(column) => ({scope:'col'})">
         <a
-            v-if="editable || details"
+            v-if="isRowEditable(props.row) || details"
             data-testid="edit"
             v-on:click="props.toggleDetails(props.row)"
             v-on:keypress.enter.space="props.toggleDetails(props.row)"
             tabindex="0"
         >
-          <span v-if="editable">Edit</span>
+          <span v-if="isRowEditable(props.row)">Edit</span>
           <span v-if="details">Details</span>
 
-          <span v-if="(editable || details) && !isVisibleDetailRow(props.row)" class="icon is-small margin-right-2 has-vertical-align-middle">
+          <span v-if="(isRowEditable(props.row) || details) && !isVisibleDetailRow(props.row)" class="icon is-small margin-right-2 has-vertical-align-middle">
             <ChevronRightIcon size="1x" aria-hidden="true"></ChevronRightIcon>
           </span>
-            <span v-if="(editable || details) && isVisibleDetailRow(props.row)" class="icon is-small margin-right-2 has-vertical-align-middle">
+            <span v-if="(isRowEditable(props.row) || details) && isVisibleDetailRow(props.row)" class="icon is-small margin-right-2 has-vertical-align-middle">
             <ChevronDownIcon size="1x" aria-hidden="true"></ChevronDownIcon>
           </span>
         </a>
@@ -129,6 +128,8 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   records!: Array<any>;
   @Prop()
   editable!: boolean;
+  @Prop()
+  rowEditable!: Function;
   @Prop()
   archivable!: boolean;
   @Prop()
@@ -230,6 +231,10 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   // A patch so if we're listening the filters, we can still debounce
   cloneFilters(event: any) {
     this.$emit('search', JSON.parse(JSON.stringify(event)));
+  }
+
+  isRowEditable(row: any) {
+    return ((typeof this.rowEditable === "function") ? this.rowEditable(row) : true) && this.editable;
   }
 }
 </script>

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -38,6 +38,8 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('archive', 'Trait');
     can('create', 'Import');
     can('access', 'ProgramConfiguration');
+    can('create', 'ProgramConfiguration');
+    can('update', 'ProgramConfiguration');
   },
   admin(user, { can }) {
     can('create', 'ProgramUser');

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -63,8 +63,9 @@ import PageNotFound from "@/views/PageNotFound.vue";
 import Germplasm from "@/views/germplasm/Germplasm.vue";
 import GermplasmByList from "@/views/germplasm/GermplasmByList.vue";
 import GermplasmLists from "@/views/germplasm/GermplasmLists.vue";
+import BreedingMethods from "@/views/germplasm/BreedingMethods.vue";
 import GermplasmDetails from "@/views/germplasm/GermplasmDetails.vue";
-import ProgramConfiguration from "@/views/program/ProgramConfiguration.vue";
+import OntologySharing from "@/views/program/OntologySharing.vue";
 import JobManagement from '@/views/program/JobManagement.vue';
 import GermplasmPedigreesView from "@/components/germplasm/GermplasmPedigreesView.vue";
 import ImportExperiment from "@/views/import/ImportExperiment.vue";
@@ -190,10 +191,18 @@ const routes = [
       layout: layouts.userSideBar
     },
     component: ProgramManagement,
-    redirect: {name: 'program-locations'},
+    redirect: {name: 'program-users'},
     beforeEnter: processProgramNavigation,
     children: [
       {
+        path: 'users',
+        name: 'program-users',
+        meta: {
+          title: 'Program User Management',
+          layout: layouts.userSideBar
+        },
+        component: ProgramUserManagement
+      },{
         path: 'locations',
         name: 'program-locations',
         meta: {
@@ -203,22 +212,22 @@ const routes = [
         component: ProgramLocationsManagement
       },
       {
-        path: 'users',
-        name: 'program-users',
+        path: 'breeding-methods',
+        name: 'breeding-methods',
         meta: {
-          title: 'Program User Management',
+          title: 'Breeding Methods',
           layout: layouts.userSideBar
         },
-        component: ProgramUserManagement
+        component: BreedingMethods
       },
       {
-        path: 'configure',
-        name: 'program-configuration',
+        path: 'ontology-sharing',
+        name: 'ontology-sharing',
         meta: {
-          title: 'Program Configuration',
+          title: 'Ontology Sharing',
           layout: layouts.userSideBar
         },
-        component: ProgramConfiguration
+        component: OntologySharing
       }
     ]
   },

--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -52,7 +52,7 @@
             class="button is-primary"
             v-on:click="openModal"
         >
-          Activate System Methods
+          Choose Predefined Methods
         </button>
         <button
             v-if="$ability.can('create', 'ProgramConfiguration')"
@@ -268,7 +268,7 @@
     </ExpandableTable>
     <GenericModal
         v-bind:active.sync="showEnableSystemMethods"
-        v-bind:msg-title="'Enable/Disable System Breeding Methods'"
+        v-bind:msg-title="'Enable/Disable Predefined Breeding Methods'"
         v-on:deactivate="showEnableSystemMethods = false"
         v-bind:modalClass="'enable-system-methods'"
     >

--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -1,0 +1,419 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information
+  - regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <div class="breeding-methods">
+    <div class="columns">
+      <div class="column is-whole has-text-right buttons">
+        <button
+            v-if="$ability.can('create', 'ProgramConfiguration')"
+            class="button is-primary"
+            v-on:click="openModal"
+        >
+          Activate System Methods
+        </button>
+        <button
+            v-if="$ability.can('create', 'ProgramConfiguration')"
+            class="button is-primary"
+            v-on:click="showNewMethod"
+        >
+          Create Breeding Method
+        </button>
+      </div>
+    </div>
+
+    <NewDataForm
+        v-if="newMethodActive"
+        v-bind:row-validations="newMethodValidations"
+        v-bind:new-record.sync="newMethod"
+        v-bind:data-form-state="newMethodFormState"
+        v-on:submit="saveMethod"
+        v-on:cancel="cancelNewMethod"
+        v-on:show-error-notification="$emit('show-error-notification', $event)"
+    >
+      <template v-slot="validations">
+        <div class="columns">
+          <div class="column is-one-fourth">
+            <BasicInputField
+                v-model="newMethod.name"
+                v-bind:validations="validations.name"
+                v-bind:field-name="'Name'"
+                v-bind:field-help="''"
+            />
+          </div>
+          <div class="column is-one-fourth">
+            <BasicInputField
+                v-model="newMethod.abbreviation"
+                v-bind:validations="validations.abbreviation"
+                v-bind:field-name="'Abbreviation'"
+                v-bind:field-help="'No more than 3 characters'"
+            />
+          </div>
+          <div class="column is-one-fourth">
+            <BasicInputField
+                v-model="newMethod.description"
+                v-bind:validations="validations.description"
+                v-bind:field-name="'Description'"
+            />
+          </div>
+        </div>
+        <div class="columns">
+          <div class="column is-one-fourth">
+            <BasicSelectField
+                v-model="newMethod.category"
+                v-bind:validations="validations.category"
+                v-bind:options="categories"
+                v-bind:field-name="'Category'"
+            />
+          </div>
+          <div class="column is-one-fourth">
+            <BasicSelectField
+                v-model="newMethod.geneticDiversity"
+                v-bind:validations="validations.geneticDiversity"
+                v-bind:options="diversities"
+                v-bind:field-name="'Genetic Diversity'"
+            />
+          </div>
+        </div>
+      </template>
+    </NewDataForm>
+
+    <ExpandableTable
+        v-bind:records.sync="programBreedingMethods"
+        v-bind:loading="loading"
+        v-bind:pagination="pagination"
+        v-bind:default-sort="['data.name', 'asc']"
+        v-bind:debounce-search="400"
+        v-bind:editable="$ability.can('update', 'ProgramConfiguration')"
+        v-bind:row-editable="isRowEditable"
+        v-bind:data-form-state="editMethodFormState"
+        v-bind:row-validations="newMethodValidations"
+        v-on:submit="updateMethod($event)"
+        v-on:show-error-notification="$emit('show-error-notification', $event)"
+    >
+      <b-table-column field="data.programId" label="Scope" searchable :customSearch="filterByScope" :th-attrs="(column) => ({scope:'col'})">
+        <template v-slot="props">
+          <span class="tag" :class="progressTagType(props.row.data.programId)">
+            {{ formatOwner(props.row.data.programId) }}
+          </span>
+        </template>
+        <template v-slot:searchable="props">
+          <div class="select">
+          <select
+              v-model="props.filters[props.column.field]"
+            >
+            <option value=""></option>
+            <option value="SYSTEM">System</option>
+            <option value="PROGRAM">Program</option>
+          </select>
+          </div>
+        </template>
+      </b-table-column>
+      <b-table-column field="data.name" label="Name" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        {{ props.row.data.name}}
+      </b-table-column>
+      <b-table-column field="data.abbreviation" label="Abbreviation" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        {{ props.row.data.abbreviation}}
+      </b-table-column>
+      <b-table-column field="data.description" label="Description" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        {{ props.row.data.description}}
+      </b-table-column>
+      <b-table-column field="data.category" label="Category" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        {{ props.row.data.category}}
+      </b-table-column>
+      <b-table-column field="data.geneticDiversity" label="Genetic Diversity" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        {{ props.row.data.geneticDiversity}}
+      </b-table-column>
+
+      <template v-slot:edit="{editData, validations}">
+        <div class="columns">
+          <div class="column is-one-fourth">
+            <BasicInputField
+                v-model="editData.name"
+                v-bind:validations="validations.name"
+                v-bind:field-name="'Name'"
+                v-bind:field-help="''"
+            />
+          </div>
+          <div class="column is-one-fourth">
+            <BasicInputField
+                v-model="editData.abbreviation"
+                v-bind:validations="validations.abbreviation"
+                v-bind:field-name="'Abbreviation'"
+                v-bind:field-help="'No more than 3 characters'"
+            />
+          </div>
+          <div class="column is-one-fourth">
+            <BasicInputField
+                v-model="editData.description"
+                v-bind:validations="validations.description"
+                v-bind:field-name="'Description'"
+            />
+          </div>
+        </div>
+        <div class="columns">
+          <div class="column is-one-fourth">
+            <BasicSelectField
+                v-model="editData.category"
+                v-bind:selected-id="editData.category"
+                v-bind:validations="validations.category"
+                v-bind:options="categories"
+                v-bind:field-name="'Category'"
+            />
+          </div>
+          <div class="column is-one-fourth">
+            <BasicSelectField
+                v-model="editData.geneticDiversity"
+                v-bind:selected-id="editData.geneticDiversity"
+                v-bind:validations="validations.geneticDiversity"
+                v-bind:options="diversities"
+                v-bind:field-name="'Genetic Diversity'"
+            />
+          </div>
+        </div>
+      </template>
+
+      <template v-slot:emptyMessage>
+        <p class="has-text-weight-bold">
+          No breeding methods exist
+        </p>
+      </template>
+    </ExpandableTable>
+    <GenericModal
+        v-bind:active.sync="showEnableSystemMethods"
+        v-bind:msg-title="'Enable/Disable System Breeding Methods'"
+        v-on:deactivate="showEnableSystemMethods = false"
+        v-bind:modalClass="'enable-system-methods'"
+    >
+      <ExpandableTable
+          v-bind:records.sync="systemBreedingMethods"
+          v-bind:pagination="systemPagination"
+          v-bind:default-sort="['data.name', 'asc']"
+          v-bind:debounce-search="400"
+          :checked-rows.sync="programEnabledSystemMethods"
+          :custom-is-checked="shouldCheck"
+          checkable
+          :checkbox-position="'left'"
+          :checkbox-type="'is-primary'"
+      >
+        <b-table-column field="data.name" label="Name" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+          {{ props.row.data.name}}
+        </b-table-column>
+        <b-table-column field="data.abbreviation" label="Abbreviation" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+          {{ props.row.data.abbreviation}}
+        </b-table-column>
+        <b-table-column field="data.description" label="Description" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+          {{ props.row.data.description}}
+        </b-table-column>
+        <b-table-column field="data.category" label="Category" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+          {{ props.row.data.category}}
+        </b-table-column>
+        <b-table-column field="data.geneticDiversity" label="Genetic Diversity" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+          {{ props.row.data.geneticDiversity}}
+        </b-table-column>
+
+        <template v-slot:emptyMessage>
+          <p class="has-text-weight-bold">
+            No breeding methods exist
+          </p>
+        </template>
+      </ExpandableTable>
+
+      <template v-slot:footer>
+        <button class="button is-success" :class="{'is-loading': savingSystemMethods}" v-on:click="saveEnabledMethods">Save changes</button>
+        <button class="button" v-on:click="showEnableSystemMethods = false">Cancel</button>
+      </template>
+    </GenericModal>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component } from 'vue-property-decorator'
+import ProgramsBase from "@/components/program/ProgramsBase.vue";
+import ExpandableTable from '@/components/tables/expandableTable/ExpandableTable.vue';
+import { Program } from '@/breeding-insight/model/Program';
+import { BreedingMethod } from '@/breeding-insight/model/BreedingMethod';
+import { Pagination } from '@/breeding-insight/model/BiResponse';
+import { PaginationController } from '@/breeding-insight/model/view_models/PaginationController';
+import { BreedingMethodService } from '@/breeding-insight/service/BreedingMethodService';
+import GenericModal from "@/components/modals/GenericModal.vue";
+import { mapGetters } from 'vuex';
+import { TableRow } from '@/breeding-insight/model/view_models/TableRow';
+import { maxLength, required } from 'vuelidate/lib/validators';
+import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
+import { DEACTIVATE_ALL_NOTIFICATIONS } from '@/store/mutation-types';
+import NewDataForm from '@/components/forms/NewDataForm.vue';
+import BasicInputField from "@/components/forms/BasicInputField.vue";
+import BasicSelectField from "@/components/forms/BasicSelectField.vue";
+@Component({
+  components: {
+    ExpandableTable, GenericModal, NewDataForm, BasicInputField, BasicSelectField
+  },
+  computed: {
+    ...mapGetters([
+      'activeProgram'
+    ])
+  }
+})
+export default class BreedingMethods extends ProgramsBase {
+  private activeProgram?: Program;
+  private programBreedingMethods: BreedingMethod[] = [];
+  private systemBreedingMethods: BreedingMethod[] = [];
+  private pagination: Pagination = new Pagination();
+  private paginationController: PaginationController = new PaginationController();
+  private systemPagination: Pagination = new Pagination();
+  private systemPaginationController: PaginationController = new PaginationController();
+  private loading = true;
+  private showEnableSystemMethods = false;
+  private savingSystemMethods = false;
+  private programEnabledSystemMethods: TableRow<BreedingMethod>[] = [];
+  private newMethodActive = false;
+  private newMethod = new BreedingMethod({});
+  private newMethodFormState: DataFormEventBusHandler = new DataFormEventBusHandler();
+  private editMethodFormState: DataFormEventBusHandler = new DataFormEventBusHandler();
+
+  private categories: Array<string> = ["Acquisition", "Asexual", "Cross", "GM", "Increase", "Inventory", "OP", "Ploidy", "Selection", "Unknown"];
+
+  private diversities: Array<string> = ["Generative (+)", "Derivative (-)", "Maintenance (0)"]
+
+  newMethodValidations = {
+    name: {required},
+    abbreviation: {required, maxLength: maxLength(3)},
+    description: {required},
+    category: {required},
+    geneticDiversity: {required}
+  }
+
+  mounted() {
+    this.getBreedingMethods();
+  }
+
+  async getBreedingMethods() {
+    try {
+      this.programBreedingMethods = await BreedingMethodService.getProgramBreedingMethods(this.activeProgram!.id!);
+      this.pagination.totalCount = this.programBreedingMethods.length;
+      this.pagination.pageSize = 20;
+      this.pagination.currentPage = 1;
+      this.pagination.totalPages = this.pagination.totalCount.valueOf() / this.pagination.pageSize.valueOf();
+
+      this.systemBreedingMethods = await BreedingMethodService.getSystemBreedingMethods();
+      this.systemPagination.totalCount = this.systemBreedingMethods.length;
+      this.systemPagination.pageSize = this.systemBreedingMethods.length;
+      this.systemPagination.currentPage = 1;
+      this.systemPagination.totalPages = this.systemPagination.totalCount.valueOf() / this.systemPagination.pageSize.valueOf();
+    } catch(e) {
+      this.$emit('show-error-notification', 'Error while trying to fetch breeding methods');
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  formatOwner(programId?:string) {
+    if(programId === undefined) {
+      return "SYSTEM";
+    }
+    return "PROGRAM";
+  }
+
+  progressTagType(programId?:string) {
+    if(programId === undefined) {
+      return "is-success";
+    }
+    return "is-warning";
+  }
+
+  openModal() {
+    this.programEnabledSystemMethods = [];
+    this.programBreedingMethods.forEach((value: BreedingMethod) => {
+      if(value.programId === undefined) {
+        var method = new BreedingMethod(value);
+        this.programEnabledSystemMethods.push(new TableRow(true, false, method));
+      }
+    });
+
+    this.showEnableSystemMethods = true;
+  }
+
+  shouldCheck(a: TableRow<BreedingMethod>, b: TableRow<BreedingMethod>){
+    return a.data.id === b.data.id;
+  }
+
+  async saveEnabledMethods() {
+    try {
+      this.savingSystemMethods = true;
+      await BreedingMethodService.enableSystemMethods(this.activeProgram!.id!, this.programEnabledSystemMethods.map(value => value.data));
+      this.showEnableSystemMethods = false;
+      this.$emit('show-success-notification', 'System breeding method enabled');
+      this.getBreedingMethods();
+    } catch (e) {
+      this.$emit('show-error-notification', 'Error while trying to enable system breeding methods');
+    } finally {
+      this.savingSystemMethods = false;
+    }
+  }
+
+  async saveMethod() {
+    try {
+      await BreedingMethodService.createProgramBreedingMethod(this.activeProgram!.id!, this.newMethod);
+      this.newMethodActive = false;
+      this.getBreedingMethods();
+      this.$emit('show-success-notification', 'Breeding method created successfully');
+    } catch (e) {
+      this.$emit('show-error-notification', 'Error while trying to create breeding method');
+    } finally {
+      this.newMethodFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT);
+    }
+  }
+
+  cancelNewMethod() {
+    this.newMethodActive = false;
+  }
+
+  showNewMethod() {
+    this.newMethod = new BreedingMethod({});
+    this.newMethodActive = true;
+    this.$store.commit(DEACTIVATE_ALL_NOTIFICATIONS);
+  }
+
+  async updateMethod(updatedMethod: BreedingMethod) {
+    try {
+      await BreedingMethodService.updateProgramBreedingMethod(this.activeProgram!.id!, updatedMethod);
+      this.getBreedingMethods();
+      this.$emit('show-success-notification', 'Breeding method updated successfully');
+    } catch (e) {
+      this.$emit('show-error-notification', 'Error while trying to update breeding method');
+    } finally {
+      this.editMethodFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT)
+    }
+  }
+
+  isRowEditable(row: TableRow<BreedingMethod>) {
+    return row.data.programId !== undefined;
+  }
+
+  filterByScope(row: TableRow<BreedingMethod>, input: string) {
+    if(input === 'SYSTEM') {
+      return row.data.programId === undefined;
+    } else if(input === 'PROGRAM') {
+      return row.data.programId !== undefined;
+    } else {
+      return true;
+    }
+  }
+
+}
+</script>

--- a/src/views/program/OntologySharing.vue
+++ b/src/views/program/OntologySharing.vue
@@ -16,11 +16,7 @@
   -->
 
 <template>
-  <div id="ontolgoy-sharing">
-<!--    <ExpandableCard-->
-<!--        title="Ontology"-->
-<!--        :show="false"-->
-<!--    >-->
+  <div id="ontology-sharing">
       <SharedOntologyConfiguration
           v-on="$listeners"
           class="mb-6"
@@ -32,14 +28,6 @@
           v-on:subscription-change="subscribeAction += 1"
           v-bind:share-change="shareAction"
       />
-<!--    </ExpandableCard>-->
-<!--    <ExpandableCard-->
-<!--      title="Breeding Methods"-->
-<!--      :show="false"-->
-<!--    >-->
-<!--      <BreedingMethods v-on="$listeners"/>-->
-<!--    </ExpandableCard>-->
-
   </div>
 </template>
 
@@ -50,11 +38,9 @@ import {mapGetters} from "vuex";
 import SharedOntologyConfiguration from "@/components/program/SharedOntologyConfiguration.vue";
 import SubscribeOntologyConfiguration from "@/components/program/SubscribeOntologyConfiguration.vue";
 import BreedingMethods from "@/views/germplasm/BreedingMethods.vue";
-import ExpandableCard from '@/components/layouts/ExpandableCard.vue';
 
 @Component({
   components: {
-    ExpandableCard,
     SubscribeOntologyConfiguration,
     SharedOntologyConfiguration,
     BreedingMethods

--- a/src/views/program/OntologySharing.vue
+++ b/src/views/program/OntologySharing.vue
@@ -16,18 +16,30 @@
   -->
 
 <template>
-  <div id="program-configuration">
-    <SharedOntologyConfiguration
-        v-on="$listeners"
-        class="mb-6"
-        v-bind:subscription-change="subscribeAction"
-        v-on:share-change="shareAction += 1"
-    />
-    <SubscribeOntologyConfiguration
-        v-on="$listeners"
-        v-on:subscription-change="subscribeAction += 1"
-        v-bind:share-change="shareAction"
-    />
+  <div id="ontolgoy-sharing">
+<!--    <ExpandableCard-->
+<!--        title="Ontology"-->
+<!--        :show="false"-->
+<!--    >-->
+      <SharedOntologyConfiguration
+          v-on="$listeners"
+          class="mb-6"
+          v-bind:subscription-change="subscribeAction"
+          v-on:share-change="shareAction += 1"
+      />
+      <SubscribeOntologyConfiguration
+          v-on="$listeners"
+          v-on:subscription-change="subscribeAction += 1"
+          v-bind:share-change="shareAction"
+      />
+<!--    </ExpandableCard>-->
+<!--    <ExpandableCard-->
+<!--      title="Breeding Methods"-->
+<!--      :show="false"-->
+<!--    >-->
+<!--      <BreedingMethods v-on="$listeners"/>-->
+<!--    </ExpandableCard>-->
+
   </div>
 </template>
 
@@ -37,11 +49,15 @@ import ProgramsBase from "@/components/program/ProgramsBase.vue";
 import {mapGetters} from "vuex";
 import SharedOntologyConfiguration from "@/components/program/SharedOntologyConfiguration.vue";
 import SubscribeOntologyConfiguration from "@/components/program/SubscribeOntologyConfiguration.vue";
+import BreedingMethods from "@/views/germplasm/BreedingMethods.vue";
+import ExpandableCard from '@/components/layouts/ExpandableCard.vue';
 
 @Component({
   components: {
+    ExpandableCard,
     SubscribeOntologyConfiguration,
-    SharedOntologyConfiguration
+    SharedOntologyConfiguration,
+    BreedingMethods
   },
   computed: {
     ...mapGetters([
@@ -49,7 +65,7 @@ import SubscribeOntologyConfiguration from "@/components/program/SubscribeOntolo
     ])
   }
 })
-export default class ProgramConfiguration extends ProgramsBase {
+export default class OntologySharing extends ProgramsBase {
   // Change tracker to pass to children for refresh
   private subscribeAction: number = 0;
   private shareAction: number = 0;

--- a/src/views/program/ProgramManagement.vue
+++ b/src/views/program/ProgramManagement.vue
@@ -25,20 +25,27 @@
       <nav class="tabs is-boxed">
         <ul>
           <router-link
-              v-bind:to="{name: 'program-locations', params: {programId: activeProgram.id}}"
-              tag="li" active-class="is-active">
-            <a>Locations</a>
-          </router-link>
-          <router-link
               v-bind:to="{name: 'program-users', params: {programId: activeProgram.id}}"
               tag="li" active-class="is-active">
             <a>Users</a>
           </router-link>
           <router-link
-              v-if="$ability.can('access', 'ProgramConfiguration')"
-              v-bind:to="{name: 'program-configuration', params: {programId: activeProgram.id}}"
+              v-bind:to="{name: 'program-locations', params: {programId: activeProgram.id}}"
               tag="li" active-class="is-active">
-            <a>Configuration</a>
+            <a>Locations</a>
+          </router-link>
+          <router-link
+              v-bind:to="{name: 'breeding-methods', params: {programId: activeProgram.id}}"
+              tag="li"
+              active-class="is-active"
+          >
+            <a>Breeding Methods</a>
+          </router-link>
+          <router-link
+              v-if="$ability.can('access', 'ProgramConfiguration')"
+              v-bind:to="{name: 'ontology-sharing', params: {programId: activeProgram.id}}"
+              tag="li" active-class="is-active">
+            <a>Ontology Sharing</a>
           </router-link>
         </ul>
       </nav>


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1651

Created a new interface under program administration to allow a breeding program to control what system breeding methods are allowed, and to create/edit/delete their own custom breeding methods.


# Dependencies
bi-api/feature/BI-1651

# Testing
1. Verify that only the `breeder` role can see the Breeding Method configuration screen
2. Verify that when first creating a program, and then navigating to the Breeding Method config screen, that all of the system breeding methods are visible
3. Verify that system breeding methods can be enabled/disabled
4. Verify that a new breeding method can be created, and that it only shows up for the program it was created in
5. Verify that germplasm can be created with program defined breeding methods
6. Verify that germplasm cannot be created with system breeding methods not enabled by the program
7. Verify that a program breeding method cannot be deleted if there is a germplasm record utilizing that method
8. Verify that a system breeding method cannot be disabled if there is a germplasm record utilizing that method


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [ ] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/3887368051
