### PR TITLE
[BI-1918] Experiment: No datasets exist

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -431,12 +431,10 @@ export default class Dataset extends ProgramsBase {
 
   createVariableDbId_to_index(): {} {
     let variableDbId_to_index = {};
-    let ov_count = 0 ;
     if( this.datasetModel.observationVariables ){
-      ov_count = this.datasetModel.observationVariables.length;
-    }
-    for (let index = 0; index < ov_count; index++) {
-      variableDbId_to_index[this.datasetModel.observationVariables[index].observationVariableDbId] = index;
+      for (let index = 0; index < this.datasetModel.observationVariables.length; index++) {
+        variableDbId_to_index[this.datasetModel.observationVariables[index].observationVariableDbId] = index;
+      }
     }
     return variableDbId_to_index;
   }

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -412,24 +412,30 @@ export default class Dataset extends ProgramsBase {
     let variableDbId_to_index = this.createVariableDbId_to_index();
 
     // populate each array of observation values found in the unitDbId_to_traitValues Hash Table
-    for (let observation of this.datasetModel.data) {
-      // find the index (ie table column) of each observation
-      // NOTE: the first observation column will have an index of 0.
-      let obsVar_index = variableDbId_to_index[observation.observationVariableDbId];
+    if( this.datasetModel.data ) {
+      for (let observation of this.datasetModel.data) {
+        // find the index (ie table column) of each observation
+        // NOTE: the first observation column will have an index of 0.
+        let obsVar_index = variableDbId_to_index[observation.observationVariableDbId];
+        let obs_value = observation.value;
+        let unitDbId = observation.observationUnitDbId;
+        let traitValueArray = unitDbId_to_traitValues[unitDbId];
+        traitValueArray[obsVar_index] = obs_value;
 
-      let obs_value = observation.value;
-      let unitDbId = observation.observationUnitDbId;
-      let traitValueArray = unitDbId_to_traitValues[unitDbId];
-      traitValueArray[obsVar_index] = obs_value;
-
+      }
     }
+
     return unitDbId_to_traitValues;
   }
 
 
   createVariableDbId_to_index(): {} {
-    let variableDbId_to_index = {}
-    for (let index = 0; index < this.datasetModel.observationVariables.length; index++) {
+    let variableDbId_to_index = {};
+    let ov_count = 0 ;
+    if( this.datasetModel.observationVariables ){
+      ov_count = this.datasetModel.observationVariables.length;
+    }
+    for (let index = 0; index < ov_count; index++) {
       variableDbId_to_index[this.datasetModel.observationVariables[index].observationVariableDbId] = index;
     }
     return variableDbId_to_index;


### PR DESCRIPTION
# Description
**Story:**  [BI-1918](https://breedinginsight.atlassian.net/browse/BI-1918)
If there is an experiment with Observation Units but no observation variables, then when displaying the experiment, no Observation Units are displayed.



# Dependencies
bi-api: develop branch

# Testing
1. Import an experiment with Observation Units but no Observation Variables (traits).
2. Display the experiment.
**EXPECTED RESULT**
Withing the Observation Dataset tab, all of the Observation Units should be displayed.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1918]: https://breedinginsight.atlassian.net/browse/BI-1918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ