### PR TITLE
[BI-1129] add fix for pagination bug

### DIFF
--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -12,7 +12,7 @@
         v-bind:default-sort="entryNumberVisible ? [fieldMap['importEntryNumber'], 'ASC'] :
         [fieldMap['accessionNumber'], 'ASC']"
         v-on:sort="setSort"
-        v-on:search="filters = $event"
+        v-on:search="initSearch"
         v-bind:search-debounce="400"
     >
       <b-table-column v-if="entryNumberVisible" field="importEntryNumber" label="Entry Number" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
@@ -184,6 +184,13 @@ export default class GermplasmTable extends Vue {
       this.updateSort(new GermplasmSort(this.fieldMap[field], Sort.orderAsBI(order)));
       this.getGermplasm();
     }
+  }
+
+  initSearch(filters: any) {
+    this.filters = filters;
+
+    // When filtering the list, set a page to the first page.
+    this.paginationController.updatePage(1);
   }
 
 }


### PR DESCRIPTION
# Description
**Story:** [BI-1129](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1129)

When the filter state is updated for the germplasm table, the page is set to 1.



# Dependencies
bi-api: develop

# Testing

    Go to an All Germplasm table with more than one page.
    Go to any page other than page 1.
    Apply a valid filter to any column.

Expected Result

    Valid filtered Germplasm table should displayed
    The Germplasm table should be on page 1

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1129]: https://breedinginsight.atlassian.net/browse/BI-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ