### PR TITLE
[BI-1707] - renamed shared ontology to configuration

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -65,7 +65,7 @@ import GermplasmByList from "@/views/germplasm/GermplasmByList.vue";
 import GermplasmLists from "@/views/germplasm/GermplasmLists.vue";
 import BreedingMethods from "@/views/germplasm/BreedingMethods.vue";
 import GermplasmDetails from "@/views/germplasm/GermplasmDetails.vue";
-import OntologySharing from "@/views/program/OntologySharing.vue";
+import ProgramConfiguration from "@/views/program/ProgramConfiguration.vue";
 import JobManagement from '@/views/program/JobManagement.vue';
 import GermplasmPedigreesView from "@/components/germplasm/GermplasmPedigreesView.vue";
 import GermplasmGenotypeView from "@/components/germplasm/GermplasmGenotypeView.vue";
@@ -223,13 +223,13 @@ const routes = [
         component: BreedingMethods
       },
       {
-        path: 'ontology-sharing',
-        name: 'ontology-sharing',
+        path: 'configuration',
+        name: 'configuration',
         meta: {
-          title: 'Ontology Sharing',
+          title: 'Configuration',
           layout: layouts.userSideBar
         },
-        component: OntologySharing
+        component: ProgramConfiguration
       }
     ]
   },

--- a/src/views/program/ProgramConfiguration.vue
+++ b/src/views/program/ProgramConfiguration.vue
@@ -16,7 +16,7 @@
   -->
 
 <template>
-  <div id="ontology-sharing">
+  <div id="program-configuration">
       <SharedOntologyConfiguration
           v-on="$listeners"
           class="mb-6"
@@ -51,7 +51,7 @@ import BreedingMethods from "@/views/germplasm/BreedingMethods.vue";
     ])
   }
 })
-export default class OntologySharing extends ProgramsBase {
+export default class ProgramConfiguration extends ProgramsBase {
   // Change tracker to pass to children for refresh
   private subscribeAction: number = 0;
   private shareAction: number = 0;

--- a/src/views/program/ProgramManagement.vue
+++ b/src/views/program/ProgramManagement.vue
@@ -43,9 +43,9 @@
           </router-link>
           <router-link
               v-if="$ability.can('access', 'ProgramConfiguration')"
-              v-bind:to="{name: 'ontology-sharing', params: {programId: activeProgram.id}}"
+              v-bind:to="{name: 'configuration', params: {programId: activeProgram.id}}"
               tag="li" active-class="is-active">
-            <a>Ontology Sharing</a>
+            <a>Configuration</a>
           </router-link>
         </ul>
       </nav>


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1707

Renamed Ontology Sharing tab to Configuration in Program Management.
Because this tab will eventually contain more than Ontology Sharing, I renamed the `OntologySharing` component to `ProgramConfiguration`.

# Dependencies

I updated TAF to account for the changes, [TAF PR](https://github.com/Breeding-Insight/taf/pull/109). Should be merged concurrently.

# Testing

If you want to run TAF locally, checkout the [feature/BI-1707 branch of TAF](https://github.com/Breeding-Insight/taf/tree/feature/BI-1707) and run TAF with `--tags @BI-1502` to test the Configuration feature.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/4680700733
