### PR TITLE
BI-1799 - Disable Germplasm Show All

### DIFF
--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -148,6 +148,7 @@ export default class GermplasmTable extends Vue {
       .reduce((obj, key) => Object.assign({}, obj, { [this.fieldMap[key]]: key }), {});
 
   mounted() {
+    this.paginationController.pageSize = 200
     this.germplasmCallStack = new CallStack(this.germplasmFetch(
         this.activeProgram!.id!,
         this.germplasmSort,

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -11,6 +11,7 @@
         v-on:sort="setSort"
         v-on:search="initSearch"
         v-bind:search-debounce="400"
+        v-bind:is-show-all-enabled="false"
     >
       <b-table-column v-if="entryNumberVisible" field="importEntryNumber" label="Entry Number" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ GermplasmUtils.getEntryNumber(props.row.data, referenceId) }}

--- a/src/components/tables/PaginationControls.vue
+++ b/src/components/tables/PaginationControls.vue
@@ -66,6 +66,7 @@
         </div>
 
         <button
+            v-if="isShowAllEnabled"
             data-testid="showAll"
             role="button"
             class="pagination-link show-all-button"
@@ -91,6 +92,8 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
     @Prop()
     private pagination!: Pagination;
+    @Prop({default: true})
+    private isShowAllEnabled!: boolean;
 
     private showAllState = false;
 

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -151,6 +151,8 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   searchDebounce!: number;
   @Prop({default: "Deactivate"})
   deactivateLinkText?: string;
+  @Prop({default: true})
+  isShowAllEnabled!: boolean;
 
   private tableRows: Array<TableRow<any>> = new Array<TableRow<any>>();
   private openDetail: Array<TableRow<any>> = new Array<TableRow<any>>();


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1799

I added a prop to `ExpandableTable` and `PaginationControls` to conditionally enable the "Show All" button. It defaults to `true`, I passed `false` in `GermlpasmTable` in order to disable it.

I made the default page size 200 in `GermplasmTable`.

# Testing
Import a large Germplasm file, make sure the default page size on the Germplasm view is 200 and the "Show All" button is not available.

Also, ensure that the other tables that use `ExpandableTable` haven't been broken.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: develop branch of TAF (fail) https://github.com/Breeding-Insight/taf/actions/runs/5870921436, bug/BI-1799 branch of TAF (pass) https://github.com/Breeding-Insight/taf/actions/runs/5931166625
