### PR TITLE
BI-2106 -  Accessibility: Web Version

### DIFF
--- a/src/components/layouts/VersionInfo.vue
+++ b/src/components/layouts/VersionInfo.vue
@@ -15,7 +15,7 @@
   -->
 
 <template>
-  <span>
+  <span role="navigation">
     <a :href="versionInfo" target="_blank">web {{ versionName }}</a> /
     <a :href="apiVersionInfo" target="_blank"> api
       <template v-if="apiInfoLoading"><span class="is-italic">loading</span></template>

--- a/src/components/layouts/VersionInfo.vue
+++ b/src/components/layouts/VersionInfo.vue
@@ -15,7 +15,7 @@
   -->
 
 <template>
-  <span role="navigation">
+  <span role="region" aria-label="versions">
     <a :href="versionInfo" target="_blank">web {{ versionName }}</a> /
     <a :href="apiVersionInfo" target="_blank"> api
       <template v-if="apiInfoLoading"><span class="is-italic">loading</span></template>

--- a/src/components/layouts/VersionInfo.vue
+++ b/src/components/layouts/VersionInfo.vue
@@ -15,7 +15,7 @@
   -->
 
 <template>
-  <span role="region" aria-label="versions">
+  <span role="contentinfo" aria-label="versions">
     <a :href="versionInfo" target="_blank">web {{ versionName }}</a> /
     <a :href="apiVersionInfo" target="_blank"> api
       <template v-if="apiInfoLoading"><span class="is-italic">loading</span></template>


### PR DESCRIPTION
# Description
[BI-2106](https://breedinginsight.atlassian.net/browse/BI-2106) Accessibility: Web Version


# Dependencies
bi-api: develop branch

# Testing
NOTE: To test this install the Siteimprove Accessibility Checker browser plugin found at https://chromewebstore.google.com/detail/siteimprove-accessibility/djcglbmbegflehmbfleechkjhmedcopn?pli=1

1. Go to any page with a side panel showing the web version
2. Run the Siteimprove Accessibility Checker

  EXPECTED RESULT
  The Siteimprove Accessibility Checker should not report the issue `Text not included in an ARIA landmark`

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2106]: https://breedinginsight.atlassian.net/browse/BI-2106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ