### PR TITLE
BI-1616 - Add Filtering to Germplasm Lists Table

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -185,3 +185,21 @@ export class ExperimentSort {
     this.order = order;
   }
 }
+
+export enum GermplasmListSortField {
+  Name = "name",
+  Description = "description",
+  TotalEntries = "size",
+  CreatedDate = "dateCreated",
+  CreatedBy = "ownerName"
+}
+
+export class GermplasmListSort {
+  field: GermplasmListSortField;
+  order: SortOrder;
+
+  constructor(field: GermplasmListSortField, order: SortOrder) {
+    this.field = field;
+    this.order = order;
+  }
+}

--- a/src/breeding-insight/service/BrAPIService.ts
+++ b/src/breeding-insight/service/BrAPIService.ts
@@ -21,7 +21,8 @@ import {SortOrder} from "@/breeding-insight/model/Sort";
 
 export enum BrAPIType {
   GERMPLASM = "germplasm",
-  EXPERIMENT = "trials"
+  EXPERIMENT = "trials",
+  LIST = "lists"
 }
 
 export class BrAPIService {

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -27,7 +27,7 @@
       backend-sorting
       v-bind:default-sort="[fieldMap['name'], 'ASC']"
       v-on:sort="setSort"
-      v-on:search="filters = $event"
+      v-on:search="initSearch"
       v-bind:search-debounce="400"
     >
       <b-table-column field="name" label="Name" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
@@ -151,7 +151,11 @@ export default class GermplasmListsTable extends Vue {
     'ownerName': GermplasmListSortField.CreatedBy
   };
 
-
+  initSearch(filter: any) {
+    this.filters = filter;
+    // When filtering the list, set the page to the first page.
+    this.paginationController.updatePage(1);
+  }
 
   mounted() {
     this.germplasmListCallStack = new CallStack(this.germplasmListFetch(

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -61,7 +61,7 @@
       <template v-slot:emptyMessage>
         <EmptyTableMessage>
           <p class="has-text-weight-bold">
-            Germplasm lists not yet specified.
+            Germplasm lists not yet specified or no matching lists found.
           </p>
         </EmptyTableMessage>
       </template>
@@ -138,7 +138,7 @@ export default class GermplasmListsTable extends Vue {
   private germplasmListSort!: GermplasmListSort;
   private filters: any = {};
   private germplasmListCallStack?: CallStack;
-  
+
   private updateSort!: (sort: GermplasmListSort) => void;
   private fieldMap: any = {
     'name': GermplasmListSortField.Name,

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -136,12 +136,9 @@ export default class GermplasmListsTable extends Vue {
   private fileOptions = Object.values(FileType);
 
   private germplasmListSort!: GermplasmListSort;
-
-
   private filters: any = {};
   private germplasmListCallStack?: CallStack;
-
-
+  
   private updateSort!: (sort: GermplasmListSort) => void;
   private fieldMap: any = {
     'name': GermplasmListSortField.Name,

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -24,20 +24,25 @@
       v-on:paginate="paginationController.updatePage($event)"
       v-on:paginate-toggle-all="paginationController.toggleShowAll(germplasmListsPagination.totalCount.valueOf())"
       v-on:paginate-page-size="paginationController.updatePageSize($event)"
+      backend-sorting
+      v-bind:default-sort="[fieldMap['name'], 'ASC']"
+      v-on:sort="setSort"
+      v-on:search="filters = $event"
+      v-bind:search-debounce="400"
     >
-      <b-table-column field="data.listName" label="Name" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="name" label="Name" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ props.row.data.listName}}
       </b-table-column>
-      <b-table-column field="data.listDescription" label="Description" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="description" label="Description" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ props.row.data.listDescription }}
       </b-table-column>
-      <b-table-column field="data.listSize" label="Total Entries" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="size" label="Total Entries" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ props.row.data.listSize }}
       </b-table-column>
-      <b-table-column field="data.dateCreated" label="Created Date" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="dateCreated" label="Created Date" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ formatDate(props.row.data.dateCreated) }}
       </b-table-column>
-      <b-table-column field="data.listOwnerName" label="Created By" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column field="ownerName" label="Created By" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ props.row.data.listOwnerName }}
       </b-table-column>
       <b-table-column  field="data.listDbId" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
@@ -65,15 +70,15 @@
 </template>
 
 <script lang="ts">
-import {Component, Vue, Watch} from 'vue-property-decorator'
+import {Component, Vue, Watch, Prop} from 'vue-property-decorator'
 import {DownloadIcon} from 'vue-feather-icons'
 import {validationMixin} from 'vuelidate';
-import { mapGetters } from 'vuex'
+import { mapGetters, mapMutations } from 'vuex'
 import {Program} from "@/breeding-insight/model/Program";
 import BasicInputField from "@/components/forms/BasicInputField.vue";
 import EmptyTableMessage from "@/components/tables/EmtpyTableMessage.vue";
 import TableColumn from "@/components/tables/TableColumn.vue";
-import {Pagination} from "@/breeding-insight/model/BiResponse";
+import {Pagination, BiResponse} from "@/breeding-insight/model/BiResponse";
 import {BackendPaginationController} from "@/breeding-insight/model/view_models/BackendPaginationController";
 import BaseTraitForm from "@/components/trait/forms/BaseTraitForm.vue";
 import {GermplasmList} from "@/breeding-insight/model/GermplasmList";
@@ -83,6 +88,14 @@ import moment from "moment";
 import SelectModal from "@/components/modals/SelectModal.vue";
 import {FileType} from "@/breeding-insight/model/FileType";
 import GermplasmDownloadButton from '@/components/germplasm/GermplasmDownloadButton.vue';
+import {UPDATE_GERMPLASM_LIST_SORT} from "@/store/sorting/mutation-types";
+import {CallStack} from "@/breeding-insight/utils/CallStack";
+import {
+  GermplasmListSort,
+  Sort,
+  GermplasmListSortField, GermplasmSort
+} from "@/breeding-insight/model/Sort";
+import {UPDATE_EXPERIMENT_SORT} from "@/store/sorting/mutation-types";
 
 @Component({
   mixins: [validationMixin],
@@ -93,10 +106,23 @@ import GermplasmDownloadButton from '@/components/germplasm/GermplasmDownloadBut
   computed: {
     ...mapGetters([
       'activeProgram'
-    ])
-  }
+    ]),
+    ...mapGetters('sorting',
+      [
+        'germplasmListSort'
+      ])
+  },
+  methods: {
+    ...mapMutations('sorting', {
+      updateSort: UPDATE_GERMPLASM_LIST_SORT
+    })
+  },
+  data: () => ({Sort})
 })
 export default class GermplasmListsTable extends Vue {
+
+  @Prop()
+  germplasmListFetch!: (programId: string, sort: GermplasmListSort, paginationController: BackendPaginationController) => (filters: any) => Promise<BiResponse>;
 
   private activeProgram?: Program;
   private germplasmListsPagination?: Pagination = new Pagination();
@@ -109,15 +135,57 @@ export default class GermplasmListsTable extends Vue {
   private modalActive: boolean = false;
   private fileOptions = Object.values(FileType);
 
+  private germplasmListSort!: GermplasmListSort;
+
+
+  private filters: any = {};
+  private germplasmListCallStack?: CallStack;
+
+
+  private updateSort!: (sort: GermplasmListSort) => void;
+  private fieldMap: any = {
+    'name': GermplasmListSortField.Name,
+    'description': GermplasmListSortField.Description,
+    'size': GermplasmListSortField.TotalEntries,
+    'dateCreated': GermplasmListSortField.CreatedDate,
+    'ownerName': GermplasmListSortField.CreatedBy
+  };
+
+
+
   mounted() {
-    this.getGermplasmLists();
+    this.germplasmListCallStack = new CallStack(this.germplasmListFetch(
+        this.activeProgram!.id!,
+        this.germplasmListSort,
+        this.paginationController
+    ));
+    this.paginationController.pageSize = 20;
   }
 
   @Watch('paginationController', { deep: true})
-  getGermplasmLists() {
+  @Watch('filters', {deep: true})
+  async getGermplasmLists() {
     let paginationQuery = BackendPaginationController.getPaginationSelections(
           this.paginationController.currentPage, this.paginationController.pageSize, this.paginationController.showAll);
 
+    this.paginationController.setCurrentCall(paginationQuery);
+
+    try {
+      const {call, callId} = this.germplasmListCallStack.makeCall(this.filters);
+      const response = await call;
+      if (!this.germplasmListCallStack.isCurrentCall(callId)) return;
+      this.germplasmListsPagination = new Pagination(response.metadata.pagination);
+      // Account for brapi 0 indexing of paging
+      this.germplasmListsPagination.currentPage = this.germplasmListsPagination.currentPage.valueOf() + 1;
+      this.germplasmLists = response.result.data;
+      this.germplasmListsLoading = false;
+    } catch (err) {
+      this.$emit('show-error-notification', 'Error while trying to load germplasm lists');
+    } finally {
+      this.germplasmListsLoading = false;
+    }
+
+    /*
     GermplasmService.getAll(this.activeProgram!.id!, paginationQuery).then(([germplasmLists, metadata]) => {
         this.germplasmLists = germplasmLists;
         this.germplasmListsPagination = new Pagination(metadata.pagination);
@@ -128,6 +196,8 @@ export default class GermplasmListsTable extends Vue {
       this.$emit('show-error-notification', 'Error while trying to load germplasm lists');
       throw error;
     }).finally(() => this.germplasmListsLoading = false);
+     */
+
   }
 
   formatDate(date: Date) {
@@ -136,6 +206,13 @@ export default class GermplasmListsTable extends Vue {
 
   updatePageSize(pageSize: string) {
     this.paginationController.updatePageSize(Number(pageSize).valueOf());
+  }
+
+  setSort(field: string, order: string) {
+    if (field in this.fieldMap) {
+      this.updateSort(new GermplasmListSort(this.fieldMap[field], Sort.orderAsBI(order)));
+      this.getGermplasmLists();
+    }
   }
 }
 </script>

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -188,20 +188,6 @@ export default class GermplasmListsTable extends Vue {
     } finally {
       this.germplasmListsLoading = false;
     }
-
-    /*
-    GermplasmService.getAll(this.activeProgram!.id!, paginationQuery).then(([germplasmLists, metadata]) => {
-        this.germplasmLists = germplasmLists;
-        this.germplasmListsPagination = new Pagination(metadata.pagination);
-        // Account for brapi 0 indexing of paging
-        this.germplasmListsPagination.currentPage = this.germplasmListsPagination.currentPage.valueOf() + 1;
-    }).catch((error) => {
-      // Display error that germplasm lists cannot be loaded
-      this.$emit('show-error-notification', 'Error while trying to load germplasm lists');
-      throw error;
-    }).finally(() => this.germplasmListsLoading = false);
-     */
-
   }
 
   formatDate(date: Date) {

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -12,7 +12,7 @@
         v-bind:default-sort="entryNumberVisible ? [fieldMap['importEntryNumber'], 'ASC'] :
         [fieldMap['accessionNumber'], 'ASC']"
         v-on:sort="setSort"
-        v-on:search="initSearch"
+        v-on:search="filters = $event"
         v-bind:search-debounce="400"
     >
       <b-table-column v-if="entryNumberVisible" field="importEntryNumber" label="Entry Number" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
@@ -155,12 +155,6 @@ export default class GermplasmTable extends Vue {
     ));
 
     this.paginationController.pageSize = 20;
-  }
-
-  initSearch(filter: any) {
-    this.filters = filter;
-    // When filtering the list, set the page to the first page.
-    this.paginationController.updatePage(1);
   }
 
   @Watch('paginationController', { deep: true})

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -12,7 +12,7 @@
         v-bind:default-sort="entryNumberVisible ? [fieldMap['importEntryNumber'], 'ASC'] :
         [fieldMap['accessionNumber'], 'ASC']"
         v-on:sort="setSort"
-        v-on:search="filters = $event"
+        v-on:search="initSearch"
         v-bind:search-debounce="400"
     >
       <b-table-column v-if="entryNumberVisible" field="importEntryNumber" label="Entry Number" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
@@ -155,6 +155,12 @@ export default class GermplasmTable extends Vue {
     ));
 
     this.paginationController.pageSize = 20;
+  }
+
+  initSearch(filter: any) {
+    this.filters = filter;
+    // When filtering the list, set the page to the first page.
+    this.paginationController.updatePage(1);
   }
 
   @Watch('paginationController', { deep: true})

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -21,6 +21,7 @@ import {SortState} from "@/store/sorting/types";
 import {
     ExperimentSort,
     GermplasmSort,
+    GermplasmListSort,
     LocationSort, OntologySort,
     ProgramSort,
     ProgramSortField,
@@ -120,6 +121,10 @@ export const getters: GetterTree<SortState, RootState> = {
     // germplasm
     germplasmSort(state: SortState): GermplasmSort {
         return state.germplasmSort;
+    },
+
+    germplasmListSort(state: SortState): GermplasmListSort {
+        return state.germplasmListSort;
     },
 
     // experiment

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -22,6 +22,8 @@ import {RootState} from '@/store/types';
 import {
     ExperimentSort,
     ExperimentSortField,
+    GermplasmListSort,
+    GermplasmListSortField,
     GermplasmSort,
     GermplasmSortField,
     LocationSort,
@@ -63,6 +65,9 @@ state = {
 
     // germplasm table
     germplasmSort: new GermplasmSort(GermplasmSortField.AccessionNumber, SortOrder.Ascending),
+
+    // germplasm list table
+    germplasmListSort: new GermplasmListSort(GermplasmListSortField.Name, SortOrder.Ascending),
 
     //experiment and observation table
     experimentSort: new ExperimentSort(ExperimentSortField.Name, SortOrder.Ascending)

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -43,5 +43,8 @@ export const UPDATE_PROGRAM_SORT = 'updateProgramSort';
 // germplasm table
 export const UPDATE_GERMPLASM_SORT = 'updateGermplasmSort';
 
+// germplasm list table
+export const UPDATE_GERMPLASM_LIST_SORT = 'updateGermplasmListSort';
+
 // experiment table
 export const UPDATE_EXPERIMENT_SORT = 'updateExperimentSort';

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -28,12 +28,14 @@ import {
     IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER,
     IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN,
     UPDATE_GERMPLASM_SORT,
+    UPDATE_GERMPLASM_LIST_SORT,
     UPDATE_EXPERIMENT_SORT
 } from "@/store/sorting/mutation-types";
 import {SortState} from "@/store/sorting/types";
 import {
     ExperimentSort,
     GermplasmSort,
+    GermplasmListSort,
     LocationSort, OntologySort, OntologySortField,
     ProgramSort, SortOrder, SystemUserSort,
     TraitSortField,
@@ -93,6 +95,12 @@ export const mutations: MutationTree<SortState> = {
     [UPDATE_GERMPLASM_SORT](state: SortState, sort: GermplasmSort) {
         state.germplasmSort.field = sort.field;
         state.germplasmSort.order = sort.order;
+    },
+
+    //germplasm list table
+    [UPDATE_GERMPLASM_LIST_SORT](state: SortState, sort: GermplasmListSort) {
+        state.germplasmListSort.field = sort.field;
+        state.germplasmListSort.order = sort.order;
     },
 
     //experiments and observations table

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -1,5 +1,5 @@
 import {
-    ExperimentSort,
+    ExperimentSort, GermplasmListSort,
     GermplasmSort,
     LocationSort,
     OntologySort,
@@ -33,6 +33,9 @@ export interface SortState {
 
     // germplasm table
     germplasmSort: GermplasmSort
+
+    // germplasm list table
+    germplasmListSort: GermplasmListSort
 
     // experiment and observation table
     experimentSort: ExperimentSort

--- a/src/views/germplasm/GermplasmLists.vue
+++ b/src/views/germplasm/GermplasmLists.vue
@@ -20,6 +20,7 @@
     <GermplasmListsTable
         v-on:show-success-notification="$emit('show-success-notification', $event)"
         v-on:show-error-notification="$emit('show-error-notification', $event)"
+        v-bind:germplasm-list-fetch="germplasmListFetch"
     >
     </GermplasmListsTable>
   </div>
@@ -29,11 +30,28 @@
 import { Component } from 'vue-property-decorator'
 import ProgramsBase from "@/components/program/ProgramsBase.vue";
 import GermplasmListsTable from "@/components/germplasm/GermplasmListsTable.vue";
+import {GermplasmListSort, GermplasmListSortField} from "@/breeding-insight/model/Sort";
+import {BackendPaginationController} from "@/breeding-insight/model/view_models/BackendPaginationController";
+import {BiResponse} from "@/breeding-insight/model/BiResponse";
+import {BrAPIService, BrAPIType} from "@/breeding-insight/service/BrAPIService";
 @Component({
   components: {
     GermplasmListsTable
   }
 })
 export default class GermplasmLists extends ProgramsBase {
+
+  private germplasmListFetch: (programId: string, sort: GermplasmListSort, paginationController: BackendPaginationController) => ((filters: any) => Promise<BiResponse>) =
+      function (programId: string, sort: GermplasmListSort, paginationController: BackendPaginationController) {
+        return function (filters: any) {
+          return BrAPIService.get<GermplasmListSortField>(
+              BrAPIType.LIST,
+              programId,
+              sort,
+              { pageSize: paginationController.pageSize, page: paginationController.currentPage - 1 },
+              filters)
+        };
+      };
 }
+
 </script>

--- a/src/views/germplasm/GermplasmLists.vue
+++ b/src/views/germplasm/GermplasmLists.vue
@@ -44,6 +44,7 @@ export default class GermplasmLists extends ProgramsBase {
   private germplasmListFetch: (programId: string, sort: GermplasmListSort, paginationController: BackendPaginationController) => ((filters: any) => Promise<BiResponse>) =
       function (programId: string, sort: GermplasmListSort, paginationController: BackendPaginationController) {
         return function (filters: any) {
+          filters.type='germplasm';
           return BrAPIService.get<GermplasmListSortField>(
               BrAPIType.LIST,
               programId,


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1616?atlOrigin=eyJpIjoiMDY3MzAwZjNlNTM4NDQ4MzkwMmJhZDUzN2UxYjdmZWMiLCJwIjoiaiJ9

- Added support for filtering on brapi lists endpoint

# Dependencies
- bi-web feature/[BI-1616](https://breedinginsight.atlassian.net/browse/BI-1616)

# Testing
- Test filtering, sorting and pagination in Germplasm Lists table to verify it's working as expected.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1616]: https://breedinginsight.atlassian.net/browse/BI-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ