### PR TITLE
BI-2152 - Experimental Collaborator Front-end Permissions

### DIFF
--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -90,10 +90,13 @@
 <!--            <li>
               <a>Germplasm Inventory</a>
             </li>-->
-            <li>
+            <li
+                v-if="$ability.can('access', 'Germplasm')"
+            >
               <router-link
                   v-bind:to="{name: 'germplasm', params: {programId: activeProgram.id}}"
                   :id="germplasmMenuId"
+                  v-if="$ability.can('access', 'Germplasm')"
               >
                 Germplasm
               </router-link>
@@ -105,24 +108,30 @@
                 Experiments & Observations
               </router-link>
             </li>
-            <li>
+            <li
+                v-if="$ability.can('access', 'Ontology')"
+            >
               <router-link
                   v-bind:to="{name: 'ontology', params: {programId: activeProgram.id}}"
                   :id="ontologyMenuId"
+
               >
                 Ontology
               </router-link>
             </li>
-            <li>
+            <li
+                v-if="$ability.can('create', 'Import')"
+            >
               <router-link
                 v-bind:to="{name: 'import'}"
                 :id="importFileMenuId"
-                v-if="$ability.can('create', 'Import')"
               >
                 Import Data
               </router-link>
             </li>
-            <li>
+            <li
+                v-if="$ability.can('access', 'SampleManagement')"
+            >
               <router-link
                   v-bind:to="{name: 'sample-management', params: {programId: activeProgram.id}}"
                   :id="sampleMgmtMenuId"
@@ -138,7 +147,9 @@
               <a>Reports</a>
             </li>
             -->
-            <li>
+            <li
+                v-if="$ability.can('access', 'ProgramAdministration')"
+            >
               <router-link
                 v-bind:to="{name: 'program-administration', params: {programId: activeProgram.id}}"
                 :id="programManagementMenuId"
@@ -151,7 +162,9 @@
                 BrAPI
               </router-link>
             </li>
-            <li>
+            <li
+                v-if="$ability.can('access', 'JobManagement')"
+            >
               <router-link
                   v-bind:to="{name: 'job-management', params: {programId: activeProgram.id}}"
                   :id="jobManagementMenuId"

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -101,7 +101,9 @@
                 Germplasm
               </router-link>
             </li>
-            <li>
+            <li
+                v-if="$ability.can('access', 'Experiment')"
+            >
               <router-link
                   v-bind:to="{name: 'experiments-observations', params: {programId: activeProgram.id}}"
               >
@@ -157,7 +159,9 @@
                 Program Administration
               </router-link>
             </li>
-            <li>
+            <li
+                v-if="$ability.can('access', 'BrAPI')"
+            >
               <router-link v-bind:to="{name: 'brapi-info', params: {programId: activeProgram.id}}" :id="brAPIMenuId">
                 BrAPI
               </router-link>

--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -96,7 +96,6 @@
               <router-link
                   v-bind:to="{name: 'germplasm', params: {programId: activeProgram.id}}"
                   :id="germplasmMenuId"
-                  v-if="$ability.can('access', 'Germplasm')"
               >
                 Germplasm
               </router-link>

--- a/src/config/AppAbility.ts
+++ b/src/config/AppAbility.ts
@@ -19,7 +19,7 @@ import {Ability, AbilityClass} from '@casl/ability';
 
 type Actions = 'manage' | 'create' | 'read' | 'update' | 'delete' | 'archive' | 'access' | 'submit';
 type Subjects = 'ProgramUser' | 'Location' | 'User' | 'AdminSection' | 'Trait' | 'Import' | 'ProgramConfiguration' | 'Submission'
-    | 'Experiment' | 'Germplasm' | 'Ontology' | 'SampleManagement' | 'ProgramAdministration' | 'JobManagement' | 'Collaborator' ;
+    | 'Experiment' | 'Germplasm' | 'Ontology' | 'SampleManagement' | 'ProgramAdministration' | 'JobManagement' | 'Collaborator' | 'BrAPI' ;
 
 export type AppAbility = Ability<[Actions, Subjects]>;
 export const AppAbility = Ability as AbilityClass<AppAbility>;

--- a/src/config/AppAbility.ts
+++ b/src/config/AppAbility.ts
@@ -18,7 +18,8 @@
 import {Ability, AbilityClass} from '@casl/ability';
 
 type Actions = 'manage' | 'create' | 'read' | 'update' | 'delete' | 'archive' | 'access' | 'submit';
-type Subjects = 'ProgramUser' | 'Location' | 'User' | 'AdminSection' | 'Trait' | 'Import' | 'ProgramConfiguration' | 'Submission';
+type Subjects = 'ProgramUser' | 'Location' | 'User' | 'AdminSection' | 'Trait' | 'Import' | 'ProgramConfiguration' | 'Submission'
+    | 'Experiment' | 'Germplasm' | 'Ontology' | 'SampleManagement' | 'ProgramAdministration' | 'JobManagement' | 'Collaborator' ;
 
 export type AppAbility = Ability<[Actions, Subjects]>;
 export const AppAbility = Ability as AbilityClass<AppAbility>;

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -30,10 +30,12 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('access', 'Germplasm');
     can('access', 'ProgramAdministration');
     can('access', 'SampleManagement');
+    can('access', 'BrAPI');
     can('access', 'JobManagement');
   },
   experimentalcollaborator(user, { can }) {
     can('access', 'Experiment');
+    can('access', 'BrAPI');
   },
   programadministrator(user, { can }) {
     can('create', 'ProgramUser');
@@ -54,8 +56,10 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('access', 'Germplasm');
     can('access', 'SampleManagement');
     can('access', 'ProgramAdministration');
+    can('access', 'BrAPI');
     can('access', 'JobManagement');
-    can( 'create', 'Collaborator');
+    can('create', 'Collaborator');
+
   },
   systemadministrator(user, { can }) {
     can('create', 'ProgramUser');
@@ -72,8 +76,9 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('access', 'Germplasm');
     can('access', 'SampleManagement');
     can('access', 'ProgramAdministration');
+    can('access', 'BrAPI');
     can('access', 'JobManagement');
-    can( 'create', 'Collaborator');
+    can('create', 'Collaborator');
 
   }
 };

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -25,6 +25,15 @@ type DefinePermissions = (user: User, builder: AbilityBuilder<AppAbility>) => vo
 
 const rolePermissions: Record<string, DefinePermissions> = {
   readonly(user, { can }) {
+    can('access', 'Experiment');
+    can('access', 'Ontology');
+    can('access', 'Germplasm');
+    can('access', 'ProgramAdministration');
+    can('access', 'SampleManagement');
+    can('access', 'JobManagement');
+  },
+  experimentalcollaborator(user, { can }) {
+    can('access', 'Experiment');
   },
   programadministrator(user, { can }) {
     can('create', 'ProgramUser');
@@ -40,14 +49,32 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('access', 'ProgramConfiguration');
     can('create', 'ProgramConfiguration');
     can('update', 'ProgramConfiguration');
+    can('access', 'Experiment');
+    can('access', 'Ontology');
+    can('access', 'Germplasm');
+    can('access', 'SampleManagement');
+    can('access', 'ProgramAdministration');
+    can('access', 'JobManagement');
+    can( 'create', 'Collaborator');
   },
   systemadministrator(user, { can }) {
     can('create', 'ProgramUser');
     can('update', 'ProgramUser');
     can('archive', 'ProgramUser');
+    can('create', 'Location');
+    can('update', 'Location');
+    can('archive', 'Location');
     can('manage', 'User');
     can('access', 'AdminSection');
     can('submit', 'Submission');
+    can('access', 'Experiment');
+    can('access', 'Ontology');
+    can('access', 'Germplasm');
+    can('access', 'SampleManagement');
+    can('access', 'ProgramAdministration');
+    can('access', 'JobManagement');
+    can( 'create', 'Collaborator');
+
   }
 };
 
@@ -81,7 +108,6 @@ export function defineAbilityFor(user: User | undefined, program: Program | unde
             programRole.program.id === program.id && programRole.domain &&
             programRole.active &&
             typeof rolePermissions[roleFunctionName] === 'function') {
-
             rolePermissions[roleFunctionName](user, builder);
           }
         }

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -201,7 +201,7 @@ export default class ExperimentDetails extends ProgramsBase {
   private actions: ActionMenuItem[] = [
       new ActionMenuItem('experiment-import-file', 'import-file', 'Import file', this.$ability.can('create', 'Import')),
       new ActionMenuItem('experiment-download-file', 'download-file', 'Download file'),
-      new ActionMenuItem('experiment-add-collaborator', 'add-collaborator', 'Add Collaborator'),
+      new ActionMenuItem('experiment-add-collaborator', 'add-collaborator', 'Add Collaborator',  this.$ability.can('create', 'Collaborator')),
       // new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset')
   ];
 


### PR DESCRIPTION
# Description
[BI-2152](https://breedinginsight.atlassian.net/browse/BI-2152) - Experimental Collaborator Front-end Permissions

# Changes made
**Hide all menu items except for home, experiments and observations, BrAPI**
1.  Added _subjects_ to `AppAbility.ts` to correspond to options in the side-bar menu.
2. In `ability.ts` add role permission list for _experimentalcollaborator_,  also mad the roll permission list explicit for _readonly_.

**Restrict Manage Experiments menu**
1. added `can('create', 'Collaborator');` to _programadministrator_ and _systemadministrator_ in `ability.ts`.
2. Modified the _ActionMenuItem_ in `ExperimentDetails.vue` to include `this.$ability.can('create',
'Collaborator')`.

# Dependencies
bi-api: **develop** branch

# Testing

1. Log in as an _Experimental Collaborator_ with at least on experiment assigned.

**Expected result**
The Side-bar Menu should have only three options:
- Home,
- Experiments & Observatins
- BrAPI

2. Go to a valid experiment.
3. Click on the **Manage Experiment** pull down.

**Expected result**

- Only the _Download file_ option should be available (the other options should be grayed-out.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2152]: https://breedinginsight.atlassian.net/browse/BI-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ