### PR TITLE
BI-1847 - Experiment import template formatting improvements

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -30,7 +30,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Experiments & Observations'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/28k65fg3mrrcv5s8hm86ap9qijbbi06b.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/ybbz5ntcx54qvylusthsv1sztovuph3d.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -30,7 +30,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Experiments & Observations'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/ybbz5ntcx54qvylusthsv1sztovuph3d.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/a7im2l2cjc7uydzhyb7ck9skxsp6jmc7.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1847

- Experiment & Observations template V05 renamed "Test (T) or Check (C )" to "Test (T) or Check (C)". (https://cornell.app.box.com/folder/154311239564)
- I changed the download link to the new template version hosted on Box.


# Dependencies
https://github.com/Breeding-Insight/bi-api/pull/292
There's a TAF PR as well: https://github.com/Breeding-Insight/taf/pull/125

# Testing
[See acceptance criteria on Jira](https://breedinginsight.atlassian.net/browse/BI-1847).


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6302645562
