### PR TITLE
BI-1799 - Updated Germplasm Import Preview Pagination

### DIFF
--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -24,6 +24,7 @@
         v-bind:import-type-name="'Germplasm'"
         v-bind:confirm-import-state="confirmImportState"
         v-bind:userInput="germplasmList"
+        v-bind:initial-page-size="200"
         v-on="$listeners"
         v-on:finished="importFinished"
     >
@@ -92,7 +93,7 @@
         <ExpandableTable
             v-bind:records="processPreviewData(previewData.import)"
             v-bind:loading="false"
-            v-bind:pagination="paginationWithPageSize(previewData.pagination, 200)"
+            v-bind:pagination="previewData.pagination"
             v-bind:rowClasses="constructRowClasses(previewData.import)"
             v-on:show-error-notification="$emit('show-error-notification', $event)"
             v-bind:is-show-all-enabled="false"
@@ -169,7 +170,6 @@ import {ImportObjectState} from "@/breeding-insight/model/import/ImportObjectSta
 import {ExternalUID} from "@/breeding-insight/model/import/germplasm/ExternalUID";
 import {GermplasmUtils} from "@/breeding-insight/utils/GermplasmUtils";
 import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
-import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 
 @Component({
   components: {
@@ -245,12 +245,5 @@ export default class ImportGermplasm extends ProgramsBase {
     return displayPedigree;
 
   }
-
-  paginationWithPageSize(pagination: PaginationController, pageSize: number) {
-    // Set pageSize on pagination and return it.
-    pagination.updatePageSize(pageSize);
-    return pagination;
-  }
-
 }
 </script>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -92,9 +92,10 @@
         <ExpandableTable
             v-bind:records="processPreviewData(previewData.import)"
             v-bind:loading="false"
-            v-bind:pagination="previewData.pagination"
+            v-bind:pagination="paginationWithPageSize(previewData.pagination, 200)"
             v-bind:rowClasses="constructRowClasses(previewData.import)"
             v-on:show-error-notification="$emit('show-error-notification', $event)"
+            v-bind:is-show-all-enabled="false"
         >
           <b-table-column v-slot="props" :th-attrs="(column) => ({scope:'col'})">
             <AlertTriangleIcon
@@ -168,6 +169,7 @@ import {ImportObjectState} from "@/breeding-insight/model/import/ImportObjectSta
 import {ExternalUID} from "@/breeding-insight/model/import/germplasm/ExternalUID";
 import {GermplasmUtils} from "@/breeding-insight/utils/GermplasmUtils";
 import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
+import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
 
 @Component({
   components: {
@@ -242,6 +244,12 @@ export default class ImportGermplasm extends ProgramsBase {
 
     return displayPedigree;
 
+  }
+
+  paginationWithPageSize(pagination: PaginationController, pageSize: number) {
+    // Set pageSize on pagination and return it.
+    pagination.updatePageSize(pageSize);
+    return pagination;
   }
 
 }

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -187,6 +187,9 @@ export default class ImportTemplate extends ProgramsBase {
   @Prop()
   userInput!: any;
 
+  @Prop({default: 10})
+  initialPageSize!: number;
+
   private systemImportTemplateId!: string;
   private currentImport?: ImportResponse = new ImportResponse({});
   private previewData: any[] = [];
@@ -502,7 +505,7 @@ export default class ImportTemplate extends ProgramsBase {
             this.importService.send(ImportEvent.IMPORT_SUCCESS);
             // TODO: Temp pagination
             this.pagination.totalCount = previewResponse.preview.rows.length;
-            this.pagination.pageSize = 10;
+            this.pagination.pageSize = this.initialPageSize;
             this.pagination.currentPage = 1;
             this.pagination.totalPages = this.pagination.totalCount.valueOf() / this.pagination.pageSize.valueOf();
           }


### PR DESCRIPTION
# Description
**Story:** [story in Jira](https://breedinginsight.atlassian.net/browse/BI-1799)

- Made the default page size 200.
- Removed the show all button.

I added a `initialPageSize` property to `ImportTemplate` with a default value to preserve the previous behavior while allowing consumers to pass their own default.

# Testing
Upload a Germplasm file and ensure the preview table has a default page size of 200 and there is no show all button.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6343050410
