### PR TITLE
BI-1845 - add listType parameter to /lists GET calls

### DIFF
--- a/src/breeding-insight/dao/GermplasmDAO.ts
+++ b/src/breeding-insight/dao/GermplasmDAO.ts
@@ -20,6 +20,7 @@ import * as api from "@/util/api";
 import {PaginationQuery} from "@/breeding-insight/model/PaginationQuery";
 import {Result, ResultGenerator} from "@/breeding-insight/model/Result";
 import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
+import {ListType} from "@/util/ListType";
 
 export class GermplasmDAO {
 
@@ -29,8 +30,7 @@ export class GermplasmDAO {
         config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/brapi/v2/lists`;
         config.method = 'get';
         config.programId = programId;
-        // TODO: make listType enum in ../utils folder.
-        config.params = {listType: 'germplasm'};
+        config.params = {listType: ListType.Germplasm};
         if (paginationQuery.page) config.params.page = paginationQuery.page - 1;
         if (paginationQuery.pageSize) config.params.pageSize = paginationQuery.pageSize;
 

--- a/src/breeding-insight/dao/GermplasmDAO.ts
+++ b/src/breeding-insight/dao/GermplasmDAO.ts
@@ -29,7 +29,8 @@ export class GermplasmDAO {
         config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/brapi/v2/lists`;
         config.method = 'get';
         config.programId = programId;
-        config.params = {};
+        // TODO: make listType enum in ../utils folder.
+        config.params = {listType: 'germplasm'};
         if (paginationQuery.page) config.params.page = paginationQuery.page - 1;
         if (paginationQuery.pageSize) config.params.pageSize = paginationQuery.pageSize;
 

--- a/src/util/ListType.ts
+++ b/src/util/ListType.ts
@@ -1,0 +1,20 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum ListType {
+    Germplasm = "germplasm",
+}

--- a/src/views/germplasm/GermplasmLists.vue
+++ b/src/views/germplasm/GermplasmLists.vue
@@ -44,7 +44,7 @@ export default class GermplasmLists extends ProgramsBase {
   private germplasmListFetch: (programId: string, sort: GermplasmListSort, paginationController: PaginationController) => ((filters: any) => Promise<BiResponse>) =
       function (programId: string, sort: GermplasmListSort, paginationController: PaginationController) {
         return function (filters: any) {
-          filters.type='germplasm';
+          filters.listType='germplasm';
           return BrAPIService.get<GermplasmListSortField>(
               BrAPIType.LIST,
               programId,

--- a/src/views/germplasm/GermplasmLists.vue
+++ b/src/views/germplasm/GermplasmLists.vue
@@ -34,6 +34,7 @@ import {GermplasmListSort, GermplasmListSortField} from "@/breeding-insight/mode
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {BiResponse} from "@/breeding-insight/model/BiResponse";
 import {BrAPIService, BrAPIType} from "@/breeding-insight/service/BrAPIService";
+import {ListType} from "@/util/ListType";
 @Component({
   components: {
     GermplasmListsTable
@@ -44,7 +45,7 @@ export default class GermplasmLists extends ProgramsBase {
   private germplasmListFetch: (programId: string, sort: GermplasmListSort, paginationController: PaginationController) => ((filters: any) => Promise<BiResponse>) =
       function (programId: string, sort: GermplasmListSort, paginationController: PaginationController) {
         return function (filters: any) {
-          filters.listType='germplasm';
+          filters.listType=ListType.Germplasm;
           return BrAPIService.get<GermplasmListSortField>(
               BrAPIType.LIST,
               programId,


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1845

Updated all GET calls to the /lists endpoint to include the `listType` parameter.

# Dependencies
https://github.com/Breeding-Insight/bi-api/pull/284

# Testing
Checkout the bi-api feature/BI-1845 branch as well for testing.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/5931132862
