### PR TITLE
Feature/bi 1618 - Import File Selection Behavior

### DIFF
--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -48,6 +48,7 @@
         <MultipleErrors
             v-bind:formatted-errors="allErrors"
             v-bind:is-validation-error="isValidationError"
+            v-bind:file-name="fileName"
         />
       </article>
     </div>
@@ -99,6 +100,14 @@
 
     get isValidationError(): boolean {
       return this.errors instanceof ValidationError;
+    }
+
+    get fileName(): string{
+      if(this.file) {
+        return this.file.name;
+      }
+      else { return "FILE IS NULL";}
+
     }
 
     get allErrors(): ImportError[] {

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -48,7 +48,6 @@
         <MultipleErrors
             v-bind:formatted-errors="allErrors"
             v-bind:is-validation-error="isValidationError"
-            v-bind:file-name="fileName"
         />
       </article>
     </div>
@@ -100,14 +99,6 @@
 
     get isValidationError(): boolean {
       return this.errors instanceof ValidationError;
-    }
-
-    get fileName(): string{
-      if(this.file) {
-        return this.file.name;
-      }
-      else { return "FILE IS NULL";}
-
     }
 
     get allErrors(): ImportError[] {

--- a/src/components/file-import/FileSelectMessageBox.vue
+++ b/src/components/file-import/FileSelectMessageBox.vue
@@ -40,7 +40,7 @@
           <div class="level-right">
             <div class="level-item">
               <div>
-                <a v-if="file" class="button is-primary has-text-weight-bold" :id="importButtonId" v-on:click="$emit('import')">Import</a>
+                <a v-if="file" class="button is-primary has-text-weight-bold" :id="importButtonId" v-on:click="$emit('import')">Upload & Validate</a>
               </div>
             </div>
           </div>

--- a/src/components/file-import/MultipleErrors.vue
+++ b/src/components/file-import/MultipleErrors.vue
@@ -57,8 +57,6 @@ export default class MultipleErrors extends Vue {
   private isValidationError!: boolean;
   @Prop({default: () => 10})
   private numDisplayedErrors!: number;
-  @Prop( {default: () => "dave"})
-  private fileName!:string;
 
   private paginationController: PaginationController = new PaginationController();
   private errorsLoading: Boolean = false;

--- a/src/components/file-import/MultipleErrors.vue
+++ b/src/components/file-import/MultipleErrors.vue
@@ -57,6 +57,8 @@ export default class MultipleErrors extends Vue {
   private isValidationError!: boolean;
   @Prop({default: () => 10})
   private numDisplayedErrors!: number;
+  @Prop( {default: () => "dave"})
+  private fileName!:string;
 
   private paginationController: PaginationController = new PaginationController();
   private errorsLoading: Boolean = false;

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -193,6 +193,7 @@ export default class ImportTemplate extends ProgramsBase {
   private previewTotalRows: number = 0;
   private newObjectCounts: any = [];
   private dynamicColumns: string[] | undefined = [];
+  private errorFileName: string = "BLANK";
 
   private file : File | null = null;
   private import_errors: ValidationError | String | null = null;
@@ -263,6 +264,7 @@ export default class ImportTemplate extends ProgramsBase {
             }
           },
           [ImportState.IMPORT_ERROR]: {
+            entry: ImportAction.RESET,
             on: {
               [ImportEvent.IMPORT_STARTED]: ImportState.IMPORTING
             }
@@ -311,8 +313,9 @@ export default class ImportTemplate extends ProgramsBase {
 
   @Watch('file')
   onFileChanged(value: string, oldValue: string) {
+    this.errorFileName = value.name;
     if (oldValue === null && value !== null) {
-      this.importService.send(ImportEvent.FILE_SELECTED);
+       this.importService.send(ImportEvent.FILE_SELECTED);
     }
   }
 
@@ -323,6 +326,7 @@ export default class ImportTemplate extends ProgramsBase {
   async upload() {
     //New button submit, clear prior notifications
     this.$store.commit( DEACTIVATE_ALL_NOTIFICATIONS );
+    console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,1.");
 
     try {
       await this.getSystemImportTemplateMapping();
@@ -339,12 +343,17 @@ export default class ImportTemplate extends ProgramsBase {
         }
         this.importService.send(ImportEvent.IMPORT_ERROR);
       }
+      console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,end.");
+
       // this.importService.send(ImportEvent.IMPORT_SUCCESS) is in getDataUpload()
     } catch(e) {
       if (e.response && e.response.status == 422 && e.response.data && e.response.data.rowErrors) {
+        console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,2.");
         this.import_errors = ValidationErrorService.parseError(e);
         this.importService.send(ImportEvent.IMPORT_ERROR);
+        this.$emit('show-error-notification',"Multiple errors in file, "+this.errorFileName+".  See below....." );
       } else if (e.response && e.response.status == 422 && e.response.statusText) {
+        console.log("......show error......" + e.response.statusText);
         this.$log.error(e);
         this.$emit('show-error-notification', e.response.statusText);
       } else if (e.response.status == 400 && e.response && e.response.data && e.response.data.message) {
@@ -357,6 +366,7 @@ export default class ImportTemplate extends ProgramsBase {
 
       this.importService.send(ImportEvent.IMPORT_ERROR);
     }
+
   }
 
   handleAbortEvent() {

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -313,7 +313,6 @@ export default class ImportTemplate extends ProgramsBase {
 
   @Watch('file')
   onFileChanged(value: string, oldValue: string) {
-    this.errorFileName = value.name;
     if (oldValue === null && value !== null) {
        this.importService.send(ImportEvent.FILE_SELECTED);
     }
@@ -333,13 +332,21 @@ export default class ImportTemplate extends ProgramsBase {
       this.import_errors=null;
       await this.uploadData();
       const response: ImportResponse = await this.updateDataUpload(this.currentImport!.importId!, false);
+      console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,1.2");
+
       if (response.progress!.statuscode == 500) {
         this.$emit('show-error-notification', 'An unknown error has occurred when processing your import.');
         this.importService.send(ImportEvent.IMPORT_ERROR);
       } else if (response.progress!.statuscode != 200) {
+        console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,1.3");
+        console.log(response);
         this.import_errors = ImportService.parseError(response);
-        if( this.import_errors==null) {
-          this.$emit('show-error-notification', `Errors: ${response!.progress!.message!}`);
+        console.log( this.import_errors );
+
+        console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,1.4");
+
+        if (response!.progress!.message!) {
+          this.$emit('show-error-notification', `Errors in ${this.file.name}: ${response!.progress!.message!}`);
         }
         this.importService.send(ImportEvent.IMPORT_ERROR);
       }
@@ -349,9 +356,10 @@ export default class ImportTemplate extends ProgramsBase {
     } catch(e) {
       if (e.response && e.response.status == 422 && e.response.data && e.response.data.rowErrors) {
         console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,2.");
+        console.log(e.response);
         this.import_errors = ValidationErrorService.parseError(e);
         this.importService.send(ImportEvent.IMPORT_ERROR);
-        this.$emit('show-error-notification',"Multiple errors in file, "+this.errorFileName+".  See below....." );
+        this.$emit('show-error-notification',"Multiple errors in file " +this.errorFileName+ ", See below....." );
       } else if (e.response && e.response.status == 422 && e.response.statusText) {
         console.log("......show error......" + e.response.statusText);
         this.$log.error(e);
@@ -439,6 +447,9 @@ export default class ImportTemplate extends ProgramsBase {
   }
 
   reset() {
+    console.log("file");
+    console.log(this.file);
+    this.errorFileName = this.file.name;
     this.file = null;
     this.tableLoaded = false;
   }

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -345,9 +345,7 @@ export default class ImportTemplate extends ProgramsBase {
 
         console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,1.4");
 
-        if (response!.progress!.message!) {
-          this.$emit('show-error-notification', `Errors in ${this.file.name}: ${response!.progress!.message!}`);
-        }
+        this.$emit('show-error-notification', `Error(s) detected in file, ${this.file.name}. (See details below.) Import cannot proceed.`);
         this.importService.send(ImportEvent.IMPORT_ERROR);
       }
       console.log("I'm here,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,end.");
@@ -359,7 +357,7 @@ export default class ImportTemplate extends ProgramsBase {
         console.log(e.response);
         this.import_errors = ValidationErrorService.parseError(e);
         this.importService.send(ImportEvent.IMPORT_ERROR);
-        this.$emit('show-error-notification',"Multiple errors in file " +this.errorFileName+ ", See below....." );
+        this.$emit('show-error-notification',"Error(s) detected in file, " +this.errorFileName+ ". (See details below.) Import cannot proceed." );
       } else if (e.response && e.response.status == 422 && e.response.statusText) {
         console.log("......show error......" + e.response.statusText);
         this.$log.error(e);

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -44,9 +44,6 @@
         </div>
       </div>
     </WarningModal>
-    HI........
-    {{state}}
-    there.......
     <template v-if="state === ImportState.CHOOSE_FILE || state === ImportState.FILE_CHOSEN">
       <h1 class="title" v-if="showTitle">Import Ontology</h1>
       <ImportInfoTemplateMessageBox v-bind:import-type-name="'Ontology'"

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -86,7 +86,7 @@
         <br/>Prepare ontology information for import using the provided template.
       </ImportInfoTemplateMessageBox>
         <div class="box">
-          <FileSelectMessageBox v-model="undefined"
+          <FileSelectMessageBox v-model="file"
                                 v-bind:fileTypes="'.csv, .xls, .xlsx'"
                                 v-bind:errors="import_errors"
                                 v-on:import="importService.send(ImportEvent.IMPORT_STARTED)"/>
@@ -236,6 +236,7 @@ export default class TraitsImport extends ProgramsBase {
         }
       },
       [ImportState.IMPORT_ERROR]: {
+        entry: ImportAction.RESET,
         on: {
           [ImportEvent.IMPORT_STARTED]: ImportState.IMPORTING
         }
@@ -305,6 +306,7 @@ export default class TraitsImport extends ProgramsBase {
       this.importService.send(ImportEvent.IMPORT_SUCCESS);
     }).catch((error: ValidationError | AxiosResponse) => {
       this.import_errors = error;
+      this.$emit('show-error-notification', `Error(s) detected in file, ${this.file.name} . (See details below.) Import cannot proceed.`);
       this.importService.send(ImportEvent.IMPORT_ERROR);
     });
   }

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -44,7 +44,9 @@
         </div>
       </div>
     </WarningModal>
-
+    HI........
+    {{state}}
+    there.......
     <template v-if="state === ImportState.CHOOSE_FILE || state === ImportState.FILE_CHOSEN">
       <h1 class="title" v-if="showTitle">Import Ontology</h1>
       <ImportInfoTemplateMessageBox v-bind:import-type-name="'Ontology'"
@@ -87,7 +89,7 @@
         <br/>Prepare ontology information for import using the provided template.
       </ImportInfoTemplateMessageBox>
         <div class="box">
-          <FileSelectMessageBox v-model="file"
+          <FileSelectMessageBox v-model="undefined"
                                 v-bind:fileTypes="'.csv, .xls, .xlsx'"
                                 v-bind:errors="import_errors"
                                 v-on:import="importService.send(ImportEvent.IMPORT_STARTED)"/>


### PR DESCRIPTION
# Description
[BI-1618 ](https://breedinginsight.atlassian.net/browse/BI-1618)- Import File Selection Behavior

- To satisfy requirement 1 --  the button wording was changed in _FileSelectMessageBox.vue_
- To satisfy requirement 2 -- In _views/import/ImportTemplate.vue_ and _views/trait/TraitsImport.vue_ the ImportAction.RESET is called to set this.file to null.  
- To satisfy requirement 3 -- All import errors will now result in an error-banner on the top of the page (If the error-banner was appearing before this release, it will still appear, but with the improved verbiage.  If there was no error-banner before this release, now it will now appear, as well as the errors as they were previously presented)


# Dependencies
**bi-api:**  feature/BI-1618

# Testing
Import files into Germplasm, Ontology, and Experiments.  One file for each type of error:
1. Improperly formatted (ex. missing expected columns)
2. Missing required data elements
3. Other errors


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: _\<link to TAF run>_
