### PR TITLE
BI-1617 bug - sorting on ontology method is broken

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -54,7 +54,7 @@ export enum TraitSortField {
 // ontology
 export enum OntologySortField {
   Name = 'name',
-  MethodDescription = 'methodDescription',
+  MethodHandle = 'methodHandle',
   ScaleClass = 'scaleClass',
   ScaleName = 'scaleName',
   entityAttributeSortLabel = 'entityAttribute',

--- a/src/components/tables/PaginationControls.vue
+++ b/src/components/tables/PaginationControls.vue
@@ -118,8 +118,9 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
     }
 
     changePageSize($event:any) {
-      this.pagination.pageSize = Number.parseInt($event.target.value);
-      this.$emit('paginate-page-size', $event.target.value)
+      const pageSize = Number.parseInt($event.target.value);
+      this.pagination.pageSize = pageSize;
+      this.$emit('paginate-page-size', pageSize);
       this.showAllState = false;
       this.setDisplayPageSize();
     }

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -228,7 +228,7 @@ export default class TraitsImportTable extends Vue {
 
   // table column sorting
   private nameSortLabel: string = OntologySortField.Name;
-  private methodSortLabel: string = OntologySortField.MethodDescription;
+  private methodSortLabel: string = OntologySortField.MethodHandle;
   private scaleClassSortLabel: string = OntologySortField.ScaleClass;
   private unitSortLabel: string = OntologySortField.ScaleName;
   private entityAttributeSortLabel: string = OntologySortField.entityAttributeSortLabel;


### PR DESCRIPTION
# Description
**Story:** [BI-1617](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1617)

`OntologySortField` enum was changed from methodDescription to methodHandle.



# Dependencies
latest bi-api

# Testing



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1617]: https://breedinginsight.atlassian.net/browse/BI-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ