### PR TITLE
BI-2259 - Disable Sub-entity Dataset option Mange experiments menu

### DIFF
--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -152,7 +152,7 @@ export default class ExperimentDetails extends ProgramsBase {
   private actions: ActionMenuItem[] = [
       new ActionMenuItem('experiment-import-file', 'import-file', 'Import file'),
       new ActionMenuItem('experiment-download-file', 'download-file', 'Download file'),
-      new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset')
+      // new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset')
   ];
 
   mounted () {


### PR DESCRIPTION
# Description
[BI-2259](https://breedinginsight.atlassian.net/browse/BI-2259) - Disable Sub-entity Dataset option Mange experiments menu

Commented out the menu option for 'Create Sub-Entity Dataset'.  (it is assumed that it will be un-commented later)

# Dependencies
bi-api: develop branch

# Testing
(see also the Acceptance Criteria on [BI-2259](https://breedinginsight.atlassian.net/browse/BI-2259).)
1. Go to an Experiment
2. Click on the _Manage Experiment_ Menu.
**EXPECTED RESULT**
you should no longer see the _Create Sub-Entity Dataset_ optin


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2259]: https://breedinginsight.atlassian.net/browse/BI-2259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2259]: https://breedinginsight.atlassian.net/browse/BI-2259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ