### PR TITLE
[BI-1927] - Entry Numbers Not Displaying

### DIFF
--- a/src/breeding-insight/utils/GermplasmUtils.ts
+++ b/src/breeding-insight/utils/GermplasmUtils.ts
@@ -49,7 +49,7 @@ export class GermplasmUtils {
     static getEntryNumber(germplasm: Germplasm, referenceId: string | undefined): string | undefined {
         if (germplasm.additionalInfo) {
             return referenceId ? germplasm.additionalInfo.listEntryNumbers[<any>referenceId] :
-                germplasm.additionalInfo.importEntryMumber;
+                germplasm.additionalInfo.importEntryNumber;
         }
         return "";
     }


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1927

- Fixed typo.

# Testing
The bug occurred with old data that lacked the `listEntryNumbers` key in `additionalInfo`. The fix allows the frontend to fall-back on the `importEntryNumber`, as the import file represents the first/original list. (When support was added to DeltaBreed for multiple lists per Germplasm, the `listEntryNumbers` key was added). I've tested creating new lists with old germplasm data and it works; the first/original list position is stored by the `importEntryNumber`, while the subsequent lists will use `listEntryNumbers`.  When testing locally you can use BreedBase and
- upload Germplasm, with List name "NEW LIST",
- delete the list external reference from the database using the SQL below,
- go to the Germplasm List list view and ensure entry numbers are present.


```SQL
-- Delete list external reference.
-- Will not remove listEntryNumbers from Germplasm, but breaks the link to a list.
DELETE FROM public.dbxref
WHERE 
    dbxref.dbxref_id =
    (
        SELECT xr.dbxref_id
        FROM
            public.dbxref xr
            JOIN
            sgn_people.list_dbxref lxr ON xr.dbxref_id = lxr.dbxref_id
            JOIN
            sgn_people.list l ON lxr.list_id = l.list_id
            JOIN
            public.db ON db.db_id = xr.db_id AND db.name = 'breedinginsight.org/lists'
        WHERE
            l.name LIKE 'NEW LIST%'
    )
;
```


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: https://github.com/Breeding-Insight/taf/actions/runs/6502014923
