### PR TITLE
BI-2167 - Lat and long values are getting swapped in the exp download file

### DIFF
--- a/src/breeding-insight/model/GeoCoordinates.ts
+++ b/src/breeding-insight/model/GeoCoordinates.ts
@@ -16,13 +16,13 @@
  */
 
 export class GeoCoordinates {
-    lat?: number;
     lon?: number;
+    lat?: number;
     elevation?: number;
 
-    constructor(lat?: number, lon?: number, elevation?: number) {
-        this.lat = lat;
+    constructor(lon?: number, lat?: number, elevation?: number) {
         this.lon = lon;
+        this.lat = lat;
         this.elevation = elevation;
     }
 }

--- a/src/breeding-insight/model/ObservationUnit.ts
+++ b/src/breeding-insight/model/ObservationUnit.ts
@@ -16,7 +16,6 @@
  */
 
 import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferences";
-import {GeoCoordinates} from "@/breeding-insight/model/GeoCoordinates";
 
 export class ObservationUnit {
   observationUnitDbId: string;

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -488,8 +488,8 @@ export default class Dataset extends ProgramsBase {
         if (unit.observationUnitPosition.geoCoordinates) {
           const coordinates = unit.observationUnitPosition.geoCoordinates.geometry!.coordinates!;
           if (coordinates.length >= 2) {
-            datasetTableRow.lat = coordinates[0];
-            datasetTableRow.lon = coordinates[1];
+            datasetTableRow.lon = coordinates[0];
+            datasetTableRow.lat = coordinates[1];
           }
           if (coordinates.length === 3) {
             datasetTableRow.elevation = coordinates[2];


### PR DESCRIPTION
# Description
**Story:** [BI-2167](https://breedinginsight.atlassian.net/browse/BI-2167?atlOrigin=eyJpIjoiN2NjMmZlNTk1ODdjNDVmZWFhNjQ0ZTFiMTc1YjQwYmIiLCJwIjoiaiJ9)

- Updated preview and experiment tables for correct [lon, lat, elevation] ordering
- Sent out message on delta breed channel noting implications for uploads prior to v0.10 release
- Shawn looked at production and there was no existing geocoordinate data that would need to be fixed

# Dependencies
- bug/BI-2167 bi-api

# Testing
    Given I have an experiment import file with lat and long values
    When I upload the file and subsequently download it from deltabreed
    Then the Lat Long columns match the file that I uploaded instead of reversed

    Given I have an experiment import file with lat and long values
    When I upload the file 
    Then I should see Lat and Long values matching the file in the preview table

    Given I have an experiment import file with lat and long values
    When I upload the file 
    And navigate to the experiments page for the created experiment
    Then I should see Lat and Long values matching the experiment data table


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2167]: https://breedinginsight.atlassian.net/browse/BI-2167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ