### PR TITLE
BI-2044 - Can't archive an observation variable that is in use

### DIFF
--- a/src/components/forms/BasicInputField.vue
+++ b/src/components/forms/BasicInputField.vue
@@ -31,6 +31,7 @@
         v-bind:type="fieldTypeComputed"
         v-bind:placeholder="placeholder ? placeholder : fieldName"
         v-bind:autocomplete="autocomplete"
+        v-bind:disabled="isDisabled"
     />
   </BaseFieldWrapper>
 </template>
@@ -64,6 +65,8 @@
     inputId: string | undefined;
     @Prop()
     autocomplete!: boolean | true;
+    @Prop()
+    isDisabled!: boolean;
 
     get fieldTypeComputed() {
       return this.fieldType ? this.fieldType : 'text';

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -448,8 +448,12 @@ export default class OntologyTable extends Vue {
   async updateTerm() {
     if (this.originalTrait && this.editTrait) {
       try {
-        if (this.originalTrait.active === !this.editTrait.active) this.activateArchive(this.editTrait);
-        else await this.updateTrait();
+        if (this.originalTrait.active === !this.editTrait.active) {
+          this.activateArchive(this.editTrait);
+        } else {
+          // check for editablity done in updatetrait
+          await this.updateTrait();
+        }
       } catch (error) {
         this.$log.error(error);
         this.$emit('show-error-notification', `"${this.editTrait.observationVariableName}" could not be updated`);
@@ -460,6 +464,7 @@ export default class OntologyTable extends Vue {
   async modalDeleteHandler(){
     try {
       const traitClone = JSON.parse(JSON.stringify(this.editTrait));
+
       const updatedTrait: Trait = await TraitService.archiveTrait(this.activeProgram!.id!, traitClone);
 
       // Replace traits in queried traits
@@ -468,7 +473,10 @@ export default class OntologyTable extends Vue {
 
       this.deactivateActive = false;
       this.paginationController.updatePage(1);
+
+      // only update if trait is editable will be handled in updateTrait
       await this.updateTrait(true);
+
     } catch(err) {
       this.$log.error(err);
       if (this.editTrait)
@@ -554,23 +562,33 @@ export default class OntologyTable extends Vue {
       let traitToSave = this.prepareScaleCategoriesForSave(this.editTrait!);
 
       this.editValidationHandler = new ValidationError();
-      const [data] = await TraitService.updateTraits(this.activeProgram!.id!, [traitToSave!]) as [Trait[], Metadata];
+      let eventPayload;
 
-      // Temporary: Only update the given trait.
-      // TODO: Select all traits and find the edited trait within results to keep row open
-      if (data.length > 0){
-        const traitInd = this.traits.findIndex(trait => trait.id === data[0].id);
-        const traitCopy = [...this.traits];
-        if (traitInd >= 0) {
-          traitCopy[traitInd] = {...data[0]} as Trait;
+      if (this.currentTraitEditable) {
+        const [data] = await TraitService.updateTraits(this.activeProgram!.id!, [traitToSave!]) as [Trait[], Metadata];
+
+        // Temporary: Only update the given trait.
+        // TODO: Select all traits and find the edited trait within results to keep row open
+        if (data.length > 0) {
+          const traitInd = this.traits.findIndex(trait => trait.id === data[0].id);
+          const traitCopy = [...this.traits];
+          if (traitInd >= 0) {
+            traitCopy[traitInd] = {...data[0]} as Trait;
+          }
+          this.traits = traitCopy;
+          eventPayload = data[0];
         }
-        this.traits = traitCopy;
+      } else {
+        eventPayload = {...traitToSave} as Trait;
       }
+
       const tagPromise = this.getTraitTags();
-      this.traitSidePanelState.bus.$emit(this.traitSidePanelState.successEditEvent, data[0]);
+      this.traitSidePanelState.bus.$emit(this.traitSidePanelState.successEditEvent, eventPayload);
       let editNote;
       if (this.editTrait) {
-        if (archiveStateChanged) {
+        if (archiveStateChanged && !this.currentTraitEditable) {
+          editNote = `"${this.editTrait.observationVariableName}" successfully ${ this.editTrait.active ? 'restored' : 'archived'}.`;
+        } else if (archiveStateChanged && this.currentTraitEditable) {
           editNote = `"${this.editTrait.observationVariableName}" successfully edited and ${ this.editTrait.active ? 'restored' : 'archived'}.`;
         } else {
           editNote = `"${this.editTrait.observationVariableName}" successfully edited.`;

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -89,6 +89,8 @@
             v-bind:tags="tagOptions"
             v-bind:client-validations="validations"
             v-bind:validation-handler="validationHandler"
+            v-bind:editable-check-loading="false"
+            v-bind:editable="true"
         ></BaseTraitForm>
       </template>
     </NewDataForm>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -255,7 +255,7 @@
               v-bind:client-validations="validations"
               v-bind:validation-handler="validationHandler"
               v-bind:editable="false"
-              v-bind:editable-check-loading="false"
+              v-bind:editable-check-loading="true"
           ></BaseTraitForm>
         </template>
       </EditDataForm>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -189,7 +189,6 @@
       <!-- maybe break out controls for reuse eventually -->
       <div v-if="!isSubscribed" class="columns is-centered is-mobile is-variable is-multiline is-0 my-0">
         <div class="column is-half p-0 mt-5">
-          <!-- editable && !loadingEditable && -->
           <a
               v-if="!data.isDup"
               v-on:click="$emit('activate-edit', data)"

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -189,8 +189,9 @@
       <!-- maybe break out controls for reuse eventually -->
       <div v-if="!isSubscribed" class="columns is-centered is-mobile is-variable is-multiline is-0 my-0">
         <div class="column is-half p-0 mt-5">
+          <!-- editable && !loadingEditable && -->
           <a
-              v-if="editable && !loadingEditable && !data.isDup"
+              v-if="!data.isDup"
               v-on:click="$emit('activate-edit', data)"
               v-on:keypress.enter.space="$emit('activate-edit', data)"
               tabindex="0"
@@ -202,10 +203,13 @@
         <div class="column is-half p-0"></div>
       </div>
 
+      <!--
       <ProgressBar v-if="loadingEditable && $ability.can('update', 'Trait')" v-bind:label="'Checking trait editability status'"
                    v-bind:estimated-time-text="'May take a few seconds'"
       />
+      -->
 
+      <!--
       <article v-if="!editable && !loadingEditable && !fromImportTable && $ability.can('update', 'Trait')" class="message is-info">
         <div class="message-body">
           <div class="media">
@@ -222,6 +226,7 @@
           </div>
         </div>
       </article>
+      -->
     </template>
 
     <template v-if="data && editActive">
@@ -249,6 +254,8 @@
               v-bind:attributes="attributeOptions"
               v-bind:client-validations="validations"
               v-bind:validation-handler="validationHandler"
+              v-bind:editable="false"
+              v-bind:editable-check-loading="false"
           ></BaseTraitForm>
         </template>
       </EditDataForm>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -254,8 +254,8 @@
               v-bind:attributes="attributeOptions"
               v-bind:client-validations="validations"
               v-bind:validation-handler="validationHandler"
-              v-bind:editable="false"
-              v-bind:editable-check-loading="true"
+              v-bind:editable="editable"
+              v-bind:editable-check-loading="loadingEditable"
           ></BaseTraitForm>
         </template>
       </EditDataForm>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -230,6 +230,7 @@
               v-bind:validation-handler="validationHandler"
               v-bind:editable="editable"
               v-bind:editable-check-loading="loadingEditable"
+              v-bind:from-import-table="fromImportTable"
           ></BaseTraitForm>
         </template>
       </EditDataForm>

--- a/src/components/trait/TraitDetailPanel.vue
+++ b/src/components/trait/TraitDetailPanel.vue
@@ -202,31 +202,6 @@
         </div>
         <div class="column is-half p-0"></div>
       </div>
-
-      <!--
-      <ProgressBar v-if="loadingEditable && $ability.can('update', 'Trait')" v-bind:label="'Checking trait editability status'"
-                   v-bind:estimated-time-text="'May take a few seconds'"
-      />
-      -->
-
-      <!--
-      <article v-if="!editable && !loadingEditable && !fromImportTable && $ability.can('update', 'Trait')" class="message is-info">
-        <div class="message-body">
-          <div class="media">
-            <figure class="media-left">
-              <p class="image is-24x24">
-                <help-circle-icon size="1.5x"></help-circle-icon>
-              </p>
-            </figure>
-            <div class="media-content">
-              <div class="has-text-dark">
-                Not editable because this trait has associated experiment data.
-              </div>
-            </div>
-          </div>
-        </div>
-      </article>
-      -->
     </template>
 
     <template v-if="data && editActive">

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -20,7 +20,7 @@
   </div>
 
   <div class="column is-full">
-    <article v-if="!editable && !editableCheckLoading" class="message is-primary mb-3">
+    <article v-if="!editable && !editableCheckLoading && !fromImportTable && $ability.can('update', 'Trait')" class="message is-primary mb-3">
       <div class="message-body">
         <div class="media">
           <figure class="media-left">
@@ -380,6 +380,8 @@ export default class BaseTraitForm extends Vue {
   editable!: boolean;
   @Prop()
   editableCheckLoading!: boolean;
+  @Prop({default: false})
+  private fromImportTable!: boolean;
 
   private termTypes: TermType[] = Object.values(TermType);
 

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -13,6 +13,11 @@
              v-on:input="toggleActiveState">
       <label for="newTermActiveToggle" class="is-pulled-right">{{trait.active ? 'Active' : 'Archived'}}</label>
     </div>
+  <div class="column is-full">
+    <ProgressBar v-if="editableCheckLoading && $ability.can('update', 'Trait')" v-bind:label="'Checking trait editability status'"
+                 v-bind:estimated-time-text="'May take a few seconds'"
+    />
+  </div>
 
   <div class="column is-full">
     <article v-if="!editable && !editableCheckLoading" class="message is-primary mb-3">
@@ -325,7 +330,8 @@ import TagField from "@/components/forms/TagField.vue";
 import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
 import {TermType} from "@/breeding-insight/model/TraitSelector";
 import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
-import { HelpCircleIcon } from 'vue-feather-icons'
+import { HelpCircleIcon } from 'vue-feather-icons';
+import ProgressBar from '@/components/forms/ProgressBar.vue';
 
 @Component({
   components: {
@@ -340,7 +346,9 @@ import { HelpCircleIcon } from 'vue-feather-icons'
     OrdinalTraitForm,
     BasicSelectField,
     BasicInputField,
-    HelpCircleIcon},
+    HelpCircleIcon,
+    ProgressBar,
+  },
   data: () => ({DataType, MethodClass, TraitError, StringFormatters, Scale}),
   filters: {
     toCSV: function (value: string[] | undefined): string {

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -14,6 +14,26 @@
       <label for="newTermActiveToggle" class="is-pulled-right">{{trait.active ? 'Active' : 'Archived'}}</label>
     </div>
 
+  <div class="column is-full">
+    <article v-if="!editable && !editableCheckLoading" class="message is-primary mb-3">
+      <div class="message-body">
+        <div class="media">
+          <figure class="media-left">
+            <p class="image is-24x24">
+              <help-circle-icon size="1.5x"></help-circle-icon>
+            </p>
+          </figure>
+          <div class="media-content">
+            <div class="has-text-dark">
+              Not editable because this trait has associated experiment data. Only active status can be changed and saved.
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+  </div>
+  <template v-if="editable">
 <!-- term type -->
   <div class="column is-2">
     <span class="is-pulled-right required new-term pb-2 pr-3">Term Type</span>
@@ -26,6 +46,7 @@
         v-bind:options="termTypes"
         v-bind:field-name="'Term Type'"
         v-bind:show-label="false"
+        v-bind:is-disabled="!editable"
         v-on:input="setTermType($event)"
     />
   </div>
@@ -44,6 +65,7 @@
           v-bind:field-help="''"
           v-bind:validations="clientValidations.observationVariableName"
           v-bind:server-validations="validationHandler.getValidation(0, TraitError.ObservationVariableName)"
+          v-bind:is-disabled="!editable"
           v-on:input="setOTName($event)"
       />
     </div>
@@ -58,6 +80,7 @@
           v-bind:placeholder="'Full Name'"
           v-bind:show-label="false"
           v-bind:server-validations="validationHandler.getValidation(0, TraitError.FullName)"
+          v-bind:is-disabled="!editable"
           v-on:input="setFullName($event)"
       />
     </div>
@@ -72,6 +95,7 @@
           v-bind:placeholder="'Ontology Term Description'"
           v-bind:show-label="false"
           v-bind:server-validations="validationHandler.getValidation(0, TraitError.TraitDescription)"
+          v-bind:is-disabled="!editable"
           v-on:input="trait.traitDescription = $event"
       />
     </div>
@@ -95,6 +119,7 @@
           v-bind:field-name="'Tags'"
           v-bind:show-label="false"
           v-bind:before-adding="checkTag"
+          v-bind:is-disabled="!editable"
           v-on:add="addTag($event)"
           v-on:remove="removeTag($event)"
       />
@@ -273,7 +298,7 @@
         />
       </div>
     </template>
-
+    </template>
   </div>
 </template>
 
@@ -300,6 +325,7 @@ import TagField from "@/components/forms/TagField.vue";
 import BaseFieldWrapper from "@/components/forms/BaseFieldWrapper.vue";
 import {TermType} from "@/breeding-insight/model/TraitSelector";
 import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
+import { HelpCircleIcon } from 'vue-feather-icons'
 
 @Component({
   components: {
@@ -308,7 +334,13 @@ import {EnumUtils} from "@/breeding-insight/utils/EnumUtils";
     CategoryTraitForm,
     NumericalTraitForm,
     BaseFieldWrapper,
-    DurationTraitForm, DateTraitForm, TextTraitForm, OrdinalTraitForm, BasicSelectField, BasicInputField},
+    DurationTraitForm,
+    DateTraitForm,
+    TextTraitForm,
+    OrdinalTraitForm,
+    BasicSelectField,
+    BasicInputField,
+    HelpCircleIcon},
   data: () => ({DataType, MethodClass, TraitError, StringFormatters, Scale}),
   filters: {
     toCSV: function (value: string[] | undefined): string {
@@ -341,6 +373,10 @@ export default class BaseTraitForm extends Vue {
   editFormat!: boolean;
   @Prop()
   tags?: string[];
+  @Prop()
+  editable!: boolean;
+  @Prop()
+  editableCheckLoading!: boolean;
 
   private termTypes: TermType[] = Object.values(TermType);
 

--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -51,7 +51,6 @@
         v-bind:options="termTypes"
         v-bind:field-name="'Term Type'"
         v-bind:show-label="false"
-        v-bind:is-disabled="!editable"
         v-on:input="setTermType($event)"
     />
   </div>
@@ -70,7 +69,6 @@
           v-bind:field-help="''"
           v-bind:validations="clientValidations.observationVariableName"
           v-bind:server-validations="validationHandler.getValidation(0, TraitError.ObservationVariableName)"
-          v-bind:is-disabled="!editable"
           v-on:input="setOTName($event)"
       />
     </div>
@@ -85,7 +83,6 @@
           v-bind:placeholder="'Full Name'"
           v-bind:show-label="false"
           v-bind:server-validations="validationHandler.getValidation(0, TraitError.FullName)"
-          v-bind:is-disabled="!editable"
           v-on:input="setFullName($event)"
       />
     </div>
@@ -100,7 +97,6 @@
           v-bind:placeholder="'Ontology Term Description'"
           v-bind:show-label="false"
           v-bind:server-validations="validationHandler.getValidation(0, TraitError.TraitDescription)"
-          v-bind:is-disabled="!editable"
           v-on:input="trait.traitDescription = $event"
       />
     </div>
@@ -124,7 +120,6 @@
           v-bind:field-name="'Tags'"
           v-bind:show-label="false"
           v-bind:before-adding="checkTag"
-          v-bind:is-disabled="!editable"
           v-on:add="addTag($event)"
           v-on:remove="removeTag($event)"
       />


### PR DESCRIPTION
# Description
**Story:** [BI-2044](https://breedinginsight.atlassian.net/browse/BI-2044?atlOrigin=eyJpIjoiNzRiMmFhNGY0ZjMwNDUwM2I5N2RmNmE1N2I3ODhkMzkiLCJwIjoiaiJ9)


- Added isDisabled prop to src/components/forms/BasicInputField.vue
  - Not used in this card was going to but decided on different approach, left in for possible future use
- Added editable and editableCheckLoading props to BaseTraitForm to facilitate hiding controls there
- Updated edit update logic to separate changing active status from updating trait, it was already using the /archive endpoint so just kept changes on the front end

**NOTE:** Seeing an issue testing this and on qa-test as well when switching between the Active and Archived tabs on the ontology page, the pages are blank and some api calls are not being made unless you do a hard refresh. Created a new bug card for this: https://breedinginsight.atlassian.net/browse/BI-2271?atlOrigin=eyJpIjoiYzc5OGVhMjJiMDVkNGJjNWFmNjZjYjI3MjA3ZDEwZTciLCJwIjoiaiJ9

# Dependencies
_Please include any dependencies to other code branches, testing configurations, scripts to be run, etc._

# Testing
- Test different combinations of archiving and restoring for traits that have experiment data collected on them and traits that don't. 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2044]: https://breedinginsight.atlassian.net/browse/BI-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ