### PR TITLE
[BI-2129] - Accessibility: Germplasm Table Fixes

### DIFF
--- a/src/components/germplasm/GermplasmLink.vue
+++ b/src/components/germplasm/GermplasmLink.vue
@@ -16,10 +16,10 @@
   -->
 
 <template>
-    <router-link v-if="this.germplasmUUID" v-bind:to="{name: 'germplasm-details', params: {programId: activeProgram.id, germplasmId: this.germplasmUUID}}">
+    <router-link v-if="this.germplasmUUID && this.germplasmUUID!=''" v-bind:to="{name: 'germplasm-details', params: {programId: activeProgram.id, germplasmId: this.germplasmUUID}}">
       {{ this.germplasmGID }}
     </router-link>
-    <router-link v-else v-bind:to="{name: 'germplasm-details', params: {programId: activeProgram.id, germplasmId: 'gid-'+this.germplasmGID}}">
+    <router-link v-else-if="this.germplasmGID && this.germplasmGID!=''" v-bind:to="{name: 'germplasm-details', params: {programId: activeProgram.id, germplasmId: 'gid-'+this.germplasmGID}}">
       {{ this.germplasmGID }}
     </router-link>
 </template>
@@ -43,7 +43,6 @@ export default class GermplasmLink extends Vue {
   private germplasmUUID!: String;
   @Prop()
   private germplasmGID!: String;
-
 }
 
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-2129 - Accessibility: Germplasm Table Fixes](https://breedinginsight.atlassian.net/browse/BI-2129)

Modified logic in GermplasmLink.vue to ensure that when there is only an empty string for germplasm GID no link is added (since an empty string is unfortunately truthy in vue if statements).

No changes were made for the second condition of the card as WAVE and SiteImprove are no longer detecting duplicate IDs on the Germplasm View Table.

# Dependencies
n/a

# Testing
Upload germplasm file that includes germplasm with both parents, germplasm with female parent only, germplasm with no parents, and germplasm

Tabbing test:
Navigate through the germplasm table by repeatedly clicking tab. Tab should only focus on links in the table with a valid GID and should skip over cells with no value.

Screen reader test: 
Use a screen reader while on germplasm table page, it should not read out links for empty cells in the table.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
