### PR TITLE
BI-2029 (Experiment Preview and Visual Progress Indicators Broken in v0.90

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -282,22 +282,18 @@ export default class ImportExperiment extends ProgramsBase {
   // Map phenotypeColumn indices to brapi observation indices for use in highlighting
   createObservationIndexMap() {
     let obs_index = 0;
+    // this assumes that any timestamp for an ontology immediately follows the ontology
+    let is_first_obs = true;
     for (let i=0; i < this.phenotypeColumns!.length; i++) {
-      if (this.phenotypeColumns![i].startsWith('TS:')) {
-        this.observationIndexMap.set(i, obs_index++);
-      } else {
-        if (i+1 < this.phenotypeColumns!.length) {
-          if (!this.phenotypeColumns![i+1].startsWith('TS:')) {
-            obs_index++;
-          }
-        } else {
-          if (obs_index > 0) {
-            obs_index++;
-          }
+      if (!this.phenotypeColumns![i].startsWith('TS:')) {
+        if( ! is_first_obs ){
+          obs_index++;
         }
-        this.observationIndexMap.set(i, obs_index);
+        is_first_obs = false;
       }
+      this.observationIndexMap.set(i, obs_index);
     }
+    console.info(this.observationIndexMap);
   }
 
   statisticsLoaded(statistics: any) {
@@ -323,8 +319,9 @@ export default class ImportExperiment extends ProgramsBase {
 
   cellClassIfExisting(row: any, column: any) {
     const index = column.meta.index
-
-    if(row.data.observations[this.observationIndexMap.get(index)!].state === 'MUTATED') {
+    let i = this.observationIndexMap.get(index);
+    console.info('i = ' + i);
+    if(row.data.observations[i].state === 'MUTATED') {
       return {'class': 'db-filled'};
     }
     return {};

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -293,7 +293,6 @@ export default class ImportExperiment extends ProgramsBase {
       }
       this.observationIndexMap.set(i, obs_index);
     }
-    console.info(this.observationIndexMap);
   }
 
   statisticsLoaded(statistics: any) {
@@ -319,9 +318,8 @@ export default class ImportExperiment extends ProgramsBase {
 
   cellClassIfExisting(row: any, column: any) {
     const index = column.meta.index
-    let i = this.observationIndexMap.get(index);
-    console.info('i = ' + i);
-    if(row.data.observations[i].state === 'MUTATED') {
+
+    if(row.data.observations[this.observationIndexMap.get(index)!].state === 'MUTATED') {
       return {'class': 'db-filled'};
     }
     return {};


### PR DESCRIPTION
# Description
[BI-2029](https://breedinginsight.atlassian.net/browse/BI-2029) Experiment Preview and Visual Progress Indicators Broken in v0.9

In _ImportExperiment.vue_,the method _createObservationIndexMap()_ was setting values in _this.observationIndexMap_ that cause an out-of-bounds error in _cellClassIfExisting_.  This modifies _createObservationIndexMap()_ so that does not happen.

# Dependencies
bi-api: development branch 

# Testing
1) import an experiment with 2 or more observation variables.
EXPECTED RESULT
Experiment preview is displayed.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2029]: https://breedinginsight.atlassian.net/browse/BI-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ