### PR TITLE
BI-1805 - Conditionally Hide Edit Form and Buttons

### DIFF
--- a/src/components/forms/DataForm.vue
+++ b/src/components/forms/DataForm.vue
@@ -24,6 +24,7 @@
     <div class="columns">
       <div class="column is-whole has-text-centered buttons">
         <button
+            v-if="showSaveButton"
             data-testid="save"
             type="button"
             class="button is-primary"
@@ -64,6 +65,8 @@ export default class DataForm extends Vue {
   dataFormState!: DataFormEventBusHandler;
   @Prop({default: "Save"})
   saveButtonLabel?: string
+  @Prop({default: true})
+  showSaveButton?: boolean
   @Prop({default: true})
   showCancelButton?: boolean
 

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -257,7 +257,6 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
 
   isSaveButtonVisible(row: any) {
     // Visible by default, evaluate saveButtonVisible on row if provided.
-    console.log(typeof this.saveButtonVisible);
     return ((typeof this.saveButtonVisible === "function") ? this.saveButtonVisible(row) : true);
   }
 

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -79,11 +79,14 @@
       </template>
 
       <template v-slot:detail="props">
-        <EditDataRowForm class="mb-0"
-                         v-if="editable"
-                         v-bind:data-form-state="dataFormState"
-                         v-on:submit="validateAndSubmit(props.row)"
-                         v-on:cancel="cancelEditClicked(props.row)"
+        <EditDataRowForm
+          v-if="editable"
+          class="mb-0"
+          v-bind:data-form-state="dataFormState"
+          v-bind:show-save-button="isSaveButtonVisible(props.row)"
+          v-bind:show-cancel-button="isCancelButtonVisible(props.row)"
+          v-on:submit="validateAndSubmit(props.row)"
+          v-on:cancel="cancelEditClicked(props.row)"
         >
           <slot
               v-bind:editData="props.row.editData"
@@ -133,6 +136,10 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
   rowEditable!: Function;
   @Prop()
   rowArchivable!: Function;
+  @Prop()
+  saveButtonVisible?: Function;
+  @Prop()
+  cancelButtonVisible?: Function;
   @Prop()
   archivable!: boolean;
   @Prop()
@@ -246,6 +253,17 @@ export default class ExpandableTable extends Mixins(ValidationMixin) {
 
   isRowArchivable(row: any) {
     return ((typeof this.rowArchivable === "function") ? this.rowArchivable(row) : true) && this.archivable;
+  }
+
+  isSaveButtonVisible(row: any) {
+    // Visible by default, evaluate saveButtonVisible on row if provided.
+    console.log(typeof this.saveButtonVisible);
+    return ((typeof this.saveButtonVisible === "function") ? this.saveButtonVisible(row) : true);
+  }
+
+  isCancelButtonVisible(row: any) {
+    // Visible by default, evaluate cancelButtonVisible on row if provided.
+    return ((typeof this.cancelButtonVisible === "function") ? this.cancelButtonVisible(row) : true);
   }
 
   paginate(event: any) {

--- a/src/views/germplasm/BreedingMethods.vue
+++ b/src/views/germplasm/BreedingMethods.vue
@@ -133,6 +133,8 @@
       v-bind:row-validations="newMethodValidations"
       v-bind:archivable="$ability.can('update', 'ProgramConfiguration')"
       v-bind:row-archivable="isRowArchivable"
+      v-bind:save-button-visible="showButtons"
+      v-bind:cancel-button-visible="showButtons"
       v-bind:deactivate-link-text="'Delete'"
       v-on:submit="updateMethod($event)"
       v-on:show-error-notification="$emit('show-error-notification', $event)"
@@ -264,54 +266,55 @@
               <AlertTriangleIcon
                 size="1.2x"
                 class="has-vertical-align-middle"
-              /> Breeding method is in use. Deletion disabled.
+              /> Breeding method is in use. Editing disabled.
             </div>
           </div>
         </div>
-
-        <div class="columns">
-          <div class="column is-one-fourth">
-            <BasicInputField
-              v-model="editData.name"
-              v-bind:validations="validations.name"
-              v-bind:field-name="'Name'"
-              v-bind:field-help="''"
-            />
+        <div v-else>
+          <div class="columns">
+            <div class="column is-one-fourth">
+              <BasicInputField
+                v-model="editData.name"
+                v-bind:validations="validations.name"
+                v-bind:field-name="'Name'"
+                v-bind:field-help="''"
+              />
+            </div>
+            <div class="column is-one-fourth">
+              <BasicInputField
+                v-model="editData.abbreviation"
+                v-bind:validations="validations.abbreviation"
+                v-bind:field-name="'Abbreviation'"
+                v-bind:field-help="'No more than 3 characters'"
+              />
+            </div>
+            <div class="column is-one-fourth">
+              <BasicInputField
+                v-model="editData.description"
+                v-bind:validations="validations.description"
+                v-bind:field-name="'Description'"
+              />
+            </div>
           </div>
-          <div class="column is-one-fourth">
-            <BasicInputField
-              v-model="editData.abbreviation"
-              v-bind:validations="validations.abbreviation"
-              v-bind:field-name="'Abbreviation'"
-              v-bind:field-help="'No more than 3 characters'"
-            />
-          </div>
-          <div class="column is-one-fourth">
-            <BasicInputField
-              v-model="editData.description"
-              v-bind:validations="validations.description"
-              v-bind:field-name="'Description'"
-            />
-          </div>
-        </div>
-        <div class="columns">
-          <div class="column is-one-fourth">
-            <BasicSelectField
-              v-model="editData.category"
-              v-bind:selected-id="editData.category"
-              v-bind:validations="validations.category"
-              v-bind:options="categories"
-              v-bind:field-name="'Category'"
-            />
-          </div>
-          <div class="column is-one-fourth">
-            <BasicSelectField
-              v-model="editData.geneticDiversity"
-              v-bind:selected-id="editData.geneticDiversity"
-              v-bind:validations="validations.geneticDiversity"
-              v-bind:options="diversities"
-              v-bind:field-name="'Genetic Diversity'"
-            />
+          <div class="columns">
+            <div class="column is-one-fourth">
+              <BasicSelectField
+                v-model="editData.category"
+                v-bind:selected-id="editData.category"
+                v-bind:validations="validations.category"
+                v-bind:options="categories"
+                v-bind:field-name="'Category'"
+              />
+            </div>
+            <div class="column is-one-fourth">
+              <BasicSelectField
+                v-model="editData.geneticDiversity"
+                v-bind:selected-id="editData.geneticDiversity"
+                v-bind:validations="validations.geneticDiversity"
+                v-bind:options="diversities"
+                v-bind:field-name="'Genetic Diversity'"
+              />
+            </div>
           </div>
         </div>
       </template>
@@ -595,6 +598,10 @@ export default class BreedingMethods extends ProgramsBase {
       return this.inUseBreedingMethods.includes(method.id!);
     }
     return false;
+  }
+
+  showButtons(row: TableRow<BreedingMethod>) {
+    return !this.isMethodInUse(row.data);
   }
 
   filterByScope(row: TableRow<BreedingMethod>, input: string) {


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1805

> Note: this is the second PR for BI-1805, it failed QA.
 
It was determined that the edit form fields and buttons should be hidden for in-use breeding methods. An informative message is shown in place of the edit form for in-use breeding methods.

# Testing
- Create 2 new breeding methods in a program.
- Upload a germplasm file that uses one of those new breeding methods.
- Ensure that the unused breeding method can be edited and deleted.
- Ensure that the in-use breeding method cannot be edited or deleted, and an informational message is shown in place of the edit form.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6354817163
