### PR TITLE
[BI-2103] Accessibility: Links on Index and Not Authorized Pages

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -116,6 +116,11 @@ $divider-margin-inner-size: 0;
 // Overrides that can't be done with variables go here
 // may be broken out into a separate file later
 
+// bold anchors to improve accessibility.
+a.customize-for-accessibility {
+  font-weight: bold;
+}
+
 main {
   /*
   a {

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -107,7 +107,7 @@
             Our breeding collaborators
           </h1>
           <p>The USDA Agricultural Research Service (ARS) supports breeding programs for approximately 90 specialty species.</p>
-          <p>Learn more about our projects for each species at <a href="https://www.breedinginsight.org">www.breedinginsight.org</a>.</p>
+          <p>Learn more about our projects for each species at <a class="customize-for-accessibility" href="https://www.breedinginsight.org">www.breedinginsight.org</a>.</p>
         </div>
       </div>
     </article>

--- a/src/views/NotAuthorized.vue
+++ b/src/views/NotAuthorized.vue
@@ -22,8 +22,8 @@
         <h1 class="title has-text-danger">Not Authorized</h1>
         <p class="has-text-dark">
           You are not authorized to access this resource. Verify your login credentials, and if the issue persists
-          <a href="#!">contact your breeding program leader</a> or
-          <a href="#!">DeltaBreed support</a>.
+          <a class="customize-for-accessibility" href="#!">contact your breeding program leader</a> or
+          <a class="customize-for-accessibility" href="#!">DeltaBreed support</a>.
         </p>
         <router-link v-bind:to="{name:'home'}" v-bind:replace="true">
           Return to Home Page


### PR DESCRIPTION
# Description
[BI-2103](https://breedinginsight.atlassian.net/browse/BI-2103) Accessibility: Links on Index and Not Authorized Pages

- On the index page, made the link to [www.breedinginsight.org](https://www.breedinginsight.org/) bold.
- On the Not Authorized page:
- - made the link to [contact your breeding program leader](http://localhost:8080/401#!) bold.
- - made the link to [DeltaBreed support](http://localhost:8080/401#!) bold.



# Dependencies
bi-api: develop

# Testing

NOTE: To test this install the Siteimprove Accessibility Checker browser plugin found at https://chromewebstore.google.com/detail/siteimprove-accessibility/djcglbmbegflehmbfleechkjhmedcopn?pli=1

1. Go to _Index_ page (go to Deltabreed without logging in)
EXPECTED RESULT
The Siteimprove Accessibility Checker should **not** report the issue "Links are not clearly Identifiable"

2.  Go to the _Not Authorized_ age
3. EXPECTED RESULT
The Siteimprove Accessibility Checker should **not** report the issue "Links are not clearly Identifiable"

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2103]: https://breedinginsight.atlassian.net/browse/BI-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ