### PR TITLE
BI-2304 - Support Duplicate Germplasm in Lists Referencing Existing Germplasm

### DIFF
--- a/src/breeding-insight/utils/GermplasmUtils.ts
+++ b/src/breeding-insight/utils/GermplasmUtils.ts
@@ -48,8 +48,7 @@ export class GermplasmUtils {
 
     static getEntryNumber(germplasm: Germplasm, referenceId: string | undefined): string | undefined {
         if (germplasm.additionalInfo) {
-            return referenceId ? germplasm.additionalInfo.listEntryNumbers[<any>referenceId] :
-                germplasm.additionalInfo.importEntryNumber;
+            return germplasm.additionalInfo.importEntryNumber;
         }
         return "";
     }


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2304

Since the `listEntryNumbers` additionalInfo key was removed in the back end change, I updated the front end to rely on `importEntryNumber` alone for display.

bi-api PR: https://github.com/Breeding-Insight/bi-api/pull/401
BrAPI-Java-TestServer PR: https://github.com/Breeding-Insight/brapi-Java-TestServer/pull/35

# Dependencies
bi-api branch: [feature/BI-2304](https://github.com/Breeding-Insight/bi-api/tree/feature/BI-2304)
BrAPI-Java-TestServer branch: [feature/BI-2304](https://github.com/Breeding-Insight/brapi-Java-TestServer/tree/feature/BI-2304)

# Testing
See testing section [in the bi-api PR](https://github.com/Breeding-Insight/bi-api/pull/401).


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
