### PR TITLE
[BI-1805] - improved communication for in-use methods

### DIFF
--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -18,9 +18,9 @@
 <template>
   <div class="breeding-methods">
     <WarningModal
-        v-bind:active.sync="deleteActive"
-        v-bind:msg-title="'Remove Breeding Method?'"
-        v-on:deactivate="cancelDelete"
+      v-bind:active.sync="deleteActive"
+      v-bind:msg-title="'Remove Breeding Method?'"
+      v-on:deactivate="cancelDelete"
     >
       <section>
         <p class="has-text-dark">
@@ -30,14 +30,14 @@
       <div class="columns">
         <div class="column is-whole has-text-centered buttons">
           <button
-              class="button is-danger"
-              v-on:click="modalDeleteHandler()"
+            class="button is-danger"
+            v-on:click="modalDeleteHandler()"
           >
             <strong>Yes, delete</strong>
           </button>
           <button
-              class="button"
-              v-on:click="cancelDelete"
+            class="button"
+            v-on:click="cancelDelete"
           >
             Cancel
           </button>
@@ -47,18 +47,18 @@
 
     <div class="columns">
       <div class="column is-whole has-text-right buttons">
-<!-- BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated -->
-<!--        <button-->
-<!--            v-if="$ability.can('update', 'ProgramConfiguration')"-->
-<!--            class="button is-primary"-->
-<!--            v-on:click="openModal"-->
-<!--        >-->
-<!--          Choose Predefined Methods-->
-<!--        </button>-->
+        <!-- BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated -->
+        <!--        <button-->
+        <!--            v-if="$ability.can('update', 'ProgramConfiguration')"-->
+        <!--            class="button is-primary"-->
+        <!--            v-on:click="openModal"-->
+        <!--        >-->
+        <!--          Choose Predefined Methods-->
+        <!--        </button>-->
         <button
-            v-if="$ability.can('create', 'ProgramConfiguration')"
-            class="button is-primary"
-            v-on:click="showNewMethod"
+          v-if="$ability.can('create', 'ProgramConfiguration')"
+          class="button is-primary"
+          v-on:click="showNewMethod"
         >
           Create Breeding Method
         </button>
@@ -66,55 +66,55 @@
     </div>
 
     <NewDataForm
-        v-if="newMethodActive"
-        v-bind:row-validations="newMethodValidations"
-        v-bind:new-record.sync="newMethod"
-        v-bind:data-form-state="newMethodFormState"
-        v-on:submit="saveMethod"
-        v-on:cancel="cancelNewMethod"
-        v-on:show-error-notification="$emit('show-error-notification', $event)"
+      v-if="newMethodActive"
+      v-bind:row-validations="newMethodValidations"
+      v-bind:new-record.sync="newMethod"
+      v-bind:data-form-state="newMethodFormState"
+      v-on:submit="saveMethod"
+      v-on:cancel="cancelNewMethod"
+      v-on:show-error-notification="$emit('show-error-notification', $event)"
     >
       <template v-slot="validations">
         <div class="columns">
           <div class="column is-one-fourth">
             <BasicInputField
-                v-model="newMethod.name"
-                v-bind:validations="validations.name"
-                v-bind:field-name="'Name'"
-                v-bind:field-help="''"
+              v-model="newMethod.name"
+              v-bind:validations="validations.name"
+              v-bind:field-name="'Name'"
+              v-bind:field-help="''"
             />
           </div>
           <div class="column is-one-fourth">
             <BasicInputField
-                v-model="newMethod.abbreviation"
-                v-bind:validations="validations.abbreviation"
-                v-bind:field-name="'Abbreviation'"
-                v-bind:field-help="'No more than 3 characters'"
+              v-model="newMethod.abbreviation"
+              v-bind:validations="validations.abbreviation"
+              v-bind:field-name="'Abbreviation'"
+              v-bind:field-help="'No more than 3 characters'"
             />
           </div>
           <div class="column is-one-fourth">
             <BasicInputField
-                v-model="newMethod.description"
-                v-bind:validations="validations.description"
-                v-bind:field-name="'Description'"
+              v-model="newMethod.description"
+              v-bind:validations="validations.description"
+              v-bind:field-name="'Description'"
             />
           </div>
         </div>
         <div class="columns">
           <div class="column is-one-fourth">
             <BasicSelectField
-                v-model="newMethod.category"
-                v-bind:validations="validations.category"
-                v-bind:options="categories"
-                v-bind:field-name="'Category'"
+              v-model="newMethod.category"
+              v-bind:validations="validations.category"
+              v-bind:options="categories"
+              v-bind:field-name="'Category'"
             />
           </div>
           <div class="column is-one-fourth">
             <BasicSelectField
-                v-model="newMethod.geneticDiversity"
-                v-bind:validations="validations.geneticDiversity"
-                v-bind:options="diversities"
-                v-bind:field-name="'Genetic Diversity'"
+              v-model="newMethod.geneticDiversity"
+              v-bind:validations="validations.geneticDiversity"
+              v-bind:options="diversities"
+              v-bind:field-name="'Genetic Diversity'"
             />
           </div>
         </div>
@@ -122,135 +122,192 @@
     </NewDataForm>
 
     <ExpandableTable
-        v-bind:records.sync="programBreedingMethods"
-        v-bind:loading="loading"
-        v-bind:pagination="paginationController"
-        v-bind:default-sort="['data.name', 'asc']"
-        v-bind:debounce-search="400"
-        v-bind:editable="$ability.can('update', 'ProgramConfiguration')"
-        v-bind:row-editable="isRowEditable"
-        v-bind:data-form-state="editMethodFormState"
-        v-bind:row-validations="newMethodValidations"
-        v-bind:archivable="$ability.can('update', 'ProgramConfiguration')"
-        v-bind:row-archivable="isRowArchivable"
-        v-bind:deactivate-link-text="'Delete'"
-        v-on:submit="updateMethod($event)"
-        v-on:show-error-notification="$emit('show-error-notification', $event)"
-        v-on:remove="displayWarning($event)"
+      v-bind:records.sync="programBreedingMethods"
+      v-bind:loading="loading"
+      v-bind:pagination="paginationController"
+      v-bind:default-sort="['data.name', 'asc']"
+      v-bind:debounce-search="400"
+      v-bind:editable="$ability.can('update', 'ProgramConfiguration')"
+      v-bind:row-editable="isRowEditable"
+      v-bind:data-form-state="editMethodFormState"
+      v-bind:row-validations="newMethodValidations"
+      v-bind:archivable="$ability.can('update', 'ProgramConfiguration')"
+      v-bind:row-archivable="isRowArchivable"
+      v-bind:deactivate-link-text="'Delete'"
+      v-on:submit="updateMethod($event)"
+      v-on:show-error-notification="$emit('show-error-notification', $event)"
+      v-on:remove="displayWarning($event)"
     >
-      <b-table-column field="scope" label="Scope" searchable :customSearch="filterByScope" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column
+        field="scope"
+        label="Scope"
+        searchable
+        :custom-search="filterByScope"
+        :th-attrs="(column) => ({scope:'col'})"
+      >
         <template v-slot="props">
-          <span class="tag" :class="progressTagType(props.row.data.programId)">
+          <span
+            class="tag"
+            :class="progressTagType(props.row.data.programId)"
+          >
             {{ formatOwner(props.row.data.programId) }}
           </span>
         </template>
         <template v-slot:searchable="props">
           <div class="select">
             <select
-                v-model="props.filters[props.column.field]"
+              v-model="props.filters[props.column.field]"
+            >
+              <option value="" />
+              <option value="SYSTEM">
+                System
+              </option>
+              <option value="PROGRAM">
+                Program
+              </option>
+            </select>
+          </div>
+        </template>
+      </b-table-column>
+      <b-table-column
+        v-slot="props"
+        field="data.name"
+        label="Name"
+        sortable
+        searchable
+        :th-attrs="(column) => ({scope:'col'})"
+      >
+        {{ props.row.data.name }}
+      </b-table-column>
+      <b-table-column
+        v-slot="props"
+        field="data.abbreviation"
+        label="Abbreviation"
+        sortable
+        searchable
+        :th-attrs="(column) => ({scope:'col'})"
+      >
+        {{ props.row.data.abbreviation }}
+      </b-table-column>
+      <b-table-column
+        v-slot="props"
+        field="data.description"
+        label="Description"
+        sortable
+        searchable
+        :th-attrs="(column) => ({scope:'col'})"
+      >
+        {{ props.row.data.description }}
+      </b-table-column>
+      <b-table-column
+        field="data.category"
+        label="Category"
+        sortable
+        searchable
+        :th-attrs="(column) => ({scope:'col'})"
+      >
+        <template v-slot="props">
+          {{ props.row.data.category }}
+        </template>
+        <template v-slot:searchable="props">
+          <div class="select">
+            <select
+              v-model="props.filters[props.column.field]"
+            >
+              <option value="" />
+              <option
+                v-for="cat in categories"
+                :key="cat"
+                :value="cat"
               >
-              <option value=""></option>
-              <option value="SYSTEM">System</option>
-              <option value="PROGRAM">Program</option>
+                {{ cat }}
+              </option>
             </select>
           </div>
         </template>
       </b-table-column>
-      <b-table-column field="data.name" label="Name" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-        {{ props.row.data.name}}
-      </b-table-column>
-      <b-table-column field="data.abbreviation" label="Abbreviation" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-        {{ props.row.data.abbreviation}}
-      </b-table-column>
-      <b-table-column field="data.description" label="Description" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-        {{ props.row.data.description}}
-      </b-table-column>
-      <b-table-column field="data.category" label="Category" sortable searchable :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column
+        field="data.geneticDiversity"
+        label="Genetic Diversity"
+        sortable
+        searchable
+        :th-attrs="(column) => ({scope:'col'})"
+      >
         <template v-slot="props">
-          {{ props.row.data.category}}
+          {{ props.row.data.geneticDiversity }}
         </template>
         <template v-slot:searchable="props">
           <div class="select">
             <select
-                v-model="props.filters[props.column.field]"
+              v-model="props.filters[props.column.field]"
             >
-              <option value=""></option>
-              <option v-for="cat in categories" :key="cat" :value="cat">{{ cat }}</option>
-            </select>
-          </div>
-        </template>
-      </b-table-column>
-      <b-table-column field="data.geneticDiversity" label="Genetic Diversity" sortable searchable :th-attrs="(column) => ({scope:'col'})">
-        <template v-slot="props">
-          {{ props.row.data.geneticDiversity}}
-        </template>
-        <template v-slot:searchable="props">
-          <div class="select">
-            <select
-                v-model="props.filters[props.column.field]"
-            >
-              <option value=""></option>
-              <option v-for="div in diversities" :key="div" :value="div">{{ div }}</option>
+              <option value="" />
+              <option
+                v-for="div in diversities"
+                :key="div"
+                :value="div"
+              >
+                {{ div }}
+              </option>
             </select>
           </div>
         </template>
       </b-table-column>
 
       <template v-slot:edit="{editData, validations}">
-
         <div v-if="isMethodInUse(editData)">
-              <div class="columns is-vcentered">
-                <div class="column has-text-primary">
-                    <AlertTriangleIcon
-                        size="1.2x"
-                        class="has-vertical-align-middle"
-                    /> Breeding method is in use. Deletion disabled.
-                </div>
-              </div>
+          <div class="columns is-vcentered">
+            <div class="column has-text-primary">
+              <AlertTriangleIcon
+                size="1.2x"
+                class="has-vertical-align-middle"
+              /> Breeding method is in use. Deletion disabled.
+            </div>
+          </div>
         </div>
 
         <div class="columns">
           <div class="column is-one-fourth">
             <BasicInputField
-                v-model="editData.name"
-                v-bind:validations="validations.name"
-                v-bind:field-name="'Name'"
-                v-bind:field-help="''"
+              v-model="editData.name"
+              v-bind:validations="validations.name"
+              v-bind:field-name="'Name'"
+              v-bind:field-help="''"
             />
           </div>
           <div class="column is-one-fourth">
             <BasicInputField
-                v-model="editData.abbreviation"
-                v-bind:validations="validations.abbreviation"
-                v-bind:field-name="'Abbreviation'"
-                v-bind:field-help="'No more than 3 characters'"
+              v-model="editData.abbreviation"
+              v-bind:validations="validations.abbreviation"
+              v-bind:field-name="'Abbreviation'"
+              v-bind:field-help="'No more than 3 characters'"
             />
           </div>
           <div class="column is-one-fourth">
             <BasicInputField
-                v-model="editData.description"
-                v-bind:validations="validations.description"
-                v-bind:field-name="'Description'"
+              v-model="editData.description"
+              v-bind:validations="validations.description"
+              v-bind:field-name="'Description'"
             />
           </div>
         </div>
         <div class="columns">
           <div class="column is-one-fourth">
             <BasicSelectField
-                v-model="editData.category"
-                v-bind:selected-id="editData.category"
-                v-bind:validations="validations.category"
-                v-bind:options="categories"
-                v-bind:field-name="'Category'"
+              v-model="editData.category"
+              v-bind:selected-id="editData.category"
+              v-bind:validations="validations.category"
+              v-bind:options="categories"
+              v-bind:field-name="'Category'"
             />
           </div>
           <div class="column is-one-fourth">
             <BasicSelectField
-                v-model="editData.geneticDiversity"
-                v-bind:selected-id="editData.geneticDiversity"
-                v-bind:validations="validations.geneticDiversity"
-                v-bind:options="diversities"
-                v-bind:field-name="'Genetic Diversity'"
+              v-model="editData.geneticDiversity"
+              v-bind:selected-id="editData.geneticDiversity"
+              v-bind:validations="validations.geneticDiversity"
+              v-bind:options="diversities"
+              v-bind:field-name="'Genetic Diversity'"
             />
           </div>
         </div>
@@ -262,93 +319,93 @@
         </p>
       </template>
     </ExpandableTable>
-<!-- BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated -->
-<!--    <GenericModal-->
-<!--        v-bind:active.sync="showEnableSystemMethods"-->
-<!--        v-bind:msg-title="'Enable/Disable Predefined Breeding Methods'"-->
-<!--        v-on:deactivate="showEnableSystemMethods = false"-->
-<!--        v-bind:modalClass="'enable-system-methods'"-->
-<!--    >-->
-<!--      <div v-if="inUseBreedingMethods.length > 0">-->
-<!--        <article class="message is-warning">-->
-<!--          <div class="message-body">-->
-<!--            <div class="columns is-vcentered">-->
-<!--              <div class="column">-->
-<!--                <div class="has-text-dark">-->
-<!--                  <AlertTriangleIcon-->
-<!--                      size="1x"-->
-<!--                      class="has-vertical-align-middle"-->
-<!--                  /> Some breeding methods cannot be deactivated because there are germplasm records using those methods in {{activeProgram.name}}-->
-<!--                </div>-->
-<!--              </div>-->
-<!--            </div>-->
-<!--          </div>-->
-<!--        </article>-->
-<!--      </div>-->
-<!--      <ExpandableTable-->
-<!--          v-bind:records.sync="systemBreedingMethods"-->
-<!--          v-bind:pagination="systemPaginationController"-->
-<!--          v-bind:default-sort="['data.name', 'asc']"-->
-<!--          v-bind:debounce-search="400"-->
-<!--          :checked-rows.sync="programEnabledSystemMethods"-->
-<!--          :custom-is-checked="shouldCheck"-->
-<!--          checkable-->
-<!--          :checkbox-position="'left'"-->
-<!--          :checkbox-type="'is-primary'"-->
-<!--          :is-row-checkable="row => !isMethodInUse(row.data)"-->
-<!--      >-->
-<!--        <b-table-column field="data.name" label="Name" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">-->
-<!--          {{ props.row.data.name}}-->
-<!--        </b-table-column>-->
-<!--        <b-table-column field="data.abbreviation" label="Abbreviation" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">-->
-<!--          {{ props.row.data.abbreviation}}-->
-<!--        </b-table-column>-->
-<!--        <b-table-column field="data.description" label="Description" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">-->
-<!--          {{ props.row.data.description}}-->
-<!--        </b-table-column>-->
-<!--        <b-table-column field="data.category" label="Category" sortable searchable :th-attrs="(column) => ({scope:'col'})">-->
-<!--          <template v-slot="props">-->
-<!--            {{ props.row.data.category}}-->
-<!--          </template>-->
-<!--          <template v-slot:searchable="props">-->
-<!--            <div class="select">-->
-<!--              <select-->
-<!--                  v-model="props.filters[props.column.field]"-->
-<!--              >-->
-<!--                <option value=""></option>-->
-<!--                <option v-for="cat in categories" :key="cat" :value="cat">{{ cat }}</option>-->
-<!--              </select>-->
-<!--            </div>-->
-<!--          </template>-->
-<!--        </b-table-column>-->
-<!--        <b-table-column field="data.geneticDiversity" label="Genetic Diversity" sortable searchable :th-attrs="(column) => ({scope:'col'})">-->
-<!--          <template v-slot="props">-->
-<!--            {{ props.row.data.geneticDiversity}}-->
-<!--          </template>-->
-<!--          <template v-slot:searchable="props">-->
-<!--            <div class="select">-->
-<!--              <select-->
-<!--                  v-model="props.filters[props.column.field]"-->
-<!--              >-->
-<!--                <option value=""></option>-->
-<!--                <option v-for="div in diversities" :key="div" :value="div">{{ div }}</option>-->
-<!--              </select>-->
-<!--            </div>-->
-<!--          </template>-->
-<!--        </b-table-column>-->
+    <!-- BI-1779 - Removing the ability to choose predefined methods for a program until we make the germplasm import template dynamically generated -->
+    <!--    <GenericModal-->
+    <!--        v-bind:active.sync="showEnableSystemMethods"-->
+    <!--        v-bind:msg-title="'Enable/Disable Predefined Breeding Methods'"-->
+    <!--        v-on:deactivate="showEnableSystemMethods = false"-->
+    <!--        v-bind:modalClass="'enable-system-methods'"-->
+    <!--    >-->
+    <!--      <div v-if="inUseBreedingMethods.length > 0">-->
+    <!--        <article class="message is-warning">-->
+    <!--          <div class="message-body">-->
+    <!--            <div class="columns is-vcentered">-->
+    <!--              <div class="column">-->
+    <!--                <div class="has-text-dark">-->
+    <!--                  <AlertTriangleIcon-->
+    <!--                      size="1x"-->
+    <!--                      class="has-vertical-align-middle"-->
+    <!--                  /> Some breeding methods cannot be deactivated because there are germplasm records using those methods in {{activeProgram.name}}-->
+    <!--                </div>-->
+    <!--              </div>-->
+    <!--            </div>-->
+    <!--          </div>-->
+    <!--        </article>-->
+    <!--      </div>-->
+    <!--      <ExpandableTable-->
+    <!--          v-bind:records.sync="systemBreedingMethods"-->
+    <!--          v-bind:pagination="systemPaginationController"-->
+    <!--          v-bind:default-sort="['data.name', 'asc']"-->
+    <!--          v-bind:debounce-search="400"-->
+    <!--          :checked-rows.sync="programEnabledSystemMethods"-->
+    <!--          :custom-is-checked="shouldCheck"-->
+    <!--          checkable-->
+    <!--          :checkbox-position="'left'"-->
+    <!--          :checkbox-type="'is-primary'"-->
+    <!--          :is-row-checkable="row => !isMethodInUse(row.data)"-->
+    <!--      >-->
+    <!--        <b-table-column field="data.name" label="Name" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">-->
+    <!--          {{ props.row.data.name}}-->
+    <!--        </b-table-column>-->
+    <!--        <b-table-column field="data.abbreviation" label="Abbreviation" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">-->
+    <!--          {{ props.row.data.abbreviation}}-->
+    <!--        </b-table-column>-->
+    <!--        <b-table-column field="data.description" label="Description" sortable searchable v-slot="props" :th-attrs="(column) => ({scope:'col'})">-->
+    <!--          {{ props.row.data.description}}-->
+    <!--        </b-table-column>-->
+    <!--        <b-table-column field="data.category" label="Category" sortable searchable :th-attrs="(column) => ({scope:'col'})">-->
+    <!--          <template v-slot="props">-->
+    <!--            {{ props.row.data.category}}-->
+    <!--          </template>-->
+    <!--          <template v-slot:searchable="props">-->
+    <!--            <div class="select">-->
+    <!--              <select-->
+    <!--                  v-model="props.filters[props.column.field]"-->
+    <!--              >-->
+    <!--                <option value=""></option>-->
+    <!--                <option v-for="cat in categories" :key="cat" :value="cat">{{ cat }}</option>-->
+    <!--              </select>-->
+    <!--            </div>-->
+    <!--          </template>-->
+    <!--        </b-table-column>-->
+    <!--        <b-table-column field="data.geneticDiversity" label="Genetic Diversity" sortable searchable :th-attrs="(column) => ({scope:'col'})">-->
+    <!--          <template v-slot="props">-->
+    <!--            {{ props.row.data.geneticDiversity}}-->
+    <!--          </template>-->
+    <!--          <template v-slot:searchable="props">-->
+    <!--            <div class="select">-->
+    <!--              <select-->
+    <!--                  v-model="props.filters[props.column.field]"-->
+    <!--              >-->
+    <!--                <option value=""></option>-->
+    <!--                <option v-for="div in diversities" :key="div" :value="div">{{ div }}</option>-->
+    <!--              </select>-->
+    <!--            </div>-->
+    <!--          </template>-->
+    <!--        </b-table-column>-->
 
-<!--        <template v-slot:emptyMessage>-->
-<!--          <p class="has-text-weight-bold">-->
-<!--            No breeding methods exist-->
-<!--          </p>-->
-<!--        </template>-->
-<!--      </ExpandableTable>-->
+    <!--        <template v-slot:emptyMessage>-->
+    <!--          <p class="has-text-weight-bold">-->
+    <!--            No breeding methods exist-->
+    <!--          </p>-->
+    <!--        </template>-->
+    <!--      </ExpandableTable>-->
 
-<!--      <template v-slot:footer>-->
-<!--        <button class="button is-success" :class="{'is-loading': savingSystemMethods}" v-on:click="saveEnabledMethods">Save changes</button>-->
-<!--        <button class="button" v-on:click="showEnableSystemMethods = false">Cancel</button>-->
-<!--      </template>-->
-<!--    </GenericModal>-->
+    <!--      <template v-slot:footer>-->
+    <!--        <button class="button is-success" :class="{'is-loading': savingSystemMethods}" v-on:click="saveEnabledMethods">Save changes</button>-->
+    <!--        <button class="button" v-on:click="showEnableSystemMethods = false">Cancel</button>-->
+    <!--      </template>-->
+    <!--    </GenericModal>-->
   </div>
 </template>
 

--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -121,23 +121,6 @@
       </template>
     </NewDataForm>
 
-    <div v-if="$ability.can('update', 'ProgramConfiguration') && inUseBreedingMethods.length > 0">
-      <article class="message is-warning">
-        <div class="message-body">
-          <div class="columns is-vcentered">
-            <div class="column">
-              <div class="has-text-dark">
-                <AlertTriangleIcon
-                    size="1x"
-                    class="has-vertical-align-middle"
-                /> Some breeding methods cannot be edited because there are germplasm records using those methods in {{activeProgram.name}}
-              </div>
-            </div>
-          </div>
-        </div>
-      </article>
-    </div>
-
     <ExpandableTable
         v-bind:records.sync="programBreedingMethods"
         v-bind:loading="loading"
@@ -214,6 +197,18 @@
       </b-table-column>
 
       <template v-slot:edit="{editData, validations}">
+
+        <div v-if="isMethodInUse(editData)">
+              <div class="columns is-vcentered">
+                <div class="column has-text-primary">
+                    <AlertTriangleIcon
+                        size="1.2x"
+                        class="has-vertical-align-middle"
+                    /> Breeding method is in use. Deletion disabled.
+                </div>
+              </div>
+        </div>
+
         <div class="columns">
           <div class="column is-one-fourth">
             <BasicInputField

--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -257,7 +257,7 @@
       <template v-slot:edit="{editData, validations}">
         <div v-if="isMethodInUse(editData)">
           <div class="columns is-vcentered">
-            <div class="column has-text-primary">
+            <div class="column has-text-grey-dark">
               <AlertTriangleIcon
                 size="1.2x"
                 class="has-vertical-align-middle"

--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -16,7 +16,7 @@
   -->
 
 <template>
-  <div class="breeding-methods">
+  <div id="breeding-methods">
     <WarningModal
       v-bind:active.sync="deleteActive"
       v-bind:msg-title="'Remove Breeding Method?'"
@@ -257,7 +257,10 @@
       <template v-slot:edit="{editData, validations}">
         <div v-if="isMethodInUse(editData)">
           <div class="columns is-vcentered">
-            <div class="column has-text-grey-dark">
+            <div
+              id="method-in-use-message"
+              class="column has-text-grey-dark"
+            >
               <AlertTriangleIcon
                 size="1.2x"
                 class="has-vertical-align-middle"


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1805

Removed the warning message above the list view that was visible when there were Program-scoped Breeding Methods that were in use. 
![Old message, which has been removed.](https://github.com/Breeding-Insight/bi-web/assets/128052931/f2246467-6489-4b4f-b3ae-524e5efe4543)

Added an informational message at the top of each edit form for Program-scoped Breeding Methods that are in use. 
<img width="1120" alt="New message." src="https://github.com/Breeding-Insight/bi-web/assets/128052931/a9212f20-4f96-4ee8-8181-b85c1855d3ef">

# Testing
Only applies to Program-scoped Breeding Methods, so create some for Testing. Then, upload Germplasm using the abbreviation you defined in the Breeding Method column of the upload file. You should be able to see the informational message "Breeding method is in use. Deletion disabled." after expanding the edit view of a Program-scoped Breeding Method that is in use.

TAF coverage: https://github.com/Breeding-Insight/taf/pull/113

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: [TAF develop branch run](https://github.com/Breeding-Insight/taf/actions/runs/5158654406), [TAF feature/BI-1805 branch run](https://github.com/Breeding-Insight/taf/actions/runs/5204220746)
