### PR TITLE
BI-1926 - Environment count incorrect

### DIFF
--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -52,7 +52,8 @@
           <section>
             <ul style="list-style-type: none;">
               <li><b>Germplasm: </b> {{ germplasmCount }}</li>
-              <li><b>Environments: </b> {{ environmentsCount }}</li>
+<!--              the following may be revived later-->
+<!--              <li><b>Environments: </b> {{ environmentsCount }}</li>-->
             </ul>
           </section>
         </article>
@@ -172,10 +173,11 @@ export default class ExperimentDetails extends ProgramsBase {
     if( !this.experiment.additionalInfo ){return '';}
     return this.experiment.additionalInfo.germplasmCount;
   }
-  get environmentsCount(): string {
-    if( !this.experiment.additionalInfo ){return '';}
-    return this.experiment.additionalInfo.environmentsCount;
-  }
+  // This is not being used.  But may be used later.
+  // get environmentsCount(): string {
+  //   if( !this.experiment.additionalInfo ){return '';}
+  //   return this.experiment.additionalInfo.environmentsCount;
+  // }
 
   @Watch('$route')
   async getExperiment () {


### PR DESCRIPTION
# Description
[BI-1926](https://breedinginsight.atlassian.net/browse/BI-1926) - Environment count incorrect

Comment out  the “Environments” count from the Experiment Details page.



# Dependencies
bi-api: develop branch

# Testing
view any experiments Details page.  The “Environments” count should not appear (it was below the "Germplasm" count in the summary section)


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [X] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6486493409


[BI-1926]: https://breedinginsight.atlassian.net/browse/BI-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ