### PR TITLE
[BI-1927] - fixed typo

### DIFF
--- a/src/breeding-insight/utils/GermplasmUtils.ts
+++ b/src/breeding-insight/utils/GermplasmUtils.ts
@@ -49,7 +49,7 @@ export class GermplasmUtils {
     static getEntryNumber(germplasm: Germplasm, referenceId: string | undefined): string | undefined {
         if (germplasm.additionalInfo) {
             return referenceId ? germplasm.additionalInfo.listEntryNumbers[<any>referenceId] :
-                germplasm.additionalInfo.importEntryMumber;
+                germplasm.additionalInfo.importEntryNumber;
         }
         return "";
     }


### PR DESCRIPTION
Identical code changes as https://github.com/Breeding-Insight/bi-web/pull/338, but based on `release/0.8.1`.
