### PR TITLE
BI-1680 - Updated Germplasm Template To Remove "Somoclone"

### DIFF
--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -31,7 +31,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/raxqv3pbz858jjdb33ymsepbyizt9imd.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/7i2nayetu0h4hawjr5nx21lsidw6c438.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>


### PR DESCRIPTION
# Description
**Story:** [BI-1680](https://breedinginsight.atlassian.net/browse/BI-1680)

I updated the germplasm import template to remove the "Somoclone" breeding method from the Breeding Methods worksheet.

This [bi-api PR](https://github.com/Breeding-Insight/bi-api/pull/344) contains the corresponding database migration.

# Dependencies
bi-api branch: `feature/BI-1680`.

# Testing
1. Checkout this branch, `git checkout feature/BI-1680`.
2. Run DeltaBreed.
3. Download the germplasm import template.
    - Ensure the template version is v10.
    - Ensure the template Breeding Methods worksheet does not contain the "Somoclone" method.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1680]: https://breedinginsight.atlassian.net/browse/BI-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ