### PR TITLE
[BI-1911] Environment Year Missing from Exp table

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,9 +93,6 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.6.10"
   },
-<<<<<<< HEAD
+
   "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/87faca99d768a53d44bc2e0f4684e1eaea88c71b"
-=======
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/82fb0ea9ec41102ff226fd4ba2799b72de3f20e1"
->>>>>>> 45a33eb6 ([autocommit] bumping build number)
 }

--- a/package.json
+++ b/package.json
@@ -93,5 +93,9 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.6.10"
   },
+<<<<<<< HEAD
   "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/87faca99d768a53d44bc2e0f4684e1eaea88c71b"
+=======
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/82fb0ea9ec41102ff226fd4ba2799b72de3f20e1"
+>>>>>>> 45a33eb6 ([autocommit] bumping build number)
 }

--- a/src/breeding-insight/dao/ExperimentDAO.ts
+++ b/src/breeding-insight/dao/ExperimentDAO.ts
@@ -38,7 +38,7 @@ export class ExperimentDAO {
             return ResultGenerator.err(error);
         }
     }
-    static getDatasetById(programId: string, experimentId: string, datasetId: string, stats: boolean): Promise<Result<Error, DatasetModel>> {
+    static async getDatasetById(programId: string, experimentId: string, datasetId: string, stats: boolean): Promise<Result<Error, DatasetModel>> {
         const config: any = {};
         config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/dataset/${datasetId}`;
         config.method = 'get';
@@ -48,15 +48,13 @@ export class ExperimentDAO {
         config.params = {
             stats : stats,
         };
-        return new Promise<Result<Error, DatasetModel>>(((resolve, reject) => {
-            api.call(config)
-                .then((response: any) => {
-                    const biResponse = new BiResponse(response.data);
-                    resolve(biResponse);
-                }).catch((error) => {
-                    reject(error);
-                })
-        }))
+        try {
+            const res = await api.call(config) as Response;
+            let { result } = res.data;
+            return ResultGenerator.success(result);
+        } catch (error) {
+            return ResultGenerator.err(error);
+        }
     }
 
 }

--- a/src/breeding-insight/model/ObservationUnit.ts
+++ b/src/breeding-insight/model/ObservationUnit.ts
@@ -20,15 +20,15 @@ import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferen
 export class ObservationUnit {
   observationUnitDbId: string;
   germplasmDbId?: string;
-  germplasmName: string;
+  germplasmName?: string;
   locationDbI?: string;
-  locationName: string;
+  locationName?: string;
   observationUnitName?: string;
   observationUnitPUI?: string;
   programDbId?: string;
   programName?: string;
   studyDbId?: string;
-  studyName: string;
+  studyName?: string;
   trialDbId?: string;
   trialName?: string;
   observationUnitPosition?: ObservationUnitPosition;

--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -170,16 +170,6 @@ export enum GermplasmSortField {
   UserName = "createdByUserName"
 }
 
-export class GermplasmSort {
-  field: GermplasmSortField;
-  order: SortOrder;
-
-  constructor(field: GermplasmSortField, order: SortOrder) {
-    this.field = field;
-    this.order = order;
-  }
-}
-
 // experiments
 export enum ExperimentSortField {
   Name = "name",
@@ -193,6 +183,17 @@ export class ExperimentSort {
   order: SortOrder;
 
   constructor(field: ExperimentSortField, order: SortOrder) {
+    this.field = field;
+    this.order = order;
+  }
+}
+
+// germplasm
+export class GermplasmSort {
+  field: GermplasmSortField;
+  order: SortOrder;
+
+  constructor(field: GermplasmSortField, order: SortOrder) {
     this.field = field;
     this.order = order;
   }

--- a/src/breeding-insight/model/Study.ts
+++ b/src/breeding-insight/model/Study.ts
@@ -27,6 +27,7 @@ export class Study {
   location?: string;
   active?: boolean;
   externalReferences?: ExternalReferences;
+  seasons?: string[];
 
 
   constructor(id?: string,
@@ -37,7 +38,8 @@ export class Study {
               endDate?: string,
               location?: string,
               active?: boolean,
-              externalReferences?: ExternalReferences
+              externalReferences?: ExternalReferences,
+              seasons?: string[]
               ) {
     this.id = id;
     this.name = name;
@@ -56,13 +58,14 @@ export class Study {
       this.active = true;
     }
     this.externalReferences = externalReferences;
+    this.seasons = seasons;
   }
 
   static assign(study: Study): Study {
     const start: string | undefined = study.startDate ? study.startDate.toISOString() : undefined;
     const end: string | undefined = study.endDate ? study.endDate.toISOString() : undefined;    
 
-    return new Study(study.id, study.name, study.description, study.type, start, end, study.location, study.active, study.externalReferences);
+    return new Study(study.id, study.name, study.description, study.type, start, end, study.location, study.active, study.externalReferences, study.seasons);
   }
 
   equals(study?: Study): boolean {

--- a/src/breeding-insight/service/BrAPIService.ts
+++ b/src/breeding-insight/service/BrAPIService.ts
@@ -22,7 +22,8 @@ import {SortOrder} from "@/breeding-insight/model/Sort";
 export enum BrAPIType {
   GERMPLASM = "germplasm",
   EXPERIMENT = "trials",
-  LIST = "lists"
+  LIST = "lists",
+  SEASON = "seasons"
 }
 
 export class BrAPIService {

--- a/src/breeding-insight/service/StudyService.ts
+++ b/src/breeding-insight/service/StudyService.ts
@@ -83,21 +83,6 @@ export class StudyService {
     }
   }
 
-  // static async getEnvYear(programId?: string, studyId?: string): Promise<Result<Error, string>> {
-  //   try {
-  //     if(!programId) throw new Error('missing or invalid program id');
-  //     if(!studyId) throw new Error('missing or invalid study id');
-  //     let studyResponse = await StudyDAO.getById(programId, studyId) as Result<Error, BiResponse>;
-  //     if (studyResponse.isErr()) throw studyResponse.value;
-  //     studyResponse.applyResult( (res: BiResponse) => {
-  //       let { result: { study }, metadata } = res;
-  //
-  //     })
-  //   } catch (error) {
-  //     return ResultGenerator.err(error);
-  //   }
-  // }
-
   static async getById(programId?: string, studyId?: string): Promise<Result<Error, Study>> {
     try {
       if(!programId) throw new Error('missing or invalid program id');

--- a/src/breeding-insight/service/StudyService.ts
+++ b/src/breeding-insight/service/StudyService.ts
@@ -56,7 +56,17 @@ export class StudyService {
         
         data = PaginationUtilities.mockSortRecords(data);
         studies = data.map((study: any) => {
-          return new Study(study.studyDbId, study.studyName, study.studyDescription, study.studyType, study.startDate, study.endDate, study.locationName, study.active, study.externalReferences);
+          return new Study(
+              study.studyDbId,
+              study.studyName,
+              study.studyDescription,
+              study.studyType,
+              study.startDate,
+              study.endDate,
+              study.locationName,
+              study.active,
+              study.externalReferences,
+              study.seasons);
         });
 
         let newPagination;
@@ -72,6 +82,21 @@ export class StudyService {
       return ResultGenerator.err(error);
     }
   }
+
+  // static async getEnvYear(programId?: string, studyId?: string): Promise<Result<Error, string>> {
+  //   try {
+  //     if(!programId) throw new Error('missing or invalid program id');
+  //     if(!studyId) throw new Error('missing or invalid study id');
+  //     let studyResponse = await StudyDAO.getById(programId, studyId) as Result<Error, BiResponse>;
+  //     if (studyResponse.isErr()) throw studyResponse.value;
+  //     studyResponse.applyResult( (res: BiResponse) => {
+  //       let { result: { study }, metadata } = res;
+  //
+  //     })
+  //   } catch (error) {
+  //     return ResultGenerator.err(error);
+  //   }
+  // }
 
   static async getById(programId?: string, studyId?: string): Promise<Result<Error, Study>> {
     try {

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -182,7 +182,6 @@ export default class ExperimentsObservationsTable extends Vue {
       // Account for brapi 0 indexing of paging
       this.paginationController.currentPage = this.paginationController.currentPage.valueOf() + 1;
       this.experiments = response.result.data;
-      console.log( this.experiments);
       this.experimentsLoading = false;
 
     } catch (err) {
@@ -206,7 +205,6 @@ export default class ExperimentsObservationsTable extends Vue {
     this.downloadExperiment = experiment;
     this.downloadModalTitle = "Download " + experiment.trialName;
     this.downloadTrialId = BrAPIUtils.getBreedingInsightId(experiment.externalReferences!, '/trials');
-    console.log(this.downloadTrialId);
   }
 
   setSort(field: string, order: string) {

--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -554,7 +554,12 @@ export default class BreedingMethods extends ProgramsBase {
       this.getBreedingMethods();
       this.$emit('show-success-notification', 'Breeding method created successfully');
     } catch (e) {
-      this.$emit('show-error-notification', 'Error while trying to create breeding method');
+      if (e.response.status == 500) {
+        this.$emit('show-error-notification', 'Error while trying to create breeding method');
+      }
+      else{
+        this.$emit('show-error-notification', e.response.data);
+      }
     } finally {
       this.newMethodFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT);
     }
@@ -576,7 +581,12 @@ export default class BreedingMethods extends ProgramsBase {
       this.getBreedingMethods();
       this.$emit('show-success-notification', 'Breeding method updated successfully');
     } catch (e) {
-      this.$emit('show-error-notification', 'Error while trying to update breeding method');
+      if (e.response.status == 500) {
+        this.$emit('show-error-notification', 'Error while trying to create breeding method');
+      }
+      else{
+        this.$emit('show-error-notification', e.response.data);
+      }
     } finally {
       this.editMethodFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT)
     }

--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -554,11 +554,15 @@ export default class BreedingMethods extends ProgramsBase {
       this.getBreedingMethods();
       this.$emit('show-success-notification', 'Breeding method created successfully');
     } catch (e) {
-      if (e.response.status == 500) {
-        this.$emit('show-error-notification', 'Error while trying to create breeding method');
+      if (e.response.status == 400 && e.response && e.response.data) {
+        this.$emit('show-error-notification', e.response.data);
       }
       else{
-        this.$emit('show-error-notification', e.response.data);
+        if( e.response && e.response.data ) {
+          //This message may also appear in the bi_api log
+          console.error(e.response.data);
+        }
+        this.$emit('show-error-notification', 'Error while trying to create breeding method');
       }
     } finally {
       this.newMethodFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT);
@@ -581,11 +585,15 @@ export default class BreedingMethods extends ProgramsBase {
       this.getBreedingMethods();
       this.$emit('show-success-notification', 'Breeding method updated successfully');
     } catch (e) {
-      if (e.response.status == 500) {
-        this.$emit('show-error-notification', 'Error while trying to create breeding method');
+      if (e.response.status == 400 && e.response && e.response.data) {
+        this.$emit('show-error-notification', e.response.data);
       }
       else{
-        this.$emit('show-error-notification', e.response.data);
+        if( e.response && e.response.data ) {
+          //This message may also appear in the bi_api log
+          console.error(e.response.data);
+        }
+        this.$emit('show-error-notification', 'Error while trying to create breeding method');
       }
     } finally {
       this.editMethodFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT)

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -543,8 +543,9 @@ export default class Dataset extends ProgramsBase {
       }
 
       // Set this.datasetModel
-      const response: Result<Error, DatasetModel> = await ExperimentService.getDatasetModel(this.activeProgram!.id!, this.experimentUUID, this.resultDatasetId);
-      this.datasetModel = response.result;
+      const response: Result<Error, DatasetModel> = await ExperimentService.getDatasetModel(this.activeProgram!.id!, this.experimentUUID, this.resultDatasetId!);
+      if (response.isErr()) throw response.value;
+      this.datasetModel = response.value;
 
       // Use this.datasetModel to initialize this.unitDbId_to_traitValues
       this.unitDbId_to_traitValues = this.createUnitDbId_to_traitValues();

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -261,7 +261,7 @@ export default class Dataset extends ProgramsBase {
   private resultDatasetId: string | undefined;
   private paginationController: PaginationController = new PaginationController();
   private datasetTableRows: DatasetTableRow[] = [];
-  private unitDbId_to_traitValues = {};
+  private unitDbId_to_traitValues: any = {};
   private envYearByStudyDbId: any = {};
 
   mounted() {
@@ -528,19 +528,19 @@ export default class Dataset extends ProgramsBase {
 
   @Watch('$route')
   async load() {
-    this.loading = true;
-
-    //Set this.experiment
-    let experimentResult = await ExperimentService.getSingleExperiment(this.activeProgram!.id!, this.experimentUUID, false);
-    this.experiment = experimentResult.value;
-
-    if (this.datasetId === 'observation') {
-      this.resultDatasetId = this.experiment.additionalInfo.observationDatasetId;
-    } else {
-      this.resultDatasetId = this.datasetId;
-    }
-
     try {
+      this.loading = true;
+
+      //Set this.experiment
+      let experimentResult = await ExperimentService.getSingleExperiment(this.activeProgram!.id!, this.experimentUUID, false);
+      if (experimentResult.isErr()) throw experimentResult.value;
+      this.experiment = experimentResult.value;
+
+      if (this.datasetId === 'observation') {
+        this.resultDatasetId = this.experiment.additionalInfo.observationDatasetId;
+      } else {
+        this.resultDatasetId = this.datasetId;
+      }
 
       // Set this.datasetModel
       const response: Result<Error, DatasetModel> = await ExperimentService.getDatasetModel(this.activeProgram!.id!, this.experimentUUID, this.resultDatasetId);

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -232,7 +232,6 @@ import {ObservationUnit} from "@/breeding-insight/model/ObservationUnit";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 import ExpandableTable from "@/components/tables/expandableTable/ExpandableTable.vue";
 import {BrAPIUtils} from "@/breeding-insight/utils/BrAPIUtils";
-import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferences";
 import {DatasetTableRow} from "@/breeding-insight/model/DatasetTableRow";
 import {Trial} from "@/breeding-insight/model/Trial";
 import ProgressBar from '@/components/forms/ProgressBar.vue'

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -254,9 +254,9 @@ import {SortOrder} from "@/breeding-insight/model/Sort";
   }
 })
 export default class Dataset extends ProgramsBase {
-  private activeProgram: Program;
-  private datasetModel: DatasetModel;
-  private experiment: Trial;
+  private activeProgram!: Program;
+  private datasetModel!: DatasetModel;
+  private experiment!: Trial;
   private loading = true;
   private resultDatasetId: string | undefined;
   private paginationController: PaginationController = new PaginationController();
@@ -476,7 +476,7 @@ export default class Dataset extends ProgramsBase {
   }
 
   createUnitDbId_to_traitValues(): {} {
-    let unitDbId_to_traitValues = {};
+    let unitDbId_to_traitValues: any = {};
     let arrayLength: number = this.phenotypesCount;
 
     let units: ObservationUnit[] = this.datasetModel.observationUnits;
@@ -487,19 +487,18 @@ export default class Dataset extends ProgramsBase {
       unitDbId_to_traitValues[unit.observationUnitDbId] = new Array<string>(arrayLength);
     }
 
-    let variableDbId_to_index = this.createVariableDbId_to_index();
+    let variableDbId_to_index: any = this.createVariableDbId_to_index();
 
     // populate each array of observation values found in the unitDbId_to_traitValues Hash Table
-    if( this.datasetModel.data ) {
-      for (let observation of this.datasetModel.data) {
-        // find the index (ie table column) of each observation
-        // NOTE: the first observation column will have an index of 0.
+    for (let observation of this.datasetModel.data) {
+      // find the index (ie table column) of each observation
+      // NOTE: the first observation column will have an index of 0.
+      if (observation.observationVariableDbId && observation.observationUnitDbId) {
         let obsVar_index = variableDbId_to_index[observation.observationVariableDbId];
         let obs_value = observation.value;
         let unitDbId = observation.observationUnitDbId;
         let traitValueArray = unitDbId_to_traitValues[unitDbId];
         traitValueArray[obsVar_index] = obs_value;
-
       }
     }
 
@@ -508,10 +507,11 @@ export default class Dataset extends ProgramsBase {
 
 
   createVariableDbId_to_index(): {} {
-    let variableDbId_to_index = {};
-    if( this.datasetModel.observationVariables ){
-      for (let index = 0; index < this.datasetModel.observationVariables.length; index++) {
-        variableDbId_to_index[this.datasetModel.observationVariables[index].observationVariableDbId] = index;
+    let variableDbId_to_index: any = {}
+    for (let index = 0; index < this.datasetModel.observationVariables.length; index++) {
+      let obsVarDbId = this.datasetModel.observationVariables[index].observationVariableDbId;
+      if (obsVarDbId) {
+        variableDbId_to_index[obsVarDbId] = index;
       }
     }
     return variableDbId_to_index;

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -112,11 +112,13 @@
         </b-table-column>
         <b-table-column
             v-slot="props"
+            field="data.envYear"
             label="Env Year"
             sortable
             searchable
             :th-attrs="(column) => ({scope:'col'})"
         >
+          {{ props.row.data.envYear }}
         </b-table-column>
         <b-table-column
             v-slot="props"
@@ -385,6 +387,9 @@ export default class Dataset extends ProgramsBase {
       datasetTableRow.envLocation = this.removeUnique(unit.locationName);
       datasetTableRow.expUnitId = this.removeUnique(unit.observationUnitName);
       datasetTableRow.obsUnitId = BrAPIUtils.getBreedingInsightId(unit.externalReferences, "/observationunits");
+      if (unit.studyDbId) {
+        datasetTableRow.envYear = this.envYearByStudyDbId[unit.studyDbId];
+      }
 
       //Exp Replicate # and Exp Block #
       datasetTableRow.expReplicate = "";
@@ -546,11 +551,11 @@ export default class Dataset extends ProgramsBase {
       // Use this.datasetModel to initialize this.unitDbId_to_traitValues
       this.unitDbId_to_traitValues = this.createUnitDbId_to_traitValues();
 
-      // Use this.datasetModel to initialize this.datasetTableRows
-      this.createDatasetTableRows();
+      // Initialize envYearByStudyDbId
+      await this.createEnvYearByStudyDbId();
 
-      // Set envYearByStudyId
-      this.createEnvYearByStudyDbId();
+      // Use this.datasetModel and this.envYearByStudyDbId to initialize this.datasetTableRows
+      this.createDatasetTableRows();
 
       //Initialize the paginationController
       this.paginationController.totalCount = this.datasetModel.observationUnits.length;

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -64,7 +64,7 @@
             label="Germplasm Name"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.germplasmName }}
         </b-table-column>
@@ -75,7 +75,7 @@
             label="GID"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.gid }}
         </b-table-column>
@@ -86,7 +86,7 @@
 "
           sortable
           searchable
-          :th-attrs="(column) => ({scope:'col'})"
+          :th-attrs="() => ({scope:'col'})"
       >
         {{ props.row.data.testOrCheck }}
       </b-table-column>
@@ -96,7 +96,7 @@
             label="Env"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.env }}
         </b-table-column>
@@ -106,7 +106,7 @@
             label="Env Location"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.envLocation }}
         </b-table-column>
@@ -116,7 +116,7 @@
             label="Env Year"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.envYear }}
         </b-table-column>
@@ -126,7 +126,7 @@
             label="Exp Unit ID"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.expUnitId }}
         </b-table-column>
@@ -136,7 +136,7 @@
             label="Exp Replicate #"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.expReplicate }}
         </b-table-column>
@@ -146,7 +146,7 @@
             label="Exp Block #"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.expBlock }}
         </b-table-column>
@@ -156,7 +156,7 @@
             label="Row"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.row }}
         </b-table-column>
@@ -166,7 +166,7 @@
             label="Column"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.column }}
         </b-table-column>
@@ -189,7 +189,7 @@
             label="ObsUnitID"
             sortable
             searchable
-            :th-attrs="(column) => ({scope:'col'})"
+            :th-attrs="() => ({scope:'col'})"
         >
           {{ props.row.data.obsUnitId }}
         </b-table-column>
@@ -261,7 +261,7 @@ export default class Dataset extends ProgramsBase {
   private resultDatasetId: string | undefined;
   private paginationController: PaginationController = new PaginationController();
   private datasetTableRows: DatasetTableRow[] = [];
-  private unitDbId_to_traitValues: any = {};
+  private unitDbIdToTraitValues: any = {};
   private envYearByStudyDbId: any = {};
 
   mounted() {
@@ -317,10 +317,6 @@ export default class Dataset extends ProgramsBase {
       count = this.datasetModel.additionalInfo.observationsWithoutData;
     }
     return count
-  }
-
-  getBreedingInsightId(refs: ExternalReferences, source: string): string | undefined {
-    return BrAPIUtils.getBreedingInsightId(refs, source);
   }
 
   filterByObservations(index: number, propsRow: any, input: string) {
@@ -428,7 +424,7 @@ export default class Dataset extends ProgramsBase {
         datasetTableRow.treatmentFactors = unit.treatments[0].factor;
       }
 
-      datasetTableRow.traitValues = this.unitDbId_to_traitValues[unit.observationUnitDbId];
+      datasetTableRow.traitValues = this.unitDbIdToTraitValues[unit.observationUnitDbId];
       this.datasetTableRows.push(datasetTableRow);
     }
   }
@@ -437,7 +433,7 @@ export default class Dataset extends ProgramsBase {
     try {
       const response: Result<Error, [Study[], Metadata]> = await StudyService.getAll(this.activeProgram!.id!, this.experiment);
       if(response.isErr()) throw response.value;
-      let [studies, metadata] = response.value;
+      let [studies] = response.value;
 
       // fetch seasons in the program
       let seasonResponse =
@@ -464,7 +460,7 @@ export default class Dataset extends ProgramsBase {
           }
         })
       }
-    } catch (e) {
+    } catch (e: any) {
 
       // Display error that seasons can't be loaded
       if (e.response && e.response.statusText && e.response.status != 500) {
@@ -475,8 +471,8 @@ export default class Dataset extends ProgramsBase {
     }
   }
 
-  createUnitDbId_to_traitValues(): {} {
-    let unitDbId_to_traitValues: any = {};
+  createUnitDbIdToTraitValues(): {} {
+    let unitDbIdToTraitValues: any = {};
     let arrayLength: number = this.phenotypesCount;
 
     let units: ObservationUnit[] = this.datasetModel.observationUnits;
@@ -484,37 +480,36 @@ export default class Dataset extends ProgramsBase {
     // create a Hash Table with the key being each observationUnit's DbId
     // and the value being an (initially) empty array of observation values.
     for (let unit of units) {
-      unitDbId_to_traitValues[unit.observationUnitDbId] = new Array<string>(arrayLength);
+      unitDbIdToTraitValues[unit.observationUnitDbId] = new Array<string>(arrayLength);
     }
 
-    let variableDbId_to_index: any = this.createVariableDbId_to_index();
+    let variableDbIdToIndex: any = this.createvariableDbIdToIndex();
 
-    // populate each array of observation values found in the unitDbId_to_traitValues Hash Table
+    // populate each array of observation values found in the unitDbIdToTraitValues Hash Table
     for (let observation of this.datasetModel.data) {
       // find the index (ie table column) of each observation
       // NOTE: the first observation column will have an index of 0.
       if (observation.observationVariableDbId && observation.observationUnitDbId) {
-        let obsVar_index = variableDbId_to_index[observation.observationVariableDbId];
-        let obs_value = observation.value;
+        let obsVarIndex = variableDbIdToIndex[observation.observationVariableDbId];
+        let obsValue = observation.value;
         let unitDbId = observation.observationUnitDbId;
-        let traitValueArray = unitDbId_to_traitValues[unitDbId];
-        traitValueArray[obsVar_index] = obs_value;
+        let traitValueArray = unitDbIdToTraitValues[unitDbId];
+        traitValueArray[obsVarIndex] = obsValue;
       }
     }
-
-    return unitDbId_to_traitValues;
+    return unitDbIdToTraitValues;
   }
 
 
-  createVariableDbId_to_index(): {} {
-    let variableDbId_to_index: any = {}
+  createvariableDbIdToIndex(): {} {
+    let variableDbIdToIndex: any = {}
     for (let index = 0; index < this.datasetModel.observationVariables.length; index++) {
       let obsVarDbId = this.datasetModel.observationVariables[index].observationVariableDbId;
       if (obsVarDbId) {
-        variableDbId_to_index[obsVarDbId] = index;
+        variableDbIdToIndex[obsVarDbId] = index;
       }
     }
-    return variableDbId_to_index;
+    return variableDbIdToIndex;
   }
 
   cellClassIfEmpty(row: any, column: any) {
@@ -547,8 +542,8 @@ export default class Dataset extends ProgramsBase {
       if (response.isErr()) throw response.value;
       this.datasetModel = response.value;
 
-      // Use this.datasetModel to initialize this.unitDbId_to_traitValues
-      this.unitDbId_to_traitValues = this.createUnitDbId_to_traitValues();
+      // Use this.datasetModel to initialize this.unitDbIdToTraitValues
+      this.unitDbIdToTraitValues = this.createUnitDbIdToTraitValues();
 
       // Initialize envYearByStudyDbId
       await this.createEnvYearByStudyDbId();
@@ -561,7 +556,7 @@ export default class Dataset extends ProgramsBase {
       this.paginationController.currentPage = 1;
       this.paginationController.pageSize = 200;
       this.paginationController.totalPages = this.paginationController.totalCount.valueOf() / this.paginationController.pageSize.valueOf();
-    } catch (err) {
+    } catch (err: any) {
 
       // Display error that experiment cannot be loaded
       this.$emit('show-error-notification', 'Error while trying to load data set' + err.message());

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -565,5 +565,4 @@ export default class Dataset extends ProgramsBase {
     }
   }
 }
-
 </script>

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -565,4 +565,5 @@ export default class Dataset extends ProgramsBase {
     }
   }
 }
+
 </script>

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -392,11 +392,9 @@ export default class Dataset extends ProgramsBase {
       }
 
       //Exp Replicate # and Exp Block #
-      datasetTableRow.expReplicate = "";
-      datasetTableRow.expBlock = "";
       if (unit.observationUnitPosition && unit.observationUnitPosition.observationLevelRelationships) {
         for (const relationship of unit.observationUnitPosition.observationLevelRelationships) {
-          if (relationship.levelName === 'replicate') {
+          if (relationship.levelName === 'rep') {
             datasetTableRow.expReplicate = relationship.levelCode;
           }
           if (relationship.levelName === 'block') {

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -112,6 +112,14 @@
         </b-table-column>
         <b-table-column
             v-slot="props"
+            label="Env Year"
+            sortable
+            searchable
+            :th-attrs="(column) => ({scope:'col'})"
+        >
+        </b-table-column>
+        <b-table-column
+            v-slot="props"
             field="data.expUnitId"
             label="Exp Unit ID"
             sortable
@@ -211,7 +219,7 @@
 
 
 <script lang="ts">
-import {Component, Prop, Vue, Watch} from 'vue-property-decorator'
+import {Component, Prop, Watch} from 'vue-property-decorator'
 import ProgramsBase from "@/components/program/ProgramsBase.vue";
 import {Result} from "@/breeding-insight/model/Result";
 import {DatasetModel} from "@/breeding-insight/model/DatasetModel";


### PR DESCRIPTION
# Description
**Story:** [BI-1911](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-1911)

A table column for environment year was added to the `Dataset.vue` component. The load method was changed to also fetch all studies and seasons for an experiment using the BrAPI proxy endpoints. A map of environment year using environment DbID as the key is then formed and used to populate the Env Year column when the dataset rows are formed.

A bug was fixed where the rep number was not displaying because the code was checking for "replicate" instead of the property "rep".

`ExperimentDAO#getDatasetById` was returning undefined and was fixed.

Various null checks, error checks,  and type assertions were added and general code clean up was done. 


# Dependencies
bi-api-develop

# Testing
1. Go to the "Experiments and Observations" table
2. Click on any experiment to view the details
3. Verify that there is a column for Environment year
4. Verify the data for both Env Yer and Rep number match the import values


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have tested my code using both Breedbase and the brapi-test-server
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: [6238768821](https://github.com/Breeding-Insight/taf/actions/runs/6238768821)


[BI-1911]: https://breedinginsight.atlassian.net/browse/BI-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ