### PR TITLE
[BI-2036] Update guest accounts listed in Sandbox left sidebar nav menu

### DIFF
--- a/src/components/layouts/InfoSideBarLayout.vue
+++ b/src/components/layouts/InfoSideBarLayout.vue
@@ -54,7 +54,7 @@
           <h1
             class="title has-text-warning is-5"
           >
-            Guest Accounts
+            Guest Account
           </h1>
           <p class="has-text-light is-paddingless">
             Use these credentials to explore sample data and currently available features.
@@ -72,7 +72,7 @@
               </div>
               <div class="column">
                 <p class="is-paddingless is-marginless has-text-light is-size-7">
-                  using one of the supplied guest accounts
+                  using the supplied guest account
                 </p>
               </div>
             </div>
@@ -81,57 +81,13 @@
 
           <article class="block">
             <h2 class="has-text-warning is-5 is-normal">
-              Alfalfa Guest
+              Guest
             </h2>
             <p class="has-text-light is-paddingless is-marginless">
-              user: alfalfa@mailinator.com
+              user: guestusr@mailinator.com
             </p>
             <p class="has-text-light is-paddingless">
-              password: alfalfa1
-            </p>
-          </article>
-          <article class="block">
-            <h2 class="has-text-warning is-5 is-normal">
-              Blueberry Guest
-            </h2>
-            <p class="has-text-light is-paddingless is-marginless">
-              user: blueberry@mailinator.com
-            </p>
-            <p class="has-text-light is-paddingless">
-              password: blueberry1
-            </p>
-          </article>
-          <article class="block">
-            <h2 class="has-text-warning is-5 is-normal">
-              Grape Guest
-            </h2>
-            <p class="has-text-light is-paddingless is-marginless">
-              user: grape@mailinator.com
-            </p>
-            <p class="has-text-light is-paddingless">
-              password: grape--1
-            </p>
-          </article>
-          <article class="block">
-            <h2 class="has-text-warning is-5 is-normal">
-              Salmonids Guest
-            </h2>
-            <p class="has-text-light is-paddingless is-marginless">
-              user: salmonid@mailinator.com
-            </p>
-            <p class="has-text-light is-paddingless">
-              password: salmonid1
-            </p>
-          </article>
-          <article class="block">
-            <h2 class="has-text-warning is-5 is-normal">
-              Sweetpotato Guest
-            </h2>
-            <p class="has-text-light is-paddingless is-marginless">
-              user: sweetpotato@mailinator.com
-            </p>
-            <p class="has-text-light is-paddingless">
-              password: sweetpotato1
+              password: guestusr1
             </p>
           </article>
         </div>


### PR DESCRIPTION
# Description
**Story:** [BI-2036](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2036)

The list of species-specific guest accounts in the sandbox sidebar is replaced with a single guest account.



# Dependencies
none

# Testing
Run bi-web in public sandbox mode and verify that only the single guest account is displayed.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2036]: https://breedinginsight.atlassian.net/browse/BI-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ