### PR TITLE
[BI-2060] Conditionally render the genotypic data import tab when running in production

### DIFF
--- a/src/views/import/ImportFile.vue
+++ b/src/views/import/ImportFile.vue
@@ -41,6 +41,7 @@
             <a>Experiments & Observations</a>
           </router-link>
           <router-link
+              v-if="!isProduction"
               v-bind:to="{name: 'geno-import', params: {programId: activeProgram.id}}"
               tag="li" active-class="is-active">
             <a>Genotypic Data</a>
@@ -101,6 +102,7 @@ export default class ImportFile extends ProgramsBase {
 
   private activeProgram?: Program;
   private isSubscribed?: boolean;
+  private isProduction: boolean = process.env.NODE_ENV === "production";
   private getSubscribedOntology!: () => any;
 
   mounted() {


### PR DESCRIPTION
# Description
**Story:** [BI-2060](https://breedinginsight.atlassian.net/browse/BI-2060)

The value of env variable NODE_ENV is used to conditionally render the genotypic data tab so that it is gone in the production environment.



# Dependencies
bi-api release/0.9

# Testing
verify that the genotypic data tab is visible in development environment. Final verification to be done after deployment to production.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2060]: https://breedinginsight.atlassian.net/browse/BI-2060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ