### PR TITLE
BI-2105 (Accessibility: Header and Navigation)

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -90,7 +90,9 @@ $medium-modal-body-padding: 0 3em 2em 3em;
 @import "~bulma/sass/utilities/_all";
 
 // Customize buefy if you want to here
-.menu-label.customize {
+
+//see https://alfa.siteimprove.com/rules/sia-r72
+.menu-label.customize_for_accessibility {
   text-transform: none;
   font-size: 0.8em;
   letter-spacing: 2px;

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -90,7 +90,11 @@ $medium-modal-body-padding: 0 3em 2em 3em;
 @import "~bulma/sass/utilities/_all";
 
 // Customize buefy if you want to here
-
+.menu-label.customize {
+  text-transform: none;
+  font-size: 0.8em;
+  letter-spacing: 2px;
+}
 
 // Update some of Bulma's component variables
 

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -92,7 +92,7 @@ $medium-modal-body-padding: 0 3em 2em 3em;
 // Customize buefy if you want to here
 
 //see https://alfa.siteimprove.com/rules/sia-r72
-.menu-label.customize_for_accessibility {
+.menu-label.customize-for-accessibility {
   text-transform: none;
   font-size: 0.8em;
   letter-spacing: 2px;

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -78,7 +78,7 @@
     <template v-slot:menu>
       <nav role="navigation" aria-label="main navigation">
         <template v-if="activeProgram">
-          <p class="menu-label customize">
+          <p class="menu-label customize_for_accessibility">
             {{activeProgram.name}}
           </p>
           <ul class="menu-list">
@@ -165,7 +165,7 @@
           <template v-if="activeProgram">
             <hr style="margin:5px;">
           </template>
-          <p class="menu-label customize">
+          <p class="menu-label customize_for_accessibility">
             System Administration
           </p>
           <ul class="menu-list">

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -78,7 +78,7 @@
     <template v-slot:menu>
       <nav role="navigation" aria-label="main navigation">
         <template v-if="activeProgram">
-          <p class="menu-label customize_for_accessibility">
+          <p class="menu-label customize-for-accessibility">
             {{activeProgram.name}}
           </p>
           <ul class="menu-list">
@@ -165,7 +165,7 @@
           <template v-if="activeProgram">
             <hr style="margin:5px;">
           </template>
-          <p class="menu-label customize_for_accessibility">
+          <p class="menu-label customize-for-accessibility">
             System Administration
           </p>
           <ul class="menu-list">

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -35,6 +35,7 @@
             aria-haspopup="true"
             aria-controls="program-menu"
           >
+
             <span class="icon is-small">
               <span class="is-sr-only">Show Program Menu</span>
               <ChevronDownIcon></ChevronDownIcon>
@@ -51,7 +52,8 @@
             class="dropdown-content"
           >
             <div class="dropdown-item">
-              <input class="input" type="text" placeholder="Program Name" v-on:input="filterPrograms($event)" v-bind:value="programFilterValue">
+              <label class="is-sr-only" for="programName">Program Name</label>
+              <input class="input" type="text" id="programName" placeholder="Program Name" v-on:input="filterPrograms($event)" v-bind:value="programFilterValue">
             </div>
             <hr class="dropdown-divider">
             <div class="programs">
@@ -76,7 +78,7 @@
     <template v-slot:menu>
       <nav role="navigation" aria-label="main navigation">
         <template v-if="activeProgram">
-          <p class="menu-label">
+          <p class="menu-label customize">
             {{activeProgram.name}}
           </p>
           <ul class="menu-list">
@@ -163,7 +165,7 @@
           <template v-if="activeProgram">
             <hr style="margin:5px;">
           </template>
-          <p class="menu-label">
+          <p class="menu-label customize">
             System Administration
           </p>
           <ul class="menu-list">

--- a/src/components/layouts/menus/UserStatusMenu.vue
+++ b/src/components/layouts/menus/UserStatusMenu.vue
@@ -23,6 +23,7 @@
       <button
           class="button is-small is-primary has-text-weight-bold"
           v-bind:id="dropDownId"
+          aria-label="User Status"
       >
         <b-icon icon="user" class="mr-0"></b-icon>
         <b-icon icon="chevron-down" class="ml-0"></b-icon>


### PR DESCRIPTION
# Description
[BI-2105](https://breedinginsight.atlassian.net/browse/BI-2105) - Accessibility: Header and Navigation

_changes made:
EXPECTED BHAVIOUR and how it was implemented_

**The program name and System Administration headers on the left sidebar should NOT be transformed to all caps by the text-transform property.**
-  in `main.scss` added the class selector `.menu-label.customize` to overwrite the buefy `.menu-label` class selector.

**The user status menu dropdown button should have an associated text label in the HTML.** 
- added the attribute `aria-label="User Status"`to the user status button

 **The user status menu dropdown div should either be a compliant role for the aria-haspopup state OR the aria-pressed state should be used for the enclosed button role.**
- IMPORTANT NOTE:  Could not correct this problem because it is within the Buefy code for a dropdown.
 
**The program dropdown menu form should have an associated label.** 
- added an HTML label with `class="is-sr-only"` so it is only visible to Screen Readers.




# Dependencies
_Please include any dependencies to other code branches, testing configurations, scripts to be run, etc._

# Testing
Confirm that the accessibility issues have been resolved by using the Chrome plug-in - https://chromewebstore.google.com/detail/siteimprove-accessibility/djcglbmbegflehmbfleechkjhmedcopn?pli=1


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_

[BI-2105]: https://breedinginsight.atlassian.net/browse/BI-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ