### PR TITLE
BI-1912 - Wonky spacing on exp dataset summary

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -27,23 +27,47 @@
           class="message is-success"
       >
         <div class="message-body">
-          <div class="columns is-multiline">
-            <div class="column is-one-third">
-              <div class="has-text-right">
-                <b>Observation unit: </b> <span style="width: 30px;"
-                                                class="is-inline-block has-text-left">{{ observationUnit }}</span><br>
-                <b>Phenotypes: </b> <span style="width: 30px;" class="is-inline-block has-text-left">{{
-                  phenotypesCount
-                }}</span><br>
-                <b>Total observations: </b> <span style="width: 30px;" class="is-inline-block has-text-left">{{
-                  totalObservationsCount
-                }}</span><br>
-                <b>Observations with data: </b> <span style="width: 30px;" class="is-inline-block has-text-left">{{
-                  observationsWithData
-                }}</span><br>
-                <b>Observations without data: </b> <span style="width: 30px;" class="is-inline-block has-text-left">{{
-                  observationsWithoutData
-                }}</span><br>
+          <div class="columns">
+            <div class="column">
+              <div class="columns mb-0">
+                <div class="column has-text-right pr-0 pb-0">
+                  <b>Observation unit:</b>
+                </div>
+                <div class="column pl-1 is-three-quarters pb-0">
+                  {{ observationUnit }}
+                </div>
+              </div>
+              <div class="columns mb-0 pb-0 pt-0">
+                <div class="column has-text-right pr-0 pb-0">
+                  <b>Phenotypes:</b>
+                </div>
+                <div class="column pl-1 is-three-quarters pb-0">
+                  {{ phenotypesCount }}
+                </div>
+              </div>
+              <div class="columns mb-0 pb-0 pt-0">
+                <div class="column has-text-right pr-0 pb-0">
+                  <b>Total observations:</b>
+                </div>
+                <div class="column pl-1 is-three-quarters pb-0">
+                  {{ totalObservationsCount }}
+                </div>
+              </div>
+              <div class="columns mb-0 pb-0 pt-0">
+                <div class="column has-text-right pr-0 pb-0">
+                  <b>Observations with data:</b>
+                </div>
+                <div class="column pl-1 is-three-quarters pb-0">
+                  {{ observationsWithData }}
+                </div>
+              </div>
+              <div class="columns mb-0 pb-0 pt-0">
+                <div class="column has-text-right pr-0 pb-0">
+                  <b>Observations without data:</b>
+                </div>
+                <div class="column pl-1 is-three-quarters pb-0">
+                  {{ observationsWithoutData }}
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Description
**Story:** [BI-1912](https://breedinginsight.atlassian.net/browse/BI-1912?atlOrigin=eyJpIjoiYjI2MDgwNjlmMGUyNDJiODkyZTM1ODdlZmQ1YzFlNjQiLCJwIjoiaiJ9)

- [Utilize more space before line wrapping text](https://github.com/Breeding-Insight/bi-web/pull/353/commits/999a51618bd48e24f2ea52593aea9a079ac10753)

# Dependencies
- None
 
# Testing
- Upload an experiment with long observation unit names and verify that the display text does not wrap as before.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1912]: https://breedinginsight.atlassian.net/browse/BI-1912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ