### PR TITLE
[BI-1692] - Change role names

### DIFF
--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -55,7 +55,8 @@ export function defineAbilityFor(user: User | undefined, program: Program | unde
   const builder = new AbilityBuilder<AppAbility>();
 
   if (user) {
-    let roleNameConcat;
+    //functions depend on no whitespace domain name, hence concat
+    let roleNameConcat = "";
     // Check system roles
     if (user.roleName) {
       roleNameConcat = user.roleName.replace(/\s/g, "").toLowerCase();

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -51,12 +51,17 @@ const rolePermissions: Record<string, DefinePermissions> = {
   }
 };
 
+//Helper method to convert domain name to associated rolePermissions function
+//Necessary as functions depend on no whitespace and present domain names have whitespace
+function toRoleFunctionName(domain: String){
+  return domain.replace(/\s/g, "").toLowerCase();
+}
+
 export function defineAbilityFor(user: User | undefined, program: Program | undefined): AppAbility {
   const builder = new AbilityBuilder<AppAbility>();
 
   if (user) {
-    //functions depend on no whitespace domain name, hence concat
-    let roleNameConcat = "";
+    let roleFunctionName = "";
     // Check system roles
     if (user.roleName) {
       roleNameConcat = user.roleName.replace(/\s/g, "").toLowerCase();
@@ -70,14 +75,14 @@ export function defineAbilityFor(user: User | undefined, program: Program | unde
       if (user.programRoles) {
         for (const programRole of user.programRoles) {
           if (programRole.domain) {
-            roleNameConcat = programRole.domain.replace(/\s/g, "").toLowerCase();
+            roleFunctionName = toRoleFunctionName(programRole.domain);
           }
           if (programRole.program && programRole.program.id &&
             programRole.program.id === program.id && programRole.domain &&
             programRole.active &&
-            typeof rolePermissions[roleNameConcat] === 'function') {
+            typeof rolePermissions[roleFunctionName] === 'function') {
 
-            rolePermissions[roleNameConcat](user, builder);
+            rolePermissions[roleFunctionName](user, builder);
           }
         }
       }

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -64,9 +64,9 @@ export function defineAbilityFor(user: User | undefined, program: Program | unde
     let roleFunctionName = "";
     // Check system roles
     if (user.roleName) {
-      roleNameConcat = user.roleName.replace(/\s/g, "").toLowerCase();
-      if (typeof rolePermissions[roleNameConcat] === 'function') {
-        rolePermissions[roleNameConcat](user, builder);
+      roleFunctionName = toRoleFunctionName(user.roleName);
+      if (typeof rolePermissions[roleFunctionName] === 'function') {
+        rolePermissions[roleFunctionName](user, builder);
       }
     }
 

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -24,9 +24,9 @@ import {Program} from "@/breeding-insight/model/Program";
 type DefinePermissions = (user: User, builder: AbilityBuilder<AppAbility>) => void;
 
 const rolePermissions: Record<string, DefinePermissions> = {
-  member(user, { can }) {
+  readonly(user, { can }) {
   },
-  breeder(user, { can }) {
+  programadministrator(user, { can }) {
     can('create', 'ProgramUser');
     can('update', 'ProgramUser');
     can('archive', 'ProgramUser');
@@ -41,7 +41,7 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('create', 'ProgramConfiguration');
     can('update', 'ProgramConfiguration');
   },
-  admin(user, { can }) {
+  systemadministrator(user, { can }) {
     can('create', 'ProgramUser');
     can('update', 'ProgramUser');
     can('archive', 'ProgramUser');
@@ -55,10 +55,13 @@ export function defineAbilityFor(user: User | undefined, program: Program | unde
   const builder = new AbilityBuilder<AppAbility>();
 
   if (user) {
+    let roleNameConcat;
     // Check system roles
     if (user.roleName) {
-      if (typeof rolePermissions[user.roleName] === 'function') {
-        rolePermissions[user.roleName](user, builder);
+      roleNameConcat = user.roleName.replace(/\s/g, "").toLowerCase();
+      console.log(roleNameConcat);
+      if (typeof rolePermissions[roleNameConcat] === 'function') {
+        rolePermissions[roleNameConcat](user, builder);
       }
     }
 
@@ -66,12 +69,13 @@ export function defineAbilityFor(user: User | undefined, program: Program | unde
       // Check program roles
       if (user.programRoles) {
         for (const programRole of user.programRoles) {
+          roleNameConcat = programRole.domain.replace(/\s/g, "").toLowerCase(); //todo may need to wrap
           if (programRole.program && programRole.program.id &&
             programRole.program.id === program.id && programRole.domain &&
             programRole.active &&
-            typeof rolePermissions[programRole.domain] === 'function') {
+            typeof rolePermissions[roleNameConcat] === 'function') {
 
-            rolePermissions[programRole.domain](user, builder);
+            rolePermissions[roleNameConcat](user, builder);
           }
         }
       }

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -60,7 +60,6 @@ export function defineAbilityFor(user: User | undefined, program: Program | unde
     // Check system roles
     if (user.roleName) {
       roleNameConcat = user.roleName.replace(/\s/g, "").toLowerCase();
-      console.log(roleNameConcat);
       if (typeof rolePermissions[roleNameConcat] === 'function') {
         rolePermissions[roleNameConcat](user, builder);
       }
@@ -70,7 +69,9 @@ export function defineAbilityFor(user: User | undefined, program: Program | unde
       // Check program roles
       if (user.programRoles) {
         for (const programRole of user.programRoles) {
-          roleNameConcat = programRole.domain.replace(/\s/g, "").toLowerCase(); //todo may need to wrap
+          if (programRole.domain) {
+            roleNameConcat = programRole.domain.replace(/\s/g, "").toLowerCase();
+          }
           if (programRole.program && programRole.program.id &&
             programRole.program.id === program.id && programRole.domain &&
             programRole.active &&

--- a/src/views/program/ProgramSelection.vue
+++ b/src/views/program/ProgramSelection.vue
@@ -23,7 +23,7 @@
     <div class="columns">
       <div class="column is-narrow">
         <div class="buttons is-block">
-          <template v-if="activeUser && activeUser.hasRole('admin')">
+          <template v-if="activeUser && activeUser.hasRole('System Administrator')">
             <router-link
               v-bind:to="{name: 'admin'}"
               class="button is-primary is-light is-block is-outlined mr-0"

--- a/tests/unit/components/program/ProgramUsersTable.spec.ts
+++ b/tests/unit/components/program/ProgramUsersTable.spec.ts
@@ -37,17 +37,17 @@ function setup() {
     roleDAO.getAll.mockResolvedValue(rolesResponse);
 
     const systemUser = {'id':'1', 'name':'Test user', 'email':'testuser@test.com', 'active':'true',
-                        'systemRoles': [{'id':'1', 'domain':'admin'}],
-                        'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]};
+                        'systemRoles': [{'id':'1', 'domain':'System Administrator'}],
+                        'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'Read Only'}}]};
     const systemUser1 = {
         'id':'2', 'name':'Test user 2', 'email':'testuser1@test.com', 'active':'true', 'orcid': '123',
-        'systemRoles': [{'id':'1', 'domain':'admin'}],
-        'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]
+        'systemRoles': [{'id':'1', 'domain':'System Administrator'}],
+        'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'Read Only'}}]
     };
     const systemUser2 = {
         'id':'2', 'name':'Test user 2', 'email':'testuse2@test.com', 'active':'true', 'orcid': '456',
-        'systemRoles': [{'id':'1', 'domain':'admin'}],
-        'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]
+        'systemRoles': [{'id':'1', 'domain':'System Administrator'}],
+        'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'Read Only'}}]
     }
     systemUsers.push(systemUser, systemUser1, systemUser2);
     const systemUsersResponse = DaoUtils.formatBiResponse(systemUsers);

--- a/tests/unit/components/tables/ExpandableTable.spec.ts
+++ b/tests/unit/components/tables/ExpandableTable.spec.ts
@@ -69,24 +69,24 @@ function setup() {
   roleDAO.getAll.mockResolvedValue(rolesResponse);
 
   const systemUser = {'id':'1', 'name':'Test user', 'email':'testuser@test.com', 'active':'true',
-    'systemRoles': [{'id':'1', 'domain':'admin'}],
-    'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]};
+    'systemRoles': [{'id':'1', 'domain':'System Administrator'}],
+    'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'Read Only'}}]};
   const systemUser1 = {
     'id':'2', 'name':'Test user 2', 'email':'testuser1@test.com', 'active':'true', 'orcid': '123',
-    'systemRoles': [{'id':'1', 'domain':'admin'}],
-    'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]
+    'systemRoles': [{'id':'1', 'domain':'System Administrator'}],
+    'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'Read Only'}}]
   };
   const systemUser2 = {
     'id':'2', 'name':'Test user 2', 'email':'testuse2@test.com', 'active':'true', 'orcid': '456',
-    'systemRoles': [{'id':'1', 'domain':'admin'}],
-    'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]
+    'systemRoles': [{'id':'1', 'domain':'System Administrator'}],
+    'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'Read Only'}}]
   }
   systemUsers.push(systemUser, systemUser1, systemUser2);
   users.forEach(user => {
     systemUsers.push({
       'id':user.id, 'name':user.name, 'email':user.email, 'active':'true', 'orcid': `456-${user.id}`,
-      'systemRoles': [{'id':'1', 'domain':'admin'}],
-      'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'member'}}]
+      'systemRoles': [{'id':'1', 'domain':'System Administrator'}],
+      'programRoles': [{'active':'true', 'program':{'id':'1', 'name':'Test Program'}, 'roles':{'id':'1','domain':'Read Only'}}]
     })
   })
   const systemUsersResponse = DaoUtils.formatBiResponse(systemUsers);

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -77,8 +77,8 @@ export const defaultStore = new Vuex.Store({
 });
 
 const fakeUser: User = new User('1', 'Test User','1', 'email@email.com',
-  new Role('1', 'admin'),
-  [new ProgramUser('1', 'Test User', 'email@email.com', '1', 'breeder', fakeProgram, true)]);
+  new Role('1', 'System Administrator'),
+  [new ProgramUser('1', 'Test User', 'email@email.com', '1', 'Program Administrator', fakeProgram, true)]);
 localVue.use(abilitiesPlugin, defineAbilityFor(fakeUser, fakeProgram));
 
 export default localVue;


### PR DESCRIPTION
# Description
**Story:** [BI-1692 - Change role names](https://breedinginsight.atlassian.net/browse/BI-1692)

Updated front end logic to use new role domains:
- admin -> System Administrator
- breeder -> Program Administrator
- member -> Read Only

Changed RolePermissions in ability.ts to utilize new domains
- This involved adding a helper method to remove whitespaces from domain names in order to convert domain names to rolePermissions function names 

# Dependencies
bi-api: [feature/BI-1692](https://github.com/Breeding-Insight/bi-api/pull/377)

# Testing
Ensure a user can can log in as:
- System Administrator
- Program Administrator
- Read Only

System User Table
- Check that System Administrator displays properly in role column
- Check that role dropdown for edit and creating a user now properly displays System Administrator and that that value can be selected
- Check that a user can be created with System Administrator role
- Check that a non-self user's role can be edited to and from System Administrator role

Program User Table
- Check that proper role names display in role column
- Check that role dropdown for edit and adding a user now properly displays the new domains and that those value scan be selected
- Check that a user can be added to a program as Program Administrator
- Check that a user can be added to a program as Read Only
- Check that a program user's role can be successfully edited

- Miscellaneous smoke testing regarding adding programs/uploading files to ensure permissions properly updated after domain changes

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/10199847184)
