### PR TITLE
BI-1922 (Add ability to download all germplasm in a program)

### DIFF
--- a/src/breeding-insight/model/ActionMenuItem.ts
+++ b/src/breeding-insight/model/ActionMenuItem.ts
@@ -19,12 +19,12 @@ export class ActionMenuItem {
     id?: string;
     event?: string;
     label?: string;
-    disabled?: boolean;
+    enabled?: boolean;
 
-    constructor(id?:string, event?:string, label?:string, disabled?: boolean) {
+    constructor(id?:string, event?:string, label?:string, enabled: boolean=true) {
         this.id = id;
         this.event = event;
         this.label = label;
-        this.disabled = disabled;
+        this.enabled = enabled;
     }
 }

--- a/src/breeding-insight/model/ActionMenuItem.ts
+++ b/src/breeding-insight/model/ActionMenuItem.ts
@@ -19,10 +19,12 @@ export class ActionMenuItem {
     id?: string;
     event?: string;
     label?: string;
+    disabled?: boolean;
 
-    constructor(id?:string, event?:string, label?:string) {
+    constructor(id?:string, event?:string, label?:string, disabled?: boolean) {
         this.id = id;
         this.event = event;
         this.label = label;
+        this.disabled = disabled;
     }
 }

--- a/src/components/layouts/menus/ActionMenu.vue
+++ b/src/components/layouts/menus/ActionMenu.vue
@@ -32,6 +32,7 @@
     <b-dropdown-item v-for="menuItem in actionMenuItems"
                      v-bind:key="menuItem.id" aria-role="menuitem"
                      v-bind:id="menuItem.id"
+                     v-bind:disabled="menuItem.disabled"
                      @click="$emit(menuItem.event)">
       {{menuItem.label}}
     </b-dropdown-item>
@@ -55,8 +56,6 @@ export default class ActionMenu extends Vue {
   id!: string;
   @Prop()
   isPrimary!: boolean;
-
-
 }
 
 </script>

--- a/src/components/layouts/menus/ActionMenu.vue
+++ b/src/components/layouts/menus/ActionMenu.vue
@@ -32,7 +32,7 @@
     <b-dropdown-item v-for="menuItem in actionMenuItems"
                      v-bind:key="menuItem.id" aria-role="menuitem"
                      v-bind:id="menuItem.id"
-                     v-bind:disabled="menuItem.disabled"
+                     v-bind:disabled="!menuItem.enabled"
                      @click="$emit(menuItem.event)">
       {{menuItem.label}}
     </b-dropdown-item>

--- a/src/views/germplasm/Germplasm.vue
+++ b/src/views/germplasm/Germplasm.vue
@@ -103,7 +103,7 @@ export default class Germplasm extends GermplasmBase {
   private downloadFile() {
     console.info('download file.');
     if (this.activeProgram) {
-      window.open(process.env.VUE_APP_BI_API_ROOT + '/v1/programs/' + this.activeProgram.id + '/germplasm/export?fileExtension=XLS' , '_blank');
+      window.open(process.env.VUE_APP_BI_API_ROOT + '/v1/programs/' + this.activeProgram.id + '/germplasm/export?fileExtension=XLSX' , '_blank');
       return true;
     }
     return false;

--- a/src/views/germplasm/Germplasm.vue
+++ b/src/views/germplasm/Germplasm.vue
@@ -38,21 +38,16 @@
           >
             <a>Lists</a>
           </router-link>
-          <button
-              v-if="$ability.can('create', 'Import')"
-              class="button is-primary is-pulled-right has-text-weight-bold above-tabs-button"
-              v-on:click="$router.push({name: 'germplasm-import', params: {programId: activeProgram.id}})"
-          >
-        <span class="icon is-small">
-          <PlusCircleIcon
-              size="1.5x"
-              aria-hidden="true"
-          />
-        </span>
-            <span>
-          Import Batch File
-        </span>
-          </button>
+            <ActionMenu
+                class = "is-pulled-right has-text-weight-bold above-tabs-button"
+                v-bind:is-primary="true"
+                        v-bind:id="'manage-experiment-dropdown-button'"
+                        v-bind:button-text="'Manage Germplasm'"
+                        v-bind:action-menu-items=actions
+                        v-on:import-file="importFile()"
+                        v-on:download-file="downloadFile()"
+            />
+
         </ul>
       </nav>
     </section>
@@ -73,9 +68,14 @@ import {mapGetters} from "vuex";
 import {Program} from "@/breeding-insight/model/Program";
 import GermplasmBase from "@/components/germplasm/GermplasmBase.vue";
 import {PlusCircleIcon} from 'vue-feather-icons'
+import ActionMenu from "@/components/layouts/menus/ActionMenu.vue";
+import {ActionMenuItem} from "@/breeding-insight/model/ActionMenuItem";
 
 @Component({
-  components: { PlusCircleIcon },
+  components: {
+    PlusCircleIcon,
+    ActionMenu
+  },
   computed: {
     ...mapGetters([
       'activeProgram'
@@ -86,5 +86,27 @@ export default class Germplasm extends GermplasmBase {
 
   private activeProgram?: Program;
 
+  private actions: ActionMenuItem[] = [
+    new ActionMenuItem('germplasm-import-file', 'import-file', 'Import file'),
+    new ActionMenuItem('germplasm-download-file', 'download-file', 'Download file')
+  ];
+
+  private importFile() {
+    this.$router.push({
+      name: 'germplasm-import',
+      params: {
+        programId: this.activeProgram!.id!
+      },
+    });
+  }
+
+  private downloadFile() {
+    console.info('download file.');
+    if (this.activeProgram) {
+      window.open(process.env.VUE_APP_BI_API_ROOT + '/v1/programs/' + this.activeProgram.id + '/germplasm/export?fileExtension=XLS' , '_blank');
+      return true;
+    }
+    return false;
+  }
 }
 </script>

--- a/src/views/germplasm/Germplasm.vue
+++ b/src/views/germplasm/Germplasm.vue
@@ -87,8 +87,8 @@ export default class Germplasm extends GermplasmBase {
   private activeProgram?: Program;
 
   private actions: ActionMenuItem[] = [
-    new ActionMenuItem('germplasm-import-file', 'import-file', 'Import file'),
-    new ActionMenuItem('germplasm-download-file', 'download-file', 'Download file')
+    new ActionMenuItem('germplasm-import-file', 'import-file', 'Import file', this.$ability.cannot('create', 'Import')),
+    new ActionMenuItem('germplasm-download-file', 'download-file', 'Download file',  false)
   ];
 
   private importFile() {

--- a/src/views/germplasm/Germplasm.vue
+++ b/src/views/germplasm/Germplasm.vue
@@ -87,8 +87,8 @@ export default class Germplasm extends GermplasmBase {
   private activeProgram?: Program;
 
   private actions: ActionMenuItem[] = [
-    new ActionMenuItem('germplasm-import-file', 'import-file', 'Import file', this.$ability.cannot('create', 'Import')),
-    new ActionMenuItem('germplasm-download-file', 'download-file', 'Download file',  false)
+    new ActionMenuItem('germplasm-import-file', 'import-file', 'Import file', this.$ability.can('create', 'Import')),
+    new ActionMenuItem('germplasm-download-file', 'download-file', 'Download file',  true)
   ];
 
   private importFile() {


### PR DESCRIPTION
# Description
[BI-1922](https://breedinginsight.atlassian.net/browse/BI-1922) Add ability to download all germplasm in a program

# Dependencies
bi-api: feature/BI-1922

# Testing

- From the side menu, select _Germplasm_ to see a list of all germplasm for the project
**Expected Result**
 . the `Mange Germplasm` pull-down is visible. 
- Select `Download file` from the `Mange Germplasm` pull-down
**Expected Result**
 . A file with the name `<project>_germplasm_<timestamp>.xlsx` should be downloaded.
 . The file should contain all the correct information (except for `Female Parent Entry No` and `Male Parent Entry No`) for every germplasm in the project.
 . The data should be in GID order.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] I have run TAF: [link](https://github.com/Breeding-Insight/taf/actions/runs/6829181990)


[BI-1922]: https://breedinginsight.atlassian.net/browse/BI-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ