### PR TITLE
bug/BI-1620 - Program Selection page doesn't show all programs if more than 50 exist

### DIFF
--- a/src/breeding-insight/service/ProgramService.ts
+++ b/src/breeding-insight/service/ProgramService.ts
@@ -96,7 +96,8 @@ export class ProgramService {
     }));
   }
 
-  static getAll(paginationQuery: PaginationQuery = new PaginationQuery(1, 50, true),
+  // the PaginationQuery 'showAll' is not being honored by the ProgramDAO.getAll() method.  So, for now, the pageSize default is set to 1000 (instead of 50)
+  static getAll(paginationQuery: PaginationQuery = new PaginationQuery(1, 1000, true),
                 sort: ProgramSort = new ProgramSort(ProgramSortField.Name, SortOrder.Ascending)): Promise<[Program[], Metadata]> {
     return new Promise<[Program[], Metadata]>(((resolve, reject) => {
 


### PR DESCRIPTION
# Description
[BI-1620](https://breedinginsight.atlassian.net/browse/BI-1620) Program Selection page doesn't show all programs if more than 50 exist

_Please include a summary of the change that was made._
Program Selection page now shows up to 1000-programs



# Dependencies
br-api : develop branch

# Testing

1.  GIVEN there are at least 50 active programs.
2. WHEN log in with a user-account that has at least 20 active programs (or the System Admin)
3. THEN on the Welcome screen, you should see all the programs listed( see screen capture below).

<img width="487" alt="Screen Shot 2023-02-06 at 10 20 49 AM" src="https://user-images.githubusercontent.com/7815559/217011625-4a880327-2889-4e04-80bb-a9af4e13175f.png">

4. WHEN the user navigates to select a new program in the upper right hand corner (see screen capture below)
5. THEN all of the programs should be listed.

6.  GIVEN the user selects the 'Programs' menu option
<img width="608" alt="Screen Shot 2023-02-06 at 10 21 23 AM" src="https://user-images.githubusercontent.com/7815559/217015562-96f41aeb-fe99-494
<img width="424" alt="Screen Shot 2023-02-06 at 10 41 36 AM" src="https://user-images.githubusercontent.com/7815559/217016894-88a6e254-6884-480d-b996-15afaec6cdfc.png">

7. THEN only the first 50 programs should be visible.
8. GIVEN the user select the the 'Show All' button.
<img width="296" alt="Screen Shot 2023-02-06 at 10 48 04 AM" src="https://user-images.githubusercontent.com/7815559/217018745-88ebe330-6c6e-48d9-9c3a-ec796fd6024e.png">
9. THEN all active programs should be visible. 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1620]: https://breedinginsight.atlassian.net/browse/BI-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ