### PR TITLE
BI-1852 - Duplicate breeding method can be created

### DIFF
--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -554,7 +554,12 @@ export default class BreedingMethods extends ProgramsBase {
       this.getBreedingMethods();
       this.$emit('show-success-notification', 'Breeding method created successfully');
     } catch (e) {
-      this.$emit('show-error-notification', 'Error while trying to create breeding method');
+      if (e.response.status == 500) {
+        this.$emit('show-error-notification', 'Error while trying to create breeding method');
+      }
+      else{
+        this.$emit('show-error-notification', e.response.data);
+      }
     } finally {
       this.newMethodFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT);
     }
@@ -576,7 +581,12 @@ export default class BreedingMethods extends ProgramsBase {
       this.getBreedingMethods();
       this.$emit('show-success-notification', 'Breeding method updated successfully');
     } catch (e) {
-      this.$emit('show-error-notification', 'Error while trying to update breeding method');
+      if (e.response.status == 500) {
+        this.$emit('show-error-notification', 'Error while trying to create breeding method');
+      }
+      else{
+        this.$emit('show-error-notification', e.response.data);
+      }
     } finally {
       this.editMethodFormState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT)
     }


### PR DESCRIPTION
# Description
**Story:**[ BI-1852](https://breedinginsight.atlassian.net/browse/BI-1852) - Duplicate breeding method can be created

Definition: A Breeding Method is a 'duplicate' if: there already exist a breeding method with the same _name_ or _abbreviation_


# Dependencies
bi-api: bug/BI-1852

# Testing
**Set up**
1. Select a program for which the current user is a _breeder_
2. Go to the Program Administration page
3. Select the _Breeding Methods_ tab

**TEST 1 (create new breeding method)**
1. Select the _Create Breeding Method_ button
2. Create a new breeding method with the same name or abbreviation as an existing breeding method.

EXPECTED RESULT
- An Error banner with the text: "A method with name:'\<name\>' or abbreviation:'\<abbreviation\>' already exist."
- No new breeding method was created.
3. Select the _Create Breeding Method_ button
4. Create a new breeding method with a unique name and abbreviation.

EXPECTED RESULT
- A Success banner is displayed
- New breeding method was created and displayed.


**TEST 2 (edit existing breeding method)**
1. Edit an existing _program_ breeding method.
2. Modify the _name_ or _abbreviation_ fields to duplicate an existing _name_ or _abbreviation_ .
3. Select the _Save_ button

EXPECTED RESULT
- An Error banner with the text: "A method with name:'\<name\>' or abbreviation:'\<abbreviation\>' already exist."
- Changes were not saved.
5. Edit an existing _program_ breeding method.
6. Modify the _name_ or _abbreviation_ fields be new unique (non-duplicate) values.
7. Select the _Save_ button

EXPECTED RESULT
- A Success banner is displayed
- Modified data is listed.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: _\<link to TAF run>_
