### PR TITLE
[BI-1969] Geologic sort: Germplasm, Experiments, and Sample Submission

### DIFF
--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -35,7 +35,7 @@
       v-bind:pagination="paginationController"
       backend-sorting
       backend-filtering
-      v-bind:default-sort="[fieldMap['name'], 'ASC']"
+      v-bind:default-sort="[fieldMap['createdDate'], 'DESC']"
       v-bind:search-debounce="400"
       v-on:show-error-notification="$emit('show-error-notification', $event)"
       v-on:sort="setSort"

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -7,7 +7,7 @@
         v-on:show-error-notification="$emit('show-error-notification', $event)"
         backend-sorting
         backend-filtering
-        v-bind:default-sort="entryNumberVisible ? [fieldMap['importEntryNumber'], 'ASC'] : [fieldMap['accessionNumber'], 'ASC']"
+        v-bind:default-sort="entryNumberVisible ? [fieldMap['importEntryNumber'], 'ASC'] : [fieldMap['accessionNumber'], 'DESC']"
         v-on:sort="setSort"
         v-on:search="initSearch"
         v-bind:search-debounce="400"

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -64,13 +64,13 @@ state = {
     programSort: new ProgramSort(ProgramSortField.Name, SortOrder.Ascending),
 
     // germplasm table
-    germplasmSort: new GermplasmSort(GermplasmSortField.AccessionNumber, SortOrder.Ascending),
+    germplasmSort: new GermplasmSort(GermplasmSortField.AccessionNumber, SortOrder.Descending),
 
     // germplasm list table
     germplasmListSort: new GermplasmListSort(GermplasmListSortField.Name, SortOrder.Ascending),
 
     //experiment and observation table
-    experimentSort: new ExperimentSort(ExperimentSortField.Name, SortOrder.Ascending)
+    experimentSort: new ExperimentSort(ExperimentSortField.CreatedDate, SortOrder.Descending)
 
 };
 


### PR DESCRIPTION
# Description
**Story:** 
[BI-1969](https://breedinginsight.atlassian.net/browse/BI-1969) - Geologic sort: Germplasm, Experiments, and Sample Submission

# Dependencies
bi-api: develop branch

# Testing

- Go to the Germplasm page.
EXPECTED RESULT
Germplasm are displayed in descending **GID** order.

- Go to the Experiments & Observations page
EXPECTED RESULT
Experiment are displayed in descending **Create Date** order


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1969]: https://breedinginsight.atlassian.net/browse/BI-1969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ