### PR TITLE
BI-1872 - Generate Access Token for using BrAPI with DeltaBreed

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -901,6 +901,19 @@ tr:nth-child(odd) td.db-filled {
   }
 }
 
+.brapi-info {
+  .access-token {
+    @extend .mb-5;
+    font-family: monospace;
+    word-wrap: break-word;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+  }
+}
+
 label.environment-option-label {
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1872

- Updated the BrAPI page to use card components
- Added a card for generating an API token

# Dependencies
bi-api/feature/BI-1872

# Testing
A)
1. Log in to DeltaBreed
2. Navigate to a program
3. Navigate to the "BrAPI" page via the menu
4. click on "Generate Access Token"
5. Ensure that a new access token is generated and displayed with the expiration timestamp

B)
1. Generate an access token (test A)
2. Using that access token, make a REST call (via Insomnia/Postman): 
   - header: `Authorization` and value of `Bearer <access token>`
   - URL: `<program BrAPI URL>/germplasm` (grab the BrAPI base URL on the BrAPI page in DeltaBreed)
3. Ensure that the rest call returns back the germplasm for that program


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6027686471
