### PR TITLE
BI-2059 - Field Book not displaying nominal categories from DeltaBreed

### DIFF
--- a/src/views/BrAPI/BrAPIInfo.vue
+++ b/src/views/BrAPI/BrAPIInfo.vue
@@ -85,7 +85,7 @@
                     </div>
                     <div class="columns">
                       <div class="column"><strong>Value vs Label Display:</strong></div>
-                      <div class="column is-two-thirds">Label</div>
+                      <div class="column is-two-thirds">Value</div>
                     </div>
                   </div>
                 </article>
@@ -167,7 +167,7 @@ export default class BrapiInfo extends Vue {
       'st': '120',
       'flow': 'implicit',
       'oidc': this.getBrAPIRootPath() + '/.well-known/openid-configuration',
-      'cat': 'label'
+      'cat': 'value'
     };
 
     return JSON.stringify(settings)


### PR DESCRIPTION
# Description
**Story:** [BI-2059](https://breedinginsight.atlassian.net/browse/BI-2059?atlOrigin=eyJpIjoiZThkMWQ5NGJhMWJjNDE5OGI1YmRlODdhYTRhMWUxYmMiLCJwIjoiaiJ9)

- Changed default Field Book BrAPI category settings from Label to Value

# Dependencies
- bi-api release/0.9
- Field Book 

# Testing
- Scan QR code for BrAPI settings in Delta Breed and verify that the category option is set to Value in Field Book
- Verify that both nominal and ordinal traits have values displayed on buttons on collect screen in Field Book

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2059]: https://breedinginsight.atlassian.net/browse/BI-2059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ