### PR TITLE
[BI-2008] Preview Summary Stats Refinement

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -55,14 +55,6 @@
           <div>
             <p>Review your experimental data import before committing to the database.</p>
           <div class = "left-confirm-column">
-            <p class="is-size-5 mb-2"><strong>Import Summary</strong></p>
-            Dataset: {{  }}
-            <br>Germplasm: {{ statistics.GIDs.newObjectCount }}
-            <br>Environment(s): {{ statistics.Environments.newObjectCount }}
-            <br>Observation Variables: {{ dynamicColumns.length }}
-            <br>Observations: {{ statistics.Observations.newObjectCount }}
-          </div>
-          <div id="experiment-summary" class ="right-confirm-column">
             <p class="is-size-5 mb-2"><strong>Experiment</strong></p>
             Title: {{ rows[0].trial.brAPIObject.trialName }}
             <br>Description: {{ rows[0].trial.brAPIObject.trialDescription }}
@@ -71,6 +63,14 @@
             <br>Experimental Design: Externally generated
             <template v-if="isExisting(rows)"><br>User: {{ rows[0].trial.brAPIObject.additionalInfo.createdBy.userName }}</template>
             <template v-if="isExisting(rows)"><br>Creation Date: {{ rows[0].trial.brAPIObject.additionalInfo.createdDate | dmy}}</template>
+          </div>
+          <div id="experiment-summary" class ="right-confirm-column">
+            <p class="is-size-5 mb-2"><strong>Import Summary</strong></p>
+            Dataset: {{ rows[0].observationUnit.brAPIObject.additionalInfo.observationLevel }}
+            <br>Germplasm: {{ statistics.GIDs.newObjectCount }}
+            <br>Environment(s): {{ statistics.Environments.newObjectCount }}
+            <br>Observation Variables: {{ dynamicColumns.length }}
+            <br>Observations: {{ statistics.Observations.newObjectCount }}
           </div>
           </div>
         </ConfirmImportMessageBox>

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -44,7 +44,7 @@
         </ImportInfoTemplateMessageBox>
       </template>
 
-      <template v-slot:confirmImportMessageBox="{ statistics, abort, confirm, rows }">
+      <template v-slot:confirmImportMessageBox="{ statistics, dynamicColumns, abort, confirm, rows }">
         <ConfirmImportMessageBox v-bind:num-records="getNumNewExperimentRecords(statistics)"
                                  v-bind:import-type-name="'Experiments & Observations'"
                                  v-bind:confirm-import-state="confirmImportState"
@@ -56,9 +56,11 @@
             <p>Review your experimental data import before committing to the database.</p>
           <div class = "left-confirm-column">
             <p class="is-size-5 mb-2"><strong>Import Summary</strong></p>
-            Environments: {{ statistics.Environments.newObjectCount }}
+            Dataset: {{  }}
             <br>Germplasm: {{ statistics.GIDs.newObjectCount }}
-            <br>Observation Units: {{ statistics.Observation_Units.newObjectCount }}
+            <br>Environment(s): {{ statistics.Environments.newObjectCount }}
+            <br>Observation Variables: {{ dynamicColumns.length }}
+            <br>Observations: {{ statistics.Observations.newObjectCount }}
           </div>
           <div id="experiment-summary" class ="right-confirm-column">
             <p class="is-size-5 mb-2"><strong>Experiment</strong></p>

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -94,6 +94,7 @@
 
       <slot name="confirmImportMessageBox"
             v-bind:statistics="newObjectCounts"
+            v-bind:dynamicColumns="dynamicColumns"
             v-bind:abort="handleAbortEvent"
             v-bind:confirm="handleConfirmEvent"
             v-bind:confirm-import-state="confirmImportState"


### PR DESCRIPTION
# Description
**Story:** [BI-2008](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2008)

The template for the Vue component ImportExperiment was updated to match the wireframes in the card, including new summary fields for observation variables and observation level.



# Dependencies
bi-api develop
# Testing
Import an experiment and verify that the summary data for the preview matches the wireframe in the [parent card](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2003). Note: The value for the dataset field in the summary will not be correct for sub-obs units without the changes to the backend in [BI-1464](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-1464). The preview table itself will not appear for the same reason.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2008]: https://breedinginsight.atlassian.net/browse/BI-2008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-1464]: https://breedinginsight.atlassian.net/browse/BI-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ