### PR TITLE
BI-2029 - fix for spinner on confirm button and progress message

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -48,7 +48,6 @@
         <ConfirmImportMessageBox v-bind:num-records="getNumNewExperimentRecords(statistics)"
                                  v-bind:import-type-name="'Experiments & Observations'"
                                  v-bind:confirm-import-state="confirmImportState"
-                                 v-bind:show-loading-on-confirm="false"
                                  v-on:abort="abort"
                                  v-on:confirm="confirm"
                                  class="mb-4">


### PR DESCRIPTION
# Description
**Story:** [BI-2029](https://breedinginsight.atlassian.net/browse/BI-2029)

I removed the line in ImportExperiment.vue which was suppressing the visual loading indicators.


# Dependencies
release/0.9 branch of bi-api for testing

# Testing
Upload small and large experiments, upload experiments with observation values that overwrite existing values.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2029]: https://breedinginsight.atlassian.net/browse/BI-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ