### PR TITLE
BI-1911 fix QA findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v0.8.1+603",
+  "version": "v0.8.1+609",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -94,5 +94,5 @@
     "vue-template-compiler": "^2.6.10"
   },
 
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/8853c484a01c25f9c2f5a01d185d2172885cd046"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/b70ddaa40ab76ca30f71946f81f7336bc2a5ee12"
 }

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -558,7 +558,7 @@ export default class Dataset extends ProgramsBase {
     } catch (err: any) {
 
       // Display error that experiment cannot be loaded
-      this.$emit('show-error-notification', 'Error while trying to load data set' + err.message());
+      this.$emit('show-error-notification', 'Error while trying to load data set');
       throw err;
     } finally {
       this.loading = false;

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -103,7 +103,7 @@
           </b-table-column>
           <!-- Env year -->
           <b-table-column field="envYear" label="Env Year" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ getEnvYear(props.row.data.study) }}
+            {{ getField(props.row.data.study, 'additionalInfo.envYear') }}
           </b-table-column>
           <!-- Exp Unit ID -->
           <b-table-column field="expUnitID" label="Exp Unit ID" v-slot="props" :th-attrs="(column) => ({scope:'col'})">

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -95,7 +95,7 @@
           </b-table-column>
           <!-- Env -->
           <b-table-column field="env" label="Env" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ getField(props.row.data.study, 'studyName') }}
+            {{ getField(props.row.data.study, 'studyName', true) }}
           </b-table-column>
           <!-- Env Location -->
           <b-table-column field="envLocation" label="Env Location" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
@@ -107,7 +107,7 @@
           </b-table-column>
           <!-- Exp Unit ID -->
           <b-table-column field="expUnitID" label="Exp Unit ID" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ getField(props.row.data.observationUnit, 'observationUnitName') }}
+            {{ getField(props.row.data.observationUnit, 'observationUnitName', true) }}
           </b-table-column>
           <!-- Exp Replicate # -->
           <b-table-column field="expRepNo" label="Exp Replicate #" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
@@ -180,7 +180,7 @@ export default class ImportExperiment extends ProgramsBase {
     return undefined;
   }
 
-  getField(importReturnObject: any, fieldAccessor: string) {
+  getField(importReturnObject: any, fieldAccessor: string, isRemovingUnique: boolean=false) {
     const accessors: string[] = fieldAccessor.split('.');
     const brapiObject = importReturnObject.brAPIObject;
     let currObject = brapiObject;
@@ -192,7 +192,11 @@ export default class ImportExperiment extends ProgramsBase {
       if (!currObject[accessor]) {
         return '';
       } else if (accessors.length == 0) {
-        return currObject[accessor];
+        let value = currObject[accessor];
+        if(isRemovingUnique){
+          value = this.removeUnique(value);
+        }
+        return value;
       } else {
         currObject = currObject[accessor];
       }
@@ -248,6 +252,15 @@ export default class ImportExperiment extends ProgramsBase {
       //Is phenotype observation
       return importReturnObject.filter((observation: { brAPIObject: { observationVariableName: string; }; }) => observation.brAPIObject.observationVariableName === column)[0].brAPIObject.value
     }
+  }
+  /*
+   * remove the '[....]' found at the end of the string
+   * */
+  removeUnique(str: string|undefined): string {
+    if(!str){ return "";}
+    str = str.trim();
+    const reg = /\[[^\]]*\]$/;
+    return str.replace(reg, '').trim();
   }
 }
 </script>


### PR DESCRIPTION
# Description
[BI-1911](https://breedinginsight.atlassian.net/browse/BI-1911) - in response to Shahana's [testing notes.](https://breedinginsight.atlassian.net/browse/BI-1911?focusedCommentId=14057)


# Dependencies
bi-api: bug/BI-1911-2 branch

# Testing
- Import an Experiment.
- Look at the confirmation page.

**Expected Results**
- The `Env Year`, `Env`, and  `Exp unit ID` columns should appear as they did in the import file.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: _\<link to TAF run>_


[BI-1911]: https://breedinginsight.atlassian.net/browse/BI-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ