### PR TITLE
[BI-1868] - Ontology: Display full name in table and details pane

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -48,7 +48,8 @@ export enum TraitSortField {
   Name = 'name',
   MethodDescription = 'methodDescription',
   ScaleClass = 'scaleClass',
-  ScaleName = 'scaleName'
+  ScaleName = 'scaleName',
+  FullName = 'fullName'
 }
 
 // ontology
@@ -58,7 +59,8 @@ export enum OntologySortField {
   ScaleClass = 'scaleClass',
   ScaleName = 'scaleName',
   entityAttributeSortLabel = 'entityAttribute',
-  TermType = 'termType'
+  TermType = 'termType',
+  FullName = 'fullName'
 }
 
 export class OntologySort {

--- a/src/breeding-insight/model/TraitSelector.ts
+++ b/src/breeding-insight/model/TraitSelector.ts
@@ -23,7 +23,8 @@ export enum TraitField {
   UPDATED_BY_USER_ID = 'updatedByUserId',
   UPDATED_BY_USER_NAME = 'updatedByUserName',
   TERM_TYPE = 'termType',
-  ENTITY_ATTRIBUTE = 'entityAttribute'
+  ENTITY_ATTRIBUTE = 'entityAttribute',
+  FULL_NAME = 'fullName'
 }
 
 export enum TermType {

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -109,6 +109,9 @@
       <b-table-column :field="traitField.NAME" label="Name" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ props.row.data.observationVariableName }}
       </b-table-column>
+      <b-table-column :field="traitField.FULL_NAME" label="Full Name" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
+        {{ props.row.data.fullName }}
+      </b-table-column>
       <b-table-column :field="traitField.TERM_TYPE" label="Term Type" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ TraitStringFormatters.getTermTypeString(props.row.data.termType) }}
       </b-table-column>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -23,6 +23,15 @@
         <span v-if="!data.active" class="tag is-link is-normal ml-1">Archived</span>
       </p><br>
 
+      <div v-if="data.fullName" class="columns is-desktop pt-1 pl-3">
+        <div class="column is-one-third pt-0 pb-0 has-text-right-desktop">
+          <span class="has-text-weight-bold">Full Name</span>
+        </div>
+        <div class="column pt-0 pb-0">
+          <span class="is-size-7 mb-0">{{data.fullName}}</span>
+        </div>
+      </div>
+
       <div v-if="data.traitDescription" class="columns is-desktop pt-1 pl-3">
         <div class="column is-one-third pt-0 pb-0 has-text-right-desktop">
           <span class="has-text-weight-bold">Description</span>

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -55,6 +55,19 @@
           {{ data.observationVariableName }}
         </TableColumn>
         <TableColumn
+            name="fullName"
+            v-bind:label="'Full Name'"
+            v-bind:visible="!collapseColumns"
+            v-bind:sortField="importPreviewOntologySort.field"
+            v-bind:sortFieldLabel="fullNameSortLabel"
+            v-bind:sortable="true"
+            v-bind:sortOrder="importPreviewOntologySort.order"
+            v-on:newSortColumn="newSortColumn"
+            v-on:toggleSortOrder="toggleSortOrder"
+        >
+          {{ data.fullName }}
+        </TableColumn>
+        <TableColumn
             name="termType"
             v-bind:label="'Term Type'"
             v-bind:visible="!collapseColumns"
@@ -233,6 +246,7 @@ export default class TraitsImportTable extends Vue {
   private unitSortLabel: string = OntologySortField.ScaleName;
   private entityAttributeSortLabel: string = OntologySortField.entityAttributeSortLabel;
   private termTypeSortLabel: string = OntologySortField.TermType;
+  private fullNameSortLabel: string = OntologySortField.FullName;
 
   mounted() {
     this.updatePagination();


### PR DESCRIPTION
# Description
**Story:** [BI-1868 - Ontology: Display full name in table and details pane] (https://breedinginsight.atlassian.net/browse/BI-1868)

Added sortable and searchable full name column for ontology term table and sortable full name column for ontology import preview table.

# Dependencies
bi-api: feature/BI-1868

# Testing
-Look at ontology table
--Check that there is a full name column with the correct values
--Check that the full name column sorts properly
--Check that the full name column can be filtered properly

- Upload an ontology file and look at the import preview table
--Check that there is a full name column with the correct values
--Check that the full name column sorts properly

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
