### PR TITLE
BI-1958 - Hide images and attributes tabs from germplasm details

### DIFF
--- a/src/views/germplasm/GermplasmDetails.vue
+++ b/src/views/germplasm/GermplasmDetails.vue
@@ -67,24 +67,28 @@
       <section>
         <nav class="tabs is-boxed">
           <ul>
+            <!--
             <router-link
                 v-bind:to="{name: '', params: {programId: activeProgram.id}}"
                 tag="li"
             >
               <a>Images</a>
             </router-link>
+            -->
             <router-link
                 v-bind:to="{name: 'germplasm-pedigrees', params: {programId: activeProgram.id, germplasmDbId: germplasm.germplasmDbId}}"
                 tag="li" active-class="is-active"
             >
               <a>Pedigrees</a>
             </router-link>
+            <!--
             <router-link
                 v-bind:to="{name: '', params: {programId: activeProgram.id}}"
                 tag="li"
             >
               <a>Attributes</a>
             </router-link>
+            -->
             <router-link
                 v-bind:to="{name: 'germplasm-genotype', params: {programId: activeProgram.id}}"
                 tag="li" active-class="is-active"


### PR DESCRIPTION
# Description
**Story:** [BI-1958](https://breedinginsight.atlassian.net/browse/BI-1958?atlOrigin=eyJpIjoiOWE2Yjc4MzExNGRjNDY3MjkyNzlhOTI5ZmRlMjE5NjYiLCJwIjoiaiJ9)

- Removed images and attributes tabs from germplasm details view

# Dependencies
- None

# Testing
- Verify that images and attributes tabs are not visible in germplasm details view


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1958]: https://breedinginsight.atlassian.net/browse/BI-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ