### PR TITLE
BI-2226  Experiment and Observations Template: Remove 2 sub-obs columns

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -129,6 +129,18 @@ main {
   a {
     text-decoration: underline;
   }
+  
+  .experiment-observation-add-collaborator-button {
+    .modal {
+      .modal-card {
+        width: $medium-modal-content-width;
+        .modal-card-body {
+          padding: $medium-modal-body-padding;
+        }
+      }
+    }
+  }
+  
   */
   p,
   dl,
@@ -932,6 +944,17 @@ tr:nth-child(odd) td.db-filled {
       width: $large-modal-content-width;
       .modal-card-body {
         padding: $medium-modal-body-padding;
+      }
+    }
+  }
+  
+  .experiment-observation-remove-collaborator-button {
+    .modal {
+      .modal-card {
+        width: $medium-modal-content-width;
+        .modal-card-body {
+          padding: $medium-modal-body-padding;
+        }
       }
     }
   }

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -129,18 +129,6 @@ main {
   a {
     text-decoration: underline;
   }
-  
-  .experiment-observation-add-collaborator-button {
-    .modal {
-      .modal-card {
-        width: $medium-modal-content-width;
-        .modal-card-body {
-          padding: $medium-modal-body-padding;
-        }
-      }
-    }
-  }
-  
   */
   p,
   dl,
@@ -927,7 +915,7 @@ tr:nth-child(odd) td.db-filled {
   }
 }
 
-.sub-entity-dataset-modal, .experiment-observations-download-button {
+.sub-entity-dataset-modal, .experiment-observations-download-button, .experiment-observation-add-collaborator-button, .experiment-observation-remove-collaborator-button {
   .modal {
     .modal-card {
       width: $medium-modal-content-width;
@@ -944,17 +932,6 @@ tr:nth-child(odd) td.db-filled {
       width: $large-modal-content-width;
       .modal-card-body {
         padding: $medium-modal-body-padding;
-      }
-    }
-  }
-  
-  .experiment-observation-remove-collaborator-button {
-    .modal {
-      .modal-card {
-        width: $medium-modal-content-width;
-        .modal-card-body {
-          padding: $medium-modal-body-padding;
-        }
       }
     }
   }

--- a/src/breeding-insight/dao/ExperimentDAO.ts
+++ b/src/breeding-insight/dao/ExperimentDAO.ts
@@ -21,6 +21,7 @@ import {Result, ResultGenerator} from "@/breeding-insight/model/Result";
 import {Trial} from "@/breeding-insight/model/Trial.ts";
 import {DatasetModel} from "@/breeding-insight/model/DatasetModel";
 import {DatasetMetadata} from "@/breeding-insight/model/DatasetMetadata";
+import {Collaborator} from "@/breeding-insight/model/Collaborator";
 
 export class ExperimentDAO {
 
@@ -31,6 +32,66 @@ export class ExperimentDAO {
         config.programId = programId;
         config.experimentId = experimentId;
         config.params = {stats: stats};
+        try {
+            const res = await api.call(config) as Response;
+            let { result } = res.data;
+            return ResultGenerator.success(result);
+        } catch (error) {
+            return ResultGenerator.err(error);
+        }
+    }
+
+    static async getUnassignedCollaborators(programId: string, experimentId: string): Promise<Result<Error, Collaborator[]>> {
+        const config: any = {};
+        config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/collaborators?active=false`;
+        config.method = 'get';
+        config.programId = programId;
+        config.experimentId = experimentId;
+        try {
+            const res = await api.call(config) as Response;
+            let { result } = res.data;
+            return ResultGenerator.success(result);
+        } catch (error) {
+            return ResultGenerator.err(error);
+        }
+    }
+
+    static async addCollaborator(programId: string, experimentId: string, userId: string): Promise<Result<Error, Collaborator>> {
+        const config: any = {};
+        config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/collaborators`;
+        config.method = 'post';
+        config.programId = programId;
+        config.experimentId = experimentId;
+        config.data = {userId: userId};
+        try {
+            const res = await api.call(config) as Response;
+            let { result } = res.data;
+            return ResultGenerator.success(result);
+        } catch (error) {
+            return ResultGenerator.err(error);
+        }
+    }
+
+    static async deleteCollaborator(programId: string, experimentId: string, id: string): Promise<Result<Error, boolean>> {
+        const config: any = {};
+        config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/collaborators/${id}`;
+        config.method = 'delete';
+        config.programId = programId;
+        config.experimentId = experimentId;
+        try {
+            const res = await api.call(config) as Response;
+            return ResultGenerator.success(true);
+        } catch (error) {
+            return ResultGenerator.err(error);
+        }
+    }
+
+    static async getAssignedCollaborators(programId: string, experimentId: string): Promise<Result<Error, Collaborator[]>> {
+        const config: any = {};
+        config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/collaborators?active=true`;
+        config.method = 'get';
+        config.programId = programId;
+        config.experimentId = experimentId;
         try {
             const res = await api.call(config) as Response;
             let { result } = res.data;

--- a/src/breeding-insight/model/Collaborator.ts
+++ b/src/breeding-insight/model/Collaborator.ts
@@ -1,0 +1,15 @@
+export class Collaborator {
+    id: string;
+    active: boolean;
+    userId: string;
+    name: string;
+    email: string;
+
+    constructor(id: string, active: boolean, userId: string, name: string, email: string) {
+        this.id = id;
+        this.active = active;
+        this.userId = userId;
+        this.name = name;
+        this.email = email;
+    }
+}

--- a/src/breeding-insight/service/ExperimentService.ts
+++ b/src/breeding-insight/service/ExperimentService.ts
@@ -22,6 +22,7 @@ import {DatasetModel} from "@/breeding-insight/model/DatasetModel";
 import {DatasetMetadata} from "@/breeding-insight/model/DatasetMetadata";
 import {SubEntityDatasetNewRequest} from "@/breeding-insight/model/SubEntityDatasetNewRequest";
 import {BrAPIUtils} from "@/breeding-insight/utils/BrAPIUtils";
+import {Collaborator} from "@/breeding-insight/model/Collaborator";
 
 export class ExperimentService {
 
@@ -70,5 +71,33 @@ export class ExperimentService {
             return ResultGenerator.err(new Error("Trial is missing external reference."));
         }
         return await ExperimentDAO.getDatasetMetadata(programId, externalReferenceId);
+    }
+    
+    static async getUnassignedCollaboratorsByExperiment(programId: string | undefined, experimentId: string): Promise<Result<Error, Collaborator[]>> {
+        if (!programId) {
+            return ResultGenerator.err(new Error('Missing or invalid program id'));
+        }
+        return await ExperimentDAO.getUnassignedCollaborators(programId, experimentId);
+    }
+
+    static async getAssignedCollaborators(programId: string | undefined, experimentId: string): Promise<Result<Error, Collaborator[]>> {
+        if (!programId) {
+            return ResultGenerator.err(new Error('Missing or invalid program id'));
+        }
+        return await ExperimentDAO.getAssignedCollaborators(programId, experimentId);
+    }
+
+    static async addCollaboratorToExperiment(programId: string | undefined, experimentId: string, userId: string): Promise<Result<Error, Collaborator>> {
+        if (!programId) {
+            return ResultGenerator.err(new Error('Missing or invalid program id'));
+        }
+        return await ExperimentDAO.addCollaborator(programId, experimentId, userId);
+    }
+
+    static async removeCollaboratorFromExperiment(programId: string | undefined, experimentId: string, id: string): Promise<Result<Error, boolean>> {
+        if (!programId) {
+            return ResultGenerator.err(new Error('Missing or invalid program id'));
+        }
+        return await ExperimentDAO.deleteCollaborator(programId, experimentId, id);
     }
 }

--- a/src/components/experiments/ExperimentAddCollaboratorModal.vue
+++ b/src/components/experiments/ExperimentAddCollaboratorModal.vue
@@ -1,0 +1,137 @@
+<!--
+- See the NOTICE file distributed with this work for additional information
+- regarding copyright ownership.
+-
+- Licensed under the Apache License, Version 2.0 (the "License");
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-->
+
+<template>
+  <AddCollaboratorModal
+    v-bind:unique-id="trialId"
+    v-bind:modal-title="modalTitle"
+    v-bind:addCollaborator="addCollaborator"
+    v-bind:active="active && loadingCollaboratorOptionsComplete"
+    modal-class="experiment-observation-add-collaborator-button"
+    v-on:deactivate="resetCollaboratorOptions"
+  >
+    <template #form>
+      <p>An experimental collaborator will  be granted read, dowload, and BrAPI pull access to this experiment ${experiment-name}. If the collaborator is not available from the dropdown menu, they will need to be added. Program Administration > Users</p>
+      <div class="columns mb-4">
+        <!-- Collaborator Select -->
+        <div class="column control">
+          <div class="field">
+            <label
+              class="label"
+              v-bind:for="`collaborator-select-${trialId}`"
+            ><span>Collaborator</span></label>
+            <div class="control">
+              <div class="select">
+                <select
+                  v-bind:id="`collaborator-select-${trialId}`"
+                  v-model="collaboratorId"
+                >
+                  <option
+                    v-for="option in collaboratorOptions"
+                    v-bind:key="option.id"
+                    v-bind:value="option.id"
+                  >
+                    {{ option.name }}
+                  </option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+    <slot />
+  </AddCollaboratorModal>
+</template>
+
+<script lang="ts">
+import {Component, Vue, Prop, Watch} from "vue-property-decorator";
+import {validationMixin} from "vuelidate";
+import {mapGetters} from "vuex";
+import {Program} from "@/breeding-insight/model/Program";
+import {AlertTriangleIcon} from 'vue-feather-icons';
+import {Trial} from "@/breeding-insight/model/Trial";
+import {Metadata} from "@/breeding-insight/model/BiResponse";
+import {Result} from "@/breeding-insight/model/Result";
+import {BrAPIUtils} from "@/breeding-insight/utils/BrAPIUtils";
+import AddCollaboratorModal from "@/components/modals/AddCollaboratorModal.vue";
+import {ExperimentService} from "@/breeding-insight/service/ExperimentService";
+import { Collaborator } from '@/breeding-insight/model/Collaborator';
+
+@Component({
+  mixins: [validationMixin],
+  components: {AddCollaboratorModal, AlertTriangleIcon},
+  computed: {
+    ...mapGetters([
+      'activeProgram'
+    ])
+  }
+})
+export default class ExperimentAddCollaboratorModal extends Vue {
+
+  @Prop()
+  active!: boolean;
+  @Prop()
+  trialId!: string;
+  @Prop()
+  experiment!: Trial;
+  @Prop()
+  modalTitle?: string;
+
+  private activeProgram?: Program;
+  private collaboratorId?: string;
+  private showValidationError: boolean = false;
+  private collaboratorOptions: object[] = [];
+  private loadingCollaboratorOptionsComplete: boolean = false;
+
+  @Watch('experiment', {immediate: true})
+  onExperimentChanged() {
+    this.loadingCollaboratorOptionsComplete = false;
+    this.getCollaboratorOptions();
+  }
+
+  async getCollaboratorOptions() {
+    try {
+      const response: Result<Error, Collaborator[]> = await ExperimentService.getUnassignedCollaboratorsByExperiment(this.activeProgram!.id!, this.trialId);
+      if(response.isErr()) throw response.value;
+      let collaborators = response.value;
+      this.collaboratorOptions = collaborators.map((c) => ({id: c.id, name: c.name}));
+      this.loadingCollaboratorOptionsComplete = true;
+    } catch (error) {
+      this.$emit('show-error-notification', 'Error while trying to load collaborators');
+    }
+  }
+
+  addCollaborator(): boolean {
+    if (this.collaboratorId !== undefined) {
+      if (this.activeProgram) {
+        ExperimentService.addCollaboratorToExperiment(this.activeProgram.id, this.trialId, this.collaboratorId);
+      }
+      return true;
+    }
+    this.$emit('show-error-notification', 'A collaborator must be selected.');
+    this.showValidationError = true;
+    return false;
+  }
+
+  resetCollaboratorOptions(){
+    this.$emit('deactivate');
+    this.collaboratorId = undefined;
+    this.showValidationError = false;
+  }
+}
+</script>

--- a/src/components/experiments/ExperimentCollaboratorRemovalModal.vue
+++ b/src/components/experiments/ExperimentCollaboratorRemovalModal.vue
@@ -1,0 +1,80 @@
+<!--
+- See the NOTICE file distributed with this work for additional information
+- regarding copyright ownership.
+-
+- Licensed under the Apache License, Version 2.0 (the "License");
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-->
+
+<template>
+  <ConfirmationModal
+    v-bind:unique-id="trialId"
+    v-bind:modal-title="modalTitle"
+    v-bind:confirmedAction="removeCollaborator"
+    v-bind:active="active"
+    modal-class="experiment-observation-remove-collaborator-button"
+    v-on:deactivate="resetCollaborator"
+  >
+    <template #form>
+      <p>Are you sure you want to revoke ${collaborator.name}'s access as an experimental collaborator?</p>
+    </template>
+    <slot />
+  </ConfirmationModal>
+</template>
+
+<script lang="ts">
+import {Component, Vue, Prop} from "vue-property-decorator";
+import {validationMixin} from "vuelidate";
+import {mapGetters} from "vuex";
+import {Program} from "@/breeding-insight/model/Program";
+import {AlertTriangleIcon} from 'vue-feather-icons';
+import {Trial} from "@/breeding-insight/model/Trial";
+import ConfirmationModal from "@/components/modals/ConfirmationModal.vue";
+import {ExperimentService} from "@/breeding-insight/service/ExperimentService";
+import { Collaborator } from '@/breeding-insight/model/Collaborator';
+
+@Component({
+  mixins: [validationMixin],
+  components: {ConfirmationModal, AlertTriangleIcon},
+  computed: {
+    ...mapGetters([
+      'activeProgram'
+    ])
+  }
+})
+export default class ExperimentCollaboratorRemovalModal extends Vue {
+
+  @Prop()
+  active!: boolean;
+  @Prop()
+  trialId!: string;
+  @Prop()
+  experiment!: Trial;
+  @Prop()
+  modalTitle?: string;
+  @Prop()
+  collaborator!: Collaborator;
+
+  private activeProgram?: Program;
+
+  removeCollaborator(): boolean {
+    if (this.activeProgram) {
+      ExperimentService.removeCollaboratorFromExperiment(this.activeProgram.id, this.trialId, this.collaborator.id);
+    }
+    return true;
+  }
+
+  resetCollaborator(){
+    this.$emit('deactivate');
+  }
+}
+</script>

--- a/src/components/modals/AddCollaboratorModal.vue
+++ b/src/components/modals/AddCollaboratorModal.vue
@@ -1,0 +1,91 @@
+<!--
+- See the NOTICE file distributed with this work for additional information
+- regarding copyright ownership.
+-
+- Licensed under the Apache License, Version 2.0 (the "License");
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-->
+
+<template>
+  <section
+    v-bind:id="'addCollaboratorModal-' + uniqueId"
+    v-bind:class="modalClass"
+  >
+    <FormModal
+      v-bind:active.sync="active"
+      v-bind:title="modalTitle"
+      v-on:deactivate="closeAddCollaboratorModal"
+    >
+      <template #form>
+        <slot name="form" />
+      </template>
+      <template #buttons>
+        <div class="columns">
+          <div class="column is-whole has-text-centered buttons">
+            <button
+              class="button is-primary has-text-weight-bold"
+              v-on:click="invokeAddCollaborator"
+            >
+              <strong>Save</strong>
+            </button>
+            <button
+              class="button"
+              v-on:click="closeAddCollaboratorModal"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </template>
+    </FormModal>
+  </section>
+</template>
+
+
+<script lang="ts">
+import {Component, Vue, Prop} from "vue-property-decorator";
+import {validationMixin} from "vuelidate";
+import FormModal from "@/components/modals/FormModal.vue";
+
+@Component({
+  mixins: [validationMixin],
+  components: {FormModal}
+})
+export default class AddCollaboratorModal extends Vue {
+
+  @Prop()
+  uniqueId!: string;
+  @Prop()
+  modalTitle?: string;
+  @Prop()
+  modalClass?: string;
+  @Prop()
+  addCollaborator!: () => boolean;
+  @Prop()
+  active!: boolean;
+
+  closeAddCollaboratorModal(){
+    // Emit deactivate event, allows parent to reset form state, for example.
+    this.$emit('deactivate');
+  }
+
+  invokeAddCollaborator(){
+    // Invoke the addCollaborator prop, which returns true if adding collaborator succeeded.
+    if (this.addCollaborator())
+    {
+      // Close and deactivate modal.
+      this.closeAddCollaboratorModal();
+    }
+  }
+
+}
+</script>

--- a/src/components/modals/ConfirmationModal.vue
+++ b/src/components/modals/ConfirmationModal.vue
@@ -1,0 +1,91 @@
+<!--
+- See the NOTICE file distributed with this work for additional information
+- regarding copyright ownership.
+-
+- Licensed under the Apache License, Version 2.0 (the "License");
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+-
+-     http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-->
+
+<template>
+  <section
+    v-bind:id="'confirmationModal-' + uniqueId"
+    v-bind:class="modalClass"
+  >
+    <FormModal
+      v-bind:active.sync="active"
+      v-bind:title="modalTitle"
+      v-on:deactivate="closeConfirmationModal"
+    >
+      <template #form>
+        <slot name="form" />
+      </template>
+      <template #buttons>
+        <div class="columns">
+          <div class="column is-whole has-text-centered buttons">
+            <button
+              class="button is-primary has-text-weight-bold"
+              v-on:click="invokeConfirmedAction"
+            >
+              <strong>Confirm</strong>
+            </button>
+            <button
+              class="button"
+              v-on:click="closeConfirmationModal"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </template>
+    </FormModal>
+  </section>
+</template>
+
+
+<script lang="ts">
+import {Component, Vue, Prop} from "vue-property-decorator";
+import {validationMixin} from "vuelidate";
+import FormModal from "@/components/modals/FormModal.vue";
+
+@Component({
+  mixins: [validationMixin],
+  components: {FormModal}
+})
+export default class ConfirmationModal extends Vue {
+
+  @Prop()
+  uniqueId!: string;
+  @Prop()
+  modalTitle?: string;
+  @Prop()
+  modalClass?: string;
+  @Prop()
+  confirmedAction!: () => boolean;
+  @Prop()
+  active!: boolean;
+
+  closeConfirmationModal(){
+    // Emit deactivate event, allows parent to reset form state, for example.
+    this.$emit('deactivate');
+  }
+
+  invokeConfirmedAction(){
+    // Invoke the confirmedAction prop, which returns true if action was confirmed.
+    if (this.confirmedAction())
+    {
+      // Close and deactivate modal.
+      this.closeConfirmationModal();
+    }
+  }
+
+}
+</script>

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -45,6 +45,15 @@
         v-on:deactivate="subEntityModalActive = false"
     />
 
+    <ExperimentAddCollaboratorModal
+        v-bind:experiment="experiment"
+        v-bind:modal-title="`Add experimental collaborator`"
+        v-bind:trial-id="experimentUUID"
+        v-bind:active="addCollaboratorActive"
+        v-on:show-error-notification="$emit('show-error-notification', $event)"
+        v-on:deactivate="addCollaboratorActive = false"
+    />
+
     <div v-if="!experimentLoading && experiment!=null">
 
       <div class="columns is-multiline is-align-items-stretch mt-4">
@@ -77,7 +86,21 @@
                       v-on:import-file="importFile()"
                       v-on:download-file="downloadFile()"
                       v-on:create-sub-entity-dataset="openSubEntityModal()"
+                      v-on:add-collaborator="addCollaborator()"
           />
+        </article>
+        <article class="column px-2">
+          <section>
+            <ul style="list-style-type: none;">
+              <li v-for="collaborator in collaborators" :key="collaborator.id">
+                <span>{{ collaborator.name }}</span>
+                <span>{{ collaborator.email }}</span>
+                <button v-on:click="selectedForRemoval = collaborator; removeCollaboratorActive = true;">
+                  <i class="fas fa-trash"></i>
+                </button>
+              </li>
+            </ul>
+          </section>
         </article>
       </div>
 
@@ -110,6 +133,7 @@
 <script lang="ts">
 import {Component, Watch} from "vue-property-decorator";
 import {mapGetters} from "vuex";
+import {Collaborator} from "@/breeding-insight/model/Collaborator";
 import {PlusCircleIcon} from 'vue-feather-icons'
 import {Program} from "@/breeding-insight/model/Program";
 import {Result} from "@/breeding-insight/model/Result";
@@ -124,12 +148,16 @@ import SubEntityDatasetModal from "@/components/modals/SubEntityDatasetModal.vue
 import {DatasetMetadata} from "@/breeding-insight/model/DatasetMetadata";
 import {SubEntityDatasetNewRequest} from "@/breeding-insight/model/SubEntityDatasetNewRequest";
 import {DatasetModel} from "@/breeding-insight/model/DatasetModel";
+import ExperimentAddCollaboratorModal from "@/components/experiments/ExperimentAddCollaboratorModal.vue";
+import ExperimentCollaboratorRemovalModal from "@/components/experiments/ExperimentCollaboratorRemovalModal.vue";
 
 @Component({
   components: {
     SubEntityDatasetModal,
     PlusCircleIcon,
     ExperimentObservationsDownloadModal,
+    ExperimentAddCollaboratorModal,
+    ExperimentCollaboratorRemovalModal,
     ActionMenu
   },
   computed: {
@@ -145,13 +173,17 @@ export default class ExperimentDetails extends ProgramsBase {
   private activeProgram: Program;
   private experiment: Trial;
   private experimentLoading: boolean = true;
+  private addCollaboratorActive: boolean = false;
   private downloadModalActive: boolean = false;
   private subEntityModalActive: boolean = false;
+  private removeCollaboratorActive: boolean = false;
+  private selectedForRemoval?: Collaborator;
   private datasetMetadata: DatasetMetadata[] = [];
 
   private actions: ActionMenuItem[] = [
       new ActionMenuItem('experiment-import-file', 'import-file', 'Import file', this.$ability.can('create', 'Import')),
       new ActionMenuItem('experiment-download-file', 'download-file', 'Download file'),
+      new ActionMenuItem('experiment-add-collaborator', 'add-collaborator', 'Add Collaborator'),
       // new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset')
   ];
 
@@ -173,6 +205,11 @@ export default class ExperimentDetails extends ProgramsBase {
     this.downloadModalActive = true;
   }
 
+  private addCollaborator() {
+    this.addCollaboratorActive = true;
+  }
+
+
   private async createSubEntityDataset(subEntityRequest: SubEntityDatasetNewRequest): Promise<boolean> {
     console.log("createSubEntityDataset invoked with arguments: datasetName=" + subEntityRequest.name + ", repeatedMeasures=" + subEntityRequest.repeatedMeasures);
     const response: Result<Error, DatasetModel> = await ExperimentService.createSubEntityDataset(this.activeProgram!.id!, this.experimentUUID, subEntityRequest);
@@ -191,6 +228,7 @@ export default class ExperimentDetails extends ProgramsBase {
     return this.$route.params.experimentId;
   }
 
+  private collaborators: Collaborator[] = [];
   get userName(): string {
     if( !this.experiment.additionalInfo ){return '';}
     if( !this.experiment.additionalInfo.createdBy){return '';}
@@ -249,11 +287,26 @@ export default class ExperimentDetails extends ProgramsBase {
     }
   }
 
+@Watch('$route')
+async getAssignedCollaborators(): Promise<void> {
+  try {
+    const response: Result<Error, Collaborator[]> = await ExperimentService.getAssignedCollaborators(this.activeProgram!.id!, this.experimentUUID);
+    if (response.isErr()) {
+      throw response.value;
+    }
+    this.collaborators = response.value;
+  } catch (err) {
+    // Display error that experiment cannot be loaded
+    this.$emit('show-error-notification', 'Error while trying to load collaborators');
+    throw err;
+  }
+}
+
   // Get metadata for all datasets available in this experiment.
   @Watch('$route')
-  async getDatasetMetadata(): DatasetMetadata[] {
+  async getDatasetMetadata(): Promise<void> {
     try {
-      const response: Result<Error, DatasetMetadata[]> = await ExperimentService.getDatasetMetadata(this.activeProgram!.id!, this.experimentUUID, true);
+      const response: Result<Error, DatasetMetadata[]> = await ExperimentService.getDatasetMetadata(this.activeProgram!.id!, this.experimentUUID);
       if (response.isErr()) {
         throw response.value;
       }

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -33,7 +33,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Experiments & Observations'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/ggmpt318mo0exw2b8qrff5axuamv3sv9.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/7ziyhhnia5i7bdvekawhb2ldyobrecmw.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>


### PR DESCRIPTION
# Description
**Story:** [BI-2226](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2226)

Version 7 of the Experiment and Observations import template was created with the two columns referring to sub-observation units deleted. The UI link to download the template was updated to point to the new version.

# Dependencies
none

# Testing
Go to import Experiments and Observations and click on the button to download the import template. Verify that version 7 is downloaded and that it does not contain columns referencing sub observation units.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2226]: https://breedinginsight.atlassian.net/browse/BI-2226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ