### PR TITLE
BI-1963 - Remove Data Mapping tab from import page

### DIFF
--- a/src/views/import/ImportFile.vue
+++ b/src/views/import/ImportFile.vue
@@ -45,11 +45,14 @@
               tag="li" active-class="is-active">
             <a>Genotypic Data</a>
           </router-link>
+          <!-- BI-1963 - Comment out data mapping tab, left url access in case want to get to it -->
+          <!--
           <router-link
               v-bind:to="{name: 'data-mapping', params: {programId: activeProgram.id}}"
               tag="li" active-class="is-active">
             <a>Data Mapping<span class="ml-2 tag is-warning">Beta</span></a>
           </router-link>
+          -->
         </ul>
       </nav>
     </section>


### PR DESCRIPTION
# Description
**Story:** [BI-1963](https://breedinginsight.atlassian.net/browse/BI-1963?atlOrigin=eyJpIjoiZTMxY2NjODUyOWI3NDQwY2I4YmRiZWQzNDc1ZDFmYTUiLCJwIjoiaiJ9)

- Removed Data Mapping tab from import page

# Dependencies
- None

# Testing
- Verify Data Mapping tab is no longer shown on import page

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1963]: https://breedinginsight.atlassian.net/browse/BI-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ