### PR TITLE
BI-1548 - Experiments: User and Creation Date Refinement

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -173,7 +173,9 @@ export class GermplasmSort {
 // experiments
 export enum ExperimentSortField {
   Name = "name",
-  Active = "active"
+  Active = "active",
+  CreatedBy = "createdBy",
+  CreatedDate = "createdDate"
 }
 
 export class ExperimentSort {

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -40,10 +40,10 @@
       <b-table-column label="Status" field="active" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" >
           {{ getStatus(props.row.data.active) }}
       </b-table-column>
-      <b-table-column label="Date Created" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column label="Date Created" field="createdDate" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
           {{ props.row.data.additionalInfo.createdDate }}
       </b-table-column>
-      <b-table-column label="Created By" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column label="Created By" field="createdBy" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ props.row.data.additionalInfo.createdBy.userName }}
       </b-table-column>
       <b-table-column label="Datasets" cell-class="fixed-width-wrapped" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
@@ -136,6 +136,8 @@ export default class ExperimentsObservationsTable extends Vue {
   private fieldMap: any = {
     'name': ExperimentSortField.Name,
     'active': ExperimentSortField.Active,
+    'createdDate': ExperimentSortField.CreatedDate,
+    'createdBy': ExperimentSortField.CreatedBy
   };
 
   mounted() {

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -41,10 +41,10 @@
           {{ getStatus(props.row.data.active) }}
       </b-table-column>
       <b-table-column label="Date Created" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-          {{  }}
+          {{ props.row.data.additionalInfo.createdDate }}
       </b-table-column>
       <b-table-column label="Created By" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-        {{  }}
+        {{ props.row.data.additionalInfo.createdBy.userName }}
       </b-table-column>
       <b-table-column label="Datasets" cell-class="fixed-width-wrapped" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         <template v-for="dataset in props.row.data.additionalInfo.datasets">


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1548?atlOrigin=eyJpIjoiMDU3NTE2YWExOTFlNGMxZWJlOTA2N2Y2YWRhOWY3NDYiLCJwIjoiaiJ9

- Added createdBy and createDate experiment filtering

# Dependencies
- bi-api BI-1548

# Testing
- Test sorting and filtering for experiments CreatedBy and createDate

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
