### PR TITLE
BI-1935 - Error remains displayed

### DIFF
--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -119,6 +119,7 @@ import {Trait} from "@/breeding-insight/model/Trait";
 import {ProgramUpload} from "@/breeding-insight/model/ProgramUpload";
 import {AxiosResponse} from "axios";
 import {DataFormEventBusHandler} from "@/components/forms/DataFormEventBusHandler";
+import {DEACTIVATE_ALL_NOTIFICATIONS} from "@/store/mutation-types";
 
 enum ImportState {
   CHOOSE_FILE = "CHOOSE_FILE",
@@ -288,6 +289,7 @@ export default class TraitsImport extends ProgramsBase {
   }
 
   upload() {
+    this.$store.commit(DEACTIVATE_ALL_NOTIFICATIONS);
     TraitUploadService.uploadFile(this.activeProgram!.id!, this.file!).then((response) => {
       let count = 0;
       let traits: Trait[] = [];
@@ -312,6 +314,7 @@ export default class TraitsImport extends ProgramsBase {
   }
 
   abort() {
+    this.$store.commit(DEACTIVATE_ALL_NOTIFICATIONS);
     // TODO: actually cancel request
     this.showCancelledNotification();
   }
@@ -340,6 +343,7 @@ export default class TraitsImport extends ProgramsBase {
   }
 
   async confirm() {
+    this.$store.commit(DEACTIVATE_ALL_NOTIFICATIONS);
     const name = this.activeProgram && this.activeProgram.name ? this.activeProgram.name : 'the program';
     try {
       // fetch uploaded traits


### PR DESCRIPTION
# Description
**Story:** [BI-1935](https://breedinginsight.atlassian.net/browse/BI-1935?atlOrigin=eyJpIjoiNDgwNzZjZjMzZTgxNGQ5MGJlYzNhODgyNDc2YTE0MGQiLCJwIjoiaiJ9)

- Clear notifications like import template does

# Dependencies
- None

# Testing
- Verify that error notification is cleared when new file is uploaded after an existing error

[bi_ontology_template_v14_good.xlsx](https://github.com/Breeding-Insight/bi-web/files/13270919/bi_ontology_template_v14_good.xlsx)
[bi_ontology_template_v14_error.xlsx](https://github.com/Breeding-Insight/bi-web/files/13270920/bi_ontology_template_v14_error.xlsx)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1935]: https://breedinginsight.atlassian.net/browse/BI-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ