### PR TITLE
[BI-1606] Allow germplasm records to be in multiple lists

### DIFF
--- a/src/breeding-insight/service/GermplasmService.ts
+++ b/src/breeding-insight/service/GermplasmService.ts
@@ -56,7 +56,7 @@ export class GermplasmService {
                 //Get the list db id
                 const paginationQuery = new PaginationQuery(0, 20, true);
                 const {result: {data: lists}} = await GermplasmDAO.getAllLists(programId, paginationQuery);
-                const matchingLists = lists.filter(list => list.listName === listName);
+                const matchingLists = lists.filter((list: any) => list.listName === listName);
                 if (matchingLists.length === 0) throw Error("List name is not valid for this program");
                 if (matchingLists.length > 1) throw Error("List name must be unique");
                 listId = matchingLists[0].listDbId;

--- a/src/breeding-insight/utils/GermplasmUtils.ts
+++ b/src/breeding-insight/utils/GermplasmUtils.ts
@@ -18,6 +18,7 @@
 import moment from "moment";
 import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
 import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferences";
+import {GermplasmService} from "@/breeding-insight/service/GermplasmService";
 
 export class GermplasmUtils {
     static getExternalUID(germplasm: Germplasm): string | undefined {
@@ -48,4 +49,13 @@ export class GermplasmUtils {
         return synonyms.map(synonym => synonym.synonym).join("; ");
     }
 
+    static getEntryNumber(germplasm: Germplasm, referenceId: string | undefined): string | undefined {
+        if (germplasm.additionalInfo) {
+            return referenceId ? germplasm.additionalInfo.listEntryNumbers[<any>referenceId] :
+                germplasm.additionalInfo.importEntryMumber;
+        }
+        return "";
+        // return germplasm.additionalInfo ? germplasm.additionalInfo.importEntryNumber ||
+        //     germplasm.additionalInfo.listEntryNumbers[<any>referenceId] : "";
+    }
 }

--- a/src/breeding-insight/utils/GermplasmUtils.ts
+++ b/src/breeding-insight/utils/GermplasmUtils.ts
@@ -55,7 +55,5 @@ export class GermplasmUtils {
                 germplasm.additionalInfo.importEntryMumber;
         }
         return "";
-        // return germplasm.additionalInfo ? germplasm.additionalInfo.importEntryNumber ||
-        //     germplasm.additionalInfo.listEntryNumbers[<any>referenceId] : "";
     }
 }

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -16,7 +16,7 @@
         v-bind:search-debounce="400"
     >
       <b-table-column v-if="entryNumberVisible" field="importEntryNumber" label="Entry Number" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
-        {{ props.row.data.additionalInfo.importEntryNumber }}
+        {{ GermplasmUtils.getEntryNumber(props.row.data, referenceId) }}
       </b-table-column>
       <b-table-column field="accessionNumber" label="GID" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         <GermplasmLink
@@ -95,6 +95,7 @@ import {
   Sort
 } from "@/breeding-insight/model/Sort";
 import {UPDATE_GERMPLASM_SORT} from "@/store/sorting/mutation-types";
+import {GermplasmService} from "@/breeding-insight/service/GermplasmService";
 
 @Component({
   mixins: [validationMixin],
@@ -121,6 +122,8 @@ export default class GermplasmTable extends Vue {
   germplasmFetch!: (programId: string, sort: GermplasmSort, paginationController: BackendPaginationController) => (filters: any) => Promise<BiResponse>;
   @Prop({default: false})
   entryNumberVisible?: Boolean;
+  @Prop()
+  referenceId?: string;
 
   private activeProgram?: Program;
   private pagination?: Pagination = new Pagination();
@@ -192,6 +195,5 @@ export default class GermplasmTable extends Vue {
     // When filtering the list, set a page to the first page.
     this.paginationController.updatePage(1);
   }
-
 }
 </script>

--- a/src/views/germplasm/GermplasmByList.vue
+++ b/src/views/germplasm/GermplasmByList.vue
@@ -60,6 +60,7 @@
     <GermplasmTable
         v-bind:germplasmFetch="germplasmFetch"
         entryNumberVisible="true"
+        v-bind:reference-id="referenceId"
     >
     </GermplasmTable>
   </div>
@@ -96,6 +97,7 @@ export default class GermplasmByList extends GermplasmBase {
 
   private activeProgram?: Program;
   private list: any = null;
+  private referenceId?: string;
 
   // Set the method used to populate the germplasm table
   private germplasmFetch: (programId: string, sort: GermplasmSort, paginationController: BackendPaginationController) => ((filters: any) => Promise<BiResponse>) =
@@ -119,6 +121,9 @@ export default class GermplasmByList extends GermplasmBase {
     const {result: {data: lists}} = await GermplasmDAO.getAllLists(this.activeProgram!.id!, paginationQuery);
     const matchingLists: any[] = lists.filter(list => list.listDbId === this.$route.params.listId);
     this.list = matchingLists[0];
+    this.referenceId = matchingLists[0].externalReferences.reduce((result: string, ref: any) => {
+      return ref.referenceSource == "breeding-insight.net/lists" ? ref.referenceID : result;
+    },undefined);
   }
 }
 </script>

--- a/src/views/germplasm/GermplasmByList.vue
+++ b/src/views/germplasm/GermplasmByList.vue
@@ -122,7 +122,7 @@ export default class GermplasmByList extends GermplasmBase {
     const matchingLists: any[] = lists.filter(list => list.listDbId === this.$route.params.listId);
     this.list = matchingLists[0];
     this.referenceId = matchingLists[0].externalReferences.reduce((result: string, ref: any) => {
-      return ref.referenceSource == "breeding-insight.net/lists" ? ref.referenceID : result;
+      return ref.referenceSource == `${process.env.VUE_APP_BI_REFERENCE_SOURCE}/lists` ? ref.referenceID : result;
     },undefined);
   }
 }

--- a/src/views/germplasm/GermplasmByList.vue
+++ b/src/views/germplasm/GermplasmByList.vue
@@ -97,12 +97,12 @@ export default class GermplasmByList extends GermplasmBase {
 
   private activeProgram?: Program;
   private list: any = null;
-  private referenceId?: string;
+  private referenceId?: string = '';
 
   // Set the method used to populate the germplasm table
   private germplasmFetch: (programId: string, sort: GermplasmSort, paginationController: BackendPaginationController) => ((filters: any) => Promise<BiResponse>) =
       function (programId: string, sort: GermplasmSort, paginationController: BackendPaginationController) {
-        let id = this.$route.params.listId;
+        let id: string = this.$route.params.listId;
         return function (filters: any) {
           return GermplasmService.getAllInList(
               programId,
@@ -121,9 +121,11 @@ export default class GermplasmByList extends GermplasmBase {
     const {result: {data: lists}} = await GermplasmDAO.getAllLists(this.activeProgram!.id!, paginationQuery);
     const matchingLists: any[] = lists.filter(list => list.listDbId === this.$route.params.listId);
     this.list = matchingLists[0];
+
+    // Find the key used, if any, for this list in the list entry numbers map
     this.referenceId = matchingLists[0].externalReferences.reduce((result: string, ref: any) => {
       return ref.referenceSource == `${process.env.VUE_APP_BI_REFERENCE_SOURCE}/lists` ? ref.referenceID : result;
-    },undefined);
+    },'');
   }
 }
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-1606](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1606)

The germplasm list details page now uses a helper function to display the entry number whether the number is stored using the old format of importEntryNumber or using the listEntryNumbers map.


# Dependencies
bi-api feature/BI-1606 branch

# Testing
1. Import germplasm with user-supplied entry numbers. 
2. Go to the Germpasm Lists tab and use the dev tools console to inspect the list object in the response and verify there is an external reference entry for /lists and note the UUID stored as the refernceID.
3. Then view all imported germplasm and use the dev tools console to inspect the germplasm objects in the response from bi-api. Verify the additionalInfo field "listEntryNumbers" exists and the value is a Map with the imported list ID from step 2 as the key and entry number as value.

4. Import germplasm without user-supplied entry numbers and repeat process above.

5. Download the imported germplasm and verify the exported file records match what is stored.
6. Download a list of previously imported germplasm that store entry number values in additionalInfo.imortEntryNumber and verify the exported file records match what is stored.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have tested that my code works with both the brapi-java-server and BreedBase
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [#136](https://github.com/Breeding-Insight/taf/actions/runs/3526754134)


[BI-1606]: https://breedinginsight.atlassian.net/browse/BI-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ