### PR TITLE
BI-2053-fix - fixed scale units issue with NumericalTraitForm

### DIFF
--- a/src/breeding-insight/model/Scale.ts
+++ b/src/breeding-insight/model/Scale.ts
@@ -27,6 +27,7 @@ export enum DataType {
 
 export class Scale {
   scaleName?: string;
+  units?:string;
   dataType?: string;
   categories?: Array<Category>;
   decimalPlaces?: number;

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -258,11 +258,11 @@
       <div class="column is-full">
         <NumericalTraitForm
             class="p-0"
-            v-bind:unit="trait.scale.scaleName"
+            v-bind:unit="trait.scale.units"
             v-bind:decimal-places="trait.scale.decimalPlaces"
             v-bind:valid-min="trait.scale.validValueMin"
             v-bind:valid-max="trait.scale.validValueMax"
-            v-on:unit-change="trait.scale.scaleName = $event"
+            v-on:unit-change="trait.scale.units = $event"
             v-on:decimal-change="trait.scale.decimalPlaces = $event"
             v-on:min-change="trait.scale.validValueMin = $event"
             v-on:max-change="trait.scale.validValueMax = $event"


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2053

The NumericalTraitForm was sending the "units" input as "scaleName". I fixed this. It should have been done along with https://github.com/Breeding-Insight/bi-api/pull/339, but I missed this workflow.

# Dependencies
https://github.com/Breeding-Insight/bi-api/pull/342

# Testing
_Please include any details needed for reviewers to test this code_


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
