### PR TITLE
[BI-1477] Bugfix:Improve All Experiments Table

### DIFF
--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -31,7 +31,7 @@
         backend-sorting
         v-bind:default-sort="[fieldMap['name'], 'ASC']"
         v-on:sort="setSort"
-        v-on:search="filters = $event"
+        v-on:search="initSearch"
         v-bind:search-debounce="400"
     >
       <b-table-column label="Title" field="name" cell-class="fixed-width-wrapped" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
@@ -209,6 +209,12 @@ export default class ExperimentsObservationsTable extends Vue {
     }
   }
 
+  initSearch(filters: any) {
+    this.filters = filters;
+
+    // When filtering the list, set a page to the first page
+    this.paginationController.updatePage(1);
+  }
 }
 
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-1477](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1477)

set page to first when exp name filter input updated



# Dependencies
bi-api develop

# Testing
1. load 11 or more experiments.
2. select any page except the first on exp&obs table.
3. enter a value for name filter
4. check that expected matches are displayed.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1477]: https://breedinginsight.atlassian.net/browse/BI-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ