### PR TITLE
[feature/BI-2108] Accessibility: Import Data - Empty Heading

### DIFF
--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -74,7 +74,7 @@
     </WarningModal>
 
     <template v-if="state === ImportState.CHOOSE_FILE || state === ImportState.FILE_CHOSEN">
-      <h1 class="title" v-if="showTitle">{{title}}</h1>
+
       <slot name="importInfoTemplateMessageBox" />
       <div class="box">
         <FileSelectMessageBox v-model="file"
@@ -91,7 +91,6 @@
 
     <template v-if="state === ImportState.CURATE"> <!-- state === ImportState.LOADING ||-->
       <h1 class="title">{{toTitleCase(confirmMsg)}}</h1>
-
       <slot name="confirmImportMessageBox"
             v-bind:statistics="newObjectCounts"
             v-bind:dynamicColumns="dynamicColumns"
@@ -193,12 +192,6 @@ enum ImportAction {
   }
 })
 export default class ImportTemplate extends ProgramsBase {
-
-  @Prop()
-  private title!: string;
-
-  @Prop({default: true})
-  private showTitle!: boolean;
 
   @Prop({default: false})
   private showProceedWarning!: boolean;


### PR DESCRIPTION
# Description
[BI-2108](https://breedinginsight.atlassian.net/browse/BI-2108) Accessibility: Import Data - Empty Heading


# Dependencies
bi-api: develop branch

# Testing
Go to the _Import_ page
- There should be no empty header above the import template. (between the _tabs_ and the gray text box)
- Import pages should have consistent spacing above the import template. (between the _tabs_ and the gray text box)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2108]: https://breedinginsight.atlassian.net/browse/BI-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ