### PR TITLE
[BI-1238] - made ids unique

### DIFF
--- a/src/components/experiments/ExperimentObservationsDownloadButton.vue
+++ b/src/components/experiments/ExperimentObservationsDownloadButton.vue
@@ -30,12 +30,12 @@
           <div class="field">
             <label
               class="label"
-              for="dataset-select"
+              v-bind:for="`dataset-select-${trialDbId}`"
             ><span>Dataset</span></label>
             <div class="control">
               <div class="select">
                 <select
-                  id="dataset-select"
+                  v-bind:id="`dataset-select-${trialDbId}`"
                   v-model="fileOptions.dataset"
                 >
                   <option
@@ -91,9 +91,8 @@
             </legend>
             <div class="field">
               <input
-                id="timestamps-switch"
+                v-bind:id="`timestamps-switch-${trialDbId}`"
                 v-model="fileOptions.includeTimestamps"
-                style="appearance: none; outline: auto;"
                 type="checkbox"
                 true-value="Yes"
                 false-value="No"
@@ -101,8 +100,8 @@
                 class="switch is-info is-rounded"
               >
               <label
-                id="timestamps-label"
-                for="timestamps-switch"
+                v-bind:id="`timestamps-label-${trialDbId}`"
+                v-bind:for="`timestamps-switch-${trialDbId}`"
               >{{ fileOptions.includeTimestamps }}</label>
             </div>
           </fieldset>


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1238

This is not the main feature, it is a bugfix after the already-merged feature failed QA. The issue was the that first download button on a list view would open its modal and all the controls would work, but subsequent download buttons would open their modals and the toggle switch could not be toggled. This was due to duplicate id attributes.

I made the id attribute of inputs that may appear multiple times on the same page unique.

I created a new task on Jira for a further refactor that I'd like to do that is lower priority: https://breedinginsight.atlassian.net/browse/BI-1800.

# Dependencies & Testing

You may want to check out the bi-api [feature/BI-1238](https://github.com/Breeding-Insight/bi-api/tree/feature/BI-1238) branch which has a dummy controller method for the download.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/4980515195
