### PR TITLE
BI-1821 - Experiment import/download buttons wrong color

### DIFF
--- a/src/breeding-insight/model/ActionMenuItem.ts
+++ b/src/breeding-insight/model/ActionMenuItem.ts
@@ -1,0 +1,28 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class ActionMenuItem {
+    id?: string;
+    event?: string;
+    label?: string;
+
+    constructor(id?:string, event?:string, label?:string) {
+        this.id = id;
+        this.event = event;
+        this.label = label;
+    }
+}

--- a/src/components/DownloadModal.vue
+++ b/src/components/DownloadModal.vue
@@ -1,0 +1,93 @@
+<!--
+- See the NOTICE file distributed with this work for additional information
+- regarding copyright ownership.
+-
+- Licensed under the Apache License, Version 2.0 (the "License");
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-->
+
+<template>
+  <section
+    v-bind:id="'downloadModal-' + uniqueId"
+    v-bind:class="modalClass"
+  >
+    <FormModal
+      v-bind:active.sync="active"
+      v-bind:title="modalTitle"
+      v-on:deactivate="closeDownloadModal"
+    >
+      <template #form>
+        <slot name="form" />
+      </template>
+      <template #buttons>
+        <div class="columns">
+          <div class="column is-whole has-text-centered buttons">
+            <button
+              class="button is-primary has-text-weight-bold"
+              v-on:click="invokeDownload"
+            >
+              <strong>Download</strong>
+            </button>
+            <button
+              class="button"
+              v-on:click="closeDownloadModal"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </template>
+    </FormModal>
+  </section>
+</template>
+
+
+<script lang="ts">
+import {Component, Vue, Prop} from "vue-property-decorator";
+import {validationMixin} from "vuelidate";
+import FormModal from "@/components/modals/FormModal.vue";
+
+@Component({
+  mixins: [validationMixin],
+  components: {FormModal}
+})
+export default class DownloadModal extends Vue {
+
+  @Prop()
+  uniqueId!: string;
+  @Prop()
+  modalTitle?: string;
+  @Prop()
+  modalClass?: string;
+  @Prop()
+  download!: () => boolean;
+  @Prop()
+  anchorClass?: string;
+  @Prop()
+  active!: boolean;
+
+  closeDownloadModal(){
+    // Emit deactivate event, allows parent to reset form state, for example.
+    this.$emit('deactivate');
+  }
+
+  invokeDownload(){
+    // Invoke the download prop, which returns true if download succeeded.
+    if (this.download())
+    {
+      // Close and deactivate modal.
+      this.closeDownloadModal();
+    }
+  }
+
+}
+</script>

--- a/src/components/DownloadModal.vue
+++ b/src/components/DownloadModal.vue
@@ -71,8 +71,6 @@ export default class DownloadModal extends Vue {
   @Prop()
   download!: () => boolean;
   @Prop()
-  anchorClass?: string;
-  @Prop()
   active!: boolean;
 
   closeDownloadModal(){

--- a/src/components/experiments/ExperimentObservationsDownloadModal.vue
+++ b/src/components/experiments/ExperimentObservationsDownloadModal.vue
@@ -16,11 +16,12 @@
 -->
 
 <template>
-  <DownloadButton
+  <DownloadModal
     v-bind:unique-id="trialId"
     v-bind:modal-title="modalTitle"
     v-bind:download="downloadList"
     v-bind:anchor-class="anchorClass"
+    v-bind:active="active"
     modal-class="experiment-observations-download-button"
     v-on:deactivate="resetExportOptions"
   >
@@ -146,7 +147,7 @@
       </div>
     </template>
     <slot />
-  </DownloadButton>
+  </DownloadModal>
 </template>
 
 
@@ -159,24 +160,24 @@ import {ExperimentExportOptions} from "@/breeding-insight/model/ExperimentExport
 import {FileTypeOption} from "@/breeding-insight/model/FileTypeOption";
 import {ExperimentDatasetOption} from "@/breeding-insight/model/ExperimentDatasetOption";
 import {AlertTriangleIcon} from 'vue-feather-icons';
-import DownloadButton from "@/components/DownloadButton.vue";
 import {Trial} from "@/breeding-insight/model/Trial";
 import {Metadata} from "@/breeding-insight/model/BiResponse";
 import {Study} from "@/breeding-insight/model/Study";
 import {StudyService} from "@/breeding-insight/service/StudyService";
 import {Result} from "@/breeding-insight/model/Result";
 import {BrAPIUtils} from "@/breeding-insight/utils/BrAPIUtils";
+import DownloadModal from "@/components/DownloadModal.vue";
 
 @Component({
   mixins: [validationMixin],
-  components: {DownloadButton, AlertTriangleIcon},
+  components: {DownloadModal, AlertTriangleIcon},
   computed: {
     ...mapGetters([
       'activeProgram'
     ])
   }
 })
-export default class ExperimentObservationsDownloadButton extends Vue {
+export default class ExperimentObservationsDownloadModal extends Vue {
 
   @Prop()
   active!: boolean;
@@ -188,6 +189,7 @@ export default class ExperimentObservationsDownloadButton extends Vue {
   modalTitle?: string;
   @Prop()
   anchorClass?: string;
+
 
   private activeProgram?: Program;
   private fileOptions: ExperimentExportOptions = new ExperimentExportOptions();
@@ -235,6 +237,8 @@ export default class ExperimentObservationsDownloadButton extends Vue {
   }
 
   resetExportOptions(){
+    // Notify parent when deactivated to close modal
+    this.$emit('deactivate');
     // Reset file export options.
     this.fileOptions = new ExperimentExportOptions();
     // Reset validation state.

--- a/src/components/experiments/ExperimentObservationsDownloadModal.vue
+++ b/src/components/experiments/ExperimentObservationsDownloadModal.vue
@@ -197,7 +197,6 @@ export default class ExperimentObservationsDownloadModal extends Vue {
 
   @Watch('experiment', {immediate: true})
   onExperimentChanged() {
-    console.log('experiment changed');
     // reset loading flag
     this.loadingStudyOptionsComplete = false;
     this.getStudyOptions();

--- a/src/components/experiments/ExperimentObservationsDownloadModal.vue
+++ b/src/components/experiments/ExperimentObservationsDownloadModal.vue
@@ -20,7 +20,6 @@
     v-bind:unique-id="trialId"
     v-bind:modal-title="modalTitle"
     v-bind:download="downloadList"
-    v-bind:anchor-class="anchorClass"
     v-bind:active="active && loadingStudyOptionsComplete"
     modal-class="experiment-observations-download-button"
     v-on:deactivate="resetExportOptions"
@@ -187,9 +186,6 @@ export default class ExperimentObservationsDownloadModal extends Vue {
   experiment!: Trial;
   @Prop()
   modalTitle?: string;
-  @Prop()
-  anchorClass?: string;
-
 
   private activeProgram?: Program;
   private fileOptions: ExperimentExportOptions = new ExperimentExportOptions();

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -62,17 +62,6 @@
         </template>
       </b-table-column>
       <b-table-column field="data.listDbId" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-        <!--
-        <ExperimentObservationsDownloadButton
-          v-bind:experiment="props.row.data"
-          v-bind:modal-title="`Download ${props.row.data.trialName}`"
-          v-bind:trial-id="BrAPIUtils.getBreedingInsightId(props.row.data.externalReferences, '/trials')"
-          v-on:show-error-notification="$emit('show-error-notification', $event)"
-        >
-          Download
-        </ExperimentObservationsDownloadButton>
-        -->
-
         <a href="javascript:void(0)" v-on:click="openDownloadModal(props.row.data)">Download</a>
       </b-table-column>
 

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -25,7 +25,6 @@
         v-bind:active="downloadModalActive"
         v-on:show-error-notification ="$emit('show-error-notification', $event)"
         v-on:deactivate="downloadModalActive = false"
-        anchor-class="button is-primary is-outlined"
     />
 
     <div class="is-clearfix"></div>

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -152,9 +152,9 @@ export default class ExperimentsObservationsTable extends Vue {
   };
 
   private downloadModalActive: boolean = false;
-  private downloadExperiment?: Trial;
-  private downloadModalTitle?: string;
-  private downloadTrialId?: string;
+  private downloadExperiment?: Trial = new Trial();
+  private downloadModalTitle?: string = 'undefined';
+  private downloadTrialId?: string = 'undefined';
 
   mounted() {
     this.experimentCallStack = new CallStack(this.experimentsFetch(
@@ -218,6 +218,7 @@ export default class ExperimentsObservationsTable extends Vue {
     this.downloadExperiment = experiment;
     this.downloadModalTitle = "Download " + experiment.trialName;
     this.downloadTrialId = BrAPIUtils.getBreedingInsightId(experiment.externalReferences!, '/trials');
+    console.log(this.downloadTrialId);
   }
 
   setSort(field: string, order: string) {

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -18,6 +18,16 @@
 <template>
   <section id="experimentsObservationsTableLabel">
 
+    <ExperimentObservationsDownloadModal
+        v-bind:experiment="downloadExperiment"
+        v-bind:modal-title="downloadModalTitle"
+        v-bind:trial-id="downloadTrialId"
+        v-bind:active="downloadModalActive"
+        v-on:show-error-notification ="$emit('show-error-notification', $event)"
+        v-on:deactivate="downloadModalActive = false"
+        anchor-class="button is-primary is-outlined"
+    />
+
     <div class="is-clearfix"></div>
 
     <ExpandableTable
@@ -53,6 +63,7 @@
         </template>
       </b-table-column>
       <b-table-column field="data.listDbId" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        <!--
         <ExperimentObservationsDownloadButton
           v-bind:experiment="props.row.data"
           v-bind:modal-title="`Download ${props.row.data.trialName}`"
@@ -61,7 +72,9 @@
         >
           Download
         </ExperimentObservationsDownloadButton>
+        -->
 
+        <a href="javascript:void(0)" v-on:click="openDownloadModal(props.row.data)">Download</a>
       </b-table-column>
 
       <template v-slot:emptyMessage>
@@ -92,12 +105,12 @@ import {
 } from "@/breeding-insight/model/Sort";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import {UPDATE_EXPERIMENT_SORT} from "@/store/sorting/mutation-types";
-import ExperimentObservationsDownloadButton from "@/components/experiments/ExperimentObservationsDownloadButton.vue";
 import {BrAPIUtils} from "@/breeding-insight/utils/BrAPIUtils";
+import ExperimentObservationsDownloadModal from "@/components/experiments/ExperimentObservationsDownloadModal.vue";
 
 @Component({
   mixins: [validationMixin],
-  components: {ExperimentObservationsDownloadButton, ExpandableTable, EmptyTableMessage, TableColumn},
+  components: {ExperimentObservationsDownloadModal, ExpandableTable, EmptyTableMessage, TableColumn},
   computed: {
     ...mapGetters([
       'activeProgram'
@@ -137,6 +150,11 @@ export default class ExperimentsObservationsTable extends Vue {
     'createdDate': ExperimentSortField.CreatedDate,
     'createdBy': ExperimentSortField.CreatedBy
   };
+
+  private downloadModalActive: boolean = false;
+  private downloadExperiment?: Trial;
+  private downloadModalTitle?: string;
+  private downloadTrialId?: string;
 
   mounted() {
     this.experimentCallStack = new CallStack(this.experimentsFetch(
@@ -193,6 +211,13 @@ export default class ExperimentsObservationsTable extends Vue {
     } else {
       return "archived";
     }
+  }
+
+  openDownloadModal(experiment: Trial) {
+    this.downloadModalActive = true;
+    this.downloadExperiment = experiment;
+    this.downloadModalTitle = "Download " + experiment.trialName;
+    this.downloadTrialId = BrAPIUtils.getBreedingInsightId(experiment.externalReferences!, '/trials');
   }
 
   setSort(field: string, order: string) {

--- a/src/components/layouts/menus/ActionMenu.vue
+++ b/src/components/layouts/menus/ActionMenu.vue
@@ -15,7 +15,6 @@
   -->
 
 <template>
-  <!-- v-if="username !== undefined" -->
   <b-dropdown
               position="is-bottom-left"
               append-to-body
@@ -25,18 +24,10 @@
           class="button is-primary has-text-weight-bold"
           v-bind:id="dropDownId"
       >
-        <!--<b-icon icon="user" class="mr-0"></b-icon>-->
         Actions
         <b-icon icon="chevron-down" class="ml-1"></b-icon>
       </button>
     </template>
-    <!--
-    <b-dropdown-item custom aria-role="menuitem" v-bind:id="userNameId">
-      Logged in as <strong>{{username}}</strong>
-    </b-dropdown-item>
-    <hr class="dropdown-divider">
-    :id="logoutId"
-    -->
     <b-dropdown-item v-for="menuItem in actionMenuItems" v-bind:key="menuItem.id" aria-role="menuitem" @click="$emit(menuItem.event)">
       {{menuItem.label}}
     </b-dropdown-item>
@@ -55,9 +46,7 @@ export default class ActionMenu extends Vue {
   @Prop()
   actionMenuItems!: ActionMenuItem[];
 
-  //private logoutId: string = "userstatusmenu-logout-button";
   private dropDownId: string = "actionmenu-dropdown-button";
-  //private userNameId: string = "userstatusmenu-username";
 }
 
 </script>

--- a/src/components/layouts/menus/ActionMenu.vue
+++ b/src/components/layouts/menus/ActionMenu.vue
@@ -22,13 +22,16 @@
     <template #trigger>
       <button
           class="button is-primary has-text-weight-bold"
-          v-bind:id="dropDownId"
+          v-bind:id="id"
       >
-        Actions
+        {{ buttonText }}
         <b-icon icon="chevron-down" class="ml-1"></b-icon>
       </button>
     </template>
-    <b-dropdown-item v-for="menuItem in actionMenuItems" v-bind:key="menuItem.id" aria-role="menuitem" @click="$emit(menuItem.event)">
+    <b-dropdown-item v-for="menuItem in actionMenuItems"
+                     v-bind:key="menuItem.id" aria-role="menuitem"
+                     v-bind:id="menuItem.id"
+                     @click="$emit(menuItem.event)">
       {{menuItem.label}}
     </b-dropdown-item>
 
@@ -44,9 +47,13 @@ import {ActionMenuItem} from "@/breeding-insight/model/ActionMenuItem";
 })
 export default class ActionMenu extends Vue {
   @Prop()
+  buttonText!: string;
+  @Prop()
   actionMenuItems!: ActionMenuItem[];
+  @Prop()
+  id!: string;
 
-  private dropDownId: string = "actionmenu-dropdown-button";
+
 }
 
 </script>

--- a/src/components/layouts/menus/ActionMenu.vue
+++ b/src/components/layouts/menus/ActionMenu.vue
@@ -21,7 +21,8 @@
               aria-role="menu">
     <template #trigger>
       <button
-          class="button is-primary has-text-weight-bold"
+          class="button has-text-weight-bold"
+          :class="[isPrimary ? 'is-primary' : 'is-primary is-light']"
           v-bind:id="id"
       >
         {{ buttonText }}
@@ -52,6 +53,8 @@ export default class ActionMenu extends Vue {
   actionMenuItems!: ActionMenuItem[];
   @Prop()
   id!: string;
+  @Prop()
+  isPrimary!: boolean;
 
 
 }

--- a/src/components/layouts/menus/ActionMenu.vue
+++ b/src/components/layouts/menus/ActionMenu.vue
@@ -1,0 +1,63 @@
+<!--
+  - See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<template>
+  <!-- v-if="username !== undefined" -->
+  <b-dropdown
+              position="is-bottom-left"
+              append-to-body
+              aria-role="menu">
+    <template #trigger>
+      <button
+          class="button is-primary has-text-weight-bold"
+          v-bind:id="dropDownId"
+      >
+        <!--<b-icon icon="user" class="mr-0"></b-icon>-->
+        Actions
+        <b-icon icon="chevron-down" class="ml-1"></b-icon>
+      </button>
+    </template>
+    <!--
+    <b-dropdown-item custom aria-role="menuitem" v-bind:id="userNameId">
+      Logged in as <strong>{{username}}</strong>
+    </b-dropdown-item>
+    <hr class="dropdown-divider">
+    :id="logoutId"
+    -->
+    <b-dropdown-item v-for="menuItem in actionMenuItems" v-bind:key="menuItem.id" aria-role="menuitem" @click="$emit(menuItem.event)">
+      {{menuItem.label}}
+    </b-dropdown-item>
+
+  </b-dropdown>
+</template>
+
+<script lang="ts">
+import {Component, Prop, Vue} from 'vue-property-decorator';
+import {ActionMenuItem} from "@/breeding-insight/model/ActionMenuItem";
+
+@Component({
+  components: {},
+})
+export default class ActionMenu extends Vue {
+  @Prop()
+  actionMenuItems!: ActionMenuItem[];
+
+  //private logoutId: string = "userstatusmenu-logout-button";
+  private dropDownId: string = "actionmenu-dropdown-button";
+  //private userNameId: string = "userstatusmenu-username";
+}
+
+</script>

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -32,7 +32,6 @@
             v-bind:active="downloadModalActive"
             v-on:show-error-notification ="$emit('show-error-notification', $event)"
             v-on:deactivate="downloadModalActive = false"
-            anchor-class="button is-primary is-outlined"
         />
 
         <ActionMenu v-bind:action-menu-items=actions

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -24,25 +24,22 @@
       {{experiment.trialName}}
     </h1>
       <span class="is-pulled-right is-flex" >
-        <router-link
-            v-bind:to="{name: 'experiment-import', params: {programId: activeProgram.id}}"
-            role="menuitem"
-            class="button is-primary is-outlined mr-2"
-        >
-          Import file
-        </router-link>
 
-        <ExperimentObservationsDownloadButton
+        <ExperimentObservationsDownloadModal
             v-bind:experiment="experiment"
             v-bind:modal-title="`Download ${experiment.trialName}`"
             v-bind:trial-id="experimentUUID"
+            v-bind:active="downloadModalActive"
             v-on:show-error-notification ="$emit('show-error-notification', $event)"
+            v-on:deactivate="downloadModalActive = false"
             anchor-class="button is-primary is-outlined"
-        >
-          Download file
-        </ExperimentObservationsDownloadButton>
-      </span>
+        />
 
+        <ActionMenu v-bind:action-menu-items=actions
+                    v-on:import-file="importFile()"
+                    v-on:download-file="downloadFile()"
+        />
+      </span>
 
     <div v-if="!experimentLoading && experiment!=null">
       <br/>
@@ -101,13 +98,16 @@ import {Result} from "@/breeding-insight/model/Result";
 import {ExperimentService} from "@/breeding-insight/service/ExperimentService";
 import ClickOutside from 'vue-click-outside';
 import {Trial} from "@/breeding-insight/model/Trial";
-import ExperimentObservationsDownloadButton from "@/components/experiments/ExperimentObservationsDownloadButton.vue";
 import ProgramsBase from "@/components/program/ProgramsBase.vue";
+import ActionMenu from "@/components/layouts/menus/ActionMenu.vue";
+import {ActionMenuItem} from "@/breeding-insight/model/ActionMenuItem";
+import ExperimentObservationsDownloadModal from "@/components/experiments/ExperimentObservationsDownloadModal.vue";
 
 @Component({
   components: {
     PlusCircleIcon,
-    ExperimentObservationsDownloadButton
+    ExperimentObservationsDownloadModal,
+    ActionMenu
   },
   computed: {
     ...mapGetters([
@@ -122,13 +122,29 @@ export default class ExperimentDetails extends ProgramsBase {
   private activeProgram: Program;
   private experiment: Trial;
   private experimentLoading: boolean = true;
-  private actionSelectActive: boolean = false;
+  private downloadModalActive: boolean = false;
 
+  private actions: ActionMenuItem[] = [
+      new ActionMenuItem('importFileId', 'import-file', 'Import file'),
+      new ActionMenuItem('downloadFileId', 'download-file', 'Download file')
+  ];
 
   mounted () {
     this.getExperiment();
   }
 
+  private importFile() {
+    this.$router.push({
+      name: 'experiment-import',
+      params: {
+        programId: this.activeProgram!.id!
+      },
+    });
+  }
+
+  private downloadFile() {
+    this.downloadModalActive = true;
+  }
 
   get experimentUUID(): string {
     return this.$route.params.experimentId;

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -57,7 +57,9 @@
           </section>
         </article>
         <article class="column is-narrow">
-          <ActionMenu v-bind:action-menu-items=actions
+          <ActionMenu v-bind:id="'manage-experiment-dropdown-button'"
+                      v-bind:button-text="'Manage Experiment'"
+                      v-bind:action-menu-items=actions
                       v-on:import-file="importFile()"
                       v-on:download-file="downloadFile()"
           />
@@ -123,8 +125,8 @@ export default class ExperimentDetails extends ProgramsBase {
   private downloadModalActive: boolean = false;
 
   private actions: ActionMenuItem[] = [
-      new ActionMenuItem('importFileId', 'import-file', 'Import file'),
-      new ActionMenuItem('downloadFileId', 'download-file', 'Download file')
+      new ActionMenuItem('experiment-import-file', 'import-file', 'Import file'),
+      new ActionMenuItem('experiment-download-file', 'download-file', 'Download file')
   ];
 
   mounted () {

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -34,14 +34,11 @@
             v-on:deactivate="downloadModalActive = false"
         />
 
-        <ActionMenu v-bind:action-menu-items=actions
-                    v-on:import-file="importFile()"
-                    v-on:download-file="downloadFile()"
-        />
+
       </span>
 
     <div v-if="!experimentLoading && experiment!=null">
-      <br/>
+    
       <div class="columns is-multiline is-align-items-stretch mt-4">
         <article class="column ">
           <section>
@@ -62,6 +59,12 @@
               <li><b>Environments: </b> {{ environmentsCount }}</li>
             </ul>
           </section>
+        </article>
+        <article class="column is-narrow">
+          <ActionMenu v-bind:action-menu-items=actions
+                      v-on:import-file="importFile()"
+                      v-on:download-file="downloadFile()"
+          />
         </article>
       </div>
 

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -23,22 +23,18 @@
     <h1 class="title">
       {{experiment.trialName}}
     </h1>
-      <span class="is-pulled-right is-flex" >
 
-        <ExperimentObservationsDownloadModal
-            v-bind:experiment="experiment"
-            v-bind:modal-title="`Download ${experiment.trialName}`"
-            v-bind:trial-id="experimentUUID"
-            v-bind:active="downloadModalActive"
-            v-on:show-error-notification ="$emit('show-error-notification', $event)"
-            v-on:deactivate="downloadModalActive = false"
-        />
-
-
-      </span>
+    <ExperimentObservationsDownloadModal
+        v-bind:experiment="experiment"
+        v-bind:modal-title="`Download ${experiment.trialName}`"
+        v-bind:trial-id="experimentUUID"
+        v-bind:active="downloadModalActive"
+        v-on:show-error-notification ="$emit('show-error-notification', $event)"
+        v-on:deactivate="downloadModalActive = false"
+    />
 
     <div v-if="!experimentLoading && experiment!=null">
-    
+
       <div class="columns is-multiline is-align-items-stretch mt-4">
         <article class="column ">
           <section>

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -57,7 +57,8 @@
           </section>
         </article>
         <article class="column is-narrow">
-          <ActionMenu v-bind:id="'manage-experiment-dropdown-button'"
+          <ActionMenu v-bind:is-primary="true"
+                      v-bind:id="'manage-experiment-dropdown-button'"
                       v-bind:button-text="'Manage Experiment'"
                       v-bind:action-menu-items=actions
                       v-on:import-file="importFile()"


### PR DESCRIPTION
# Description
**Story:** [BI-1821](https://breedinginsight.atlassian.net/browse/BI-1821?atlOrigin=eyJpIjoiNDRjODQ5MDZmNTQ3NDhkMjk3M2M1MmU4NjFkNWI1MDQiLCJwIjoiaiJ9)

- Added action menu component and replaced buttons with it on Experiment page
- Refactored ExperimentObservationsDownloadButton so that activation is outside the component and has dynamic reloading of study options and renamed to modal
- Refactored ExperimentObservationsTable so that there is one modal rather than one for each row in the table

# Dependencies
- develop on bi-api

# Testing
- Ensure download links in ExperimentObservationsTable work as before
- Ensure action menu items work as expected

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1821]: https://breedinginsight.atlassian.net/browse/BI-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ