### PR TITLE
BI-1933 - Erroneous message: No germplasm are currently defined for this program 

### DIFF
--- a/src/components/admin/AdminProgramsTable.vue
+++ b/src/components/admin/AdminProgramsTable.vue
@@ -311,7 +311,6 @@ export default class AdminProgramsTable extends Vue {
   }
 
   mounted() {
-    this.updatePagination();
     this.getSpecies();
     this.paginationChanged();
   }
@@ -333,7 +332,7 @@ export default class AdminProgramsTable extends Vue {
 
   @Watch('paginationController', { deep: true})
   paginationChanged() {
-    let currentCall = this.paginationController.currentCall
+    let currentCall = this.paginationController.currentCall;
     let paginationQuery = this.paginationController.getPaginationSelections();
     if(currentCall && currentCall!.page == paginationQuery.page && currentCall!.pageSize == paginationQuery.pageSize && currentCall!.showAll == paginationQuery.showAll) {
       return;

--- a/src/components/admin/AdminProgramsTable.vue
+++ b/src/components/admin/AdminProgramsTable.vue
@@ -312,8 +312,8 @@ export default class AdminProgramsTable extends Vue {
 
   mounted() {
     this.updatePagination();
-    this.getPrograms();
     this.getSpecies();
+    this.paginationChanged();
   }
 
   setSort(field: string, order: string) {
@@ -348,6 +348,7 @@ export default class AdminProgramsTable extends Vue {
   }
 
   getPrograms() {
+    this.programsLoading = true;
     ProgramService.getAll(this.paginationController.currentCall, this.programSort).then(([programs, metadata]) => {
 
       // Check that our most recent query is this one

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -296,7 +296,6 @@ export default class AdminUsersTable extends Vue {
 
   mounted() {
     this.getRoles();
-    this.updatePagination();
     this.paginationChanged();
   }
 

--- a/src/components/admin/AdminUsersTable.vue
+++ b/src/components/admin/AdminUsersTable.vue
@@ -297,7 +297,7 @@ export default class AdminUsersTable extends Vue {
   mounted() {
     this.getRoles();
     this.updatePagination();
-    this.getUsers();
+    this.paginationChanged();
   }
 
     setSort(field: string, order: string) {
@@ -344,6 +344,7 @@ export default class AdminUsersTable extends Vue {
   }
 
   getUsers() {
+    this.usersLoading = true;
     UserService.getAll(this.paginationController.currentCall, this.systemUserSort).then(([users, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.users = users;

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -154,6 +154,7 @@ export default class ExperimentsObservationsTable extends Vue {
     ));
 
     this.paginationController.pageSize = 20;
+    this.paginationChanged();
   }
 
   @Watch('paginationController', { deep: true})
@@ -174,6 +175,7 @@ export default class ExperimentsObservationsTable extends Vue {
 
   @Watch('filters', {deep: true})
   async getExperiments() {
+    this.experimentsLoading = true;
     try {
       const {call, callId} = this.experimentCallStack.makeCall(this.filters);
 

--- a/src/components/germplasm/GermplasmListsTable.vue
+++ b/src/components/germplasm/GermplasmListsTable.vue
@@ -162,7 +162,7 @@ export default class GermplasmListsTable extends Vue {
         this.germplasmListSort,
         this.paginationController
     ));
-    this.getGermplasmLists();
+    this.paginationChanged();
   }
 
   @Watch('paginationController', { deep: true})
@@ -183,6 +183,7 @@ export default class GermplasmListsTable extends Vue {
 
   @Watch('filters', {deep: true})
   async getGermplasmLists() {
+    this.germplasmListsLoading = true;
     try {
       const {call, callId} = this.germplasmListCallStack.makeCall(this.filters);
       const response = await call;

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -175,6 +175,9 @@ export default class GermplasmTable extends Vue {
 
   @Watch('filters', {deep: true})
   async getGermplasm() {
+    // Set loading = true so the table shows a loading indicator rather than an "empty" message.
+    this.germplasmLoading = true;
+
     try {
       // Only process the most recent call
       const {call, callId} = this.germplasmCallStack.makeCall(this.filters);

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -155,8 +155,6 @@ export default class GermplasmTable extends Vue {
         this.germplasmSort,
         this.paginationController
     ));
-
-    this.getGermplasm();
   }
 
   @Watch('paginationController', { deep: true})

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -155,6 +155,7 @@ export default class GermplasmTable extends Vue {
         this.germplasmSort,
         this.paginationController
     ));
+    this.paginationChanged();
   }
 
   @Watch('paginationController', { deep: true})

--- a/src/components/ontology/OntologyTable.vue
+++ b/src/components/ontology/OntologyTable.vue
@@ -339,6 +339,7 @@ export default class OntologyTable extends Vue {
   ontologySort!: OntologySort;
 
   mounted() {
+    this.paginationController.pageSize = 200;
     this.getSubscribedOntology();
     this.getObservationLevels();
     this.getAttributesEntitiesDescriptions();
@@ -349,7 +350,7 @@ export default class OntologyTable extends Vue {
         this.paginationController
     ));
     this.registerSidePanelEventHandlers();
-    this.getTraits();
+    this.paginationChanged();
   }
 
   @Watch('paginationController', { deep: true})

--- a/src/components/program/ProgramLocationsTable.vue
+++ b/src/components/program/ProgramLocationsTable.vue
@@ -193,7 +193,6 @@ export default class ProgramLocationsTable extends Vue {
   }
 
   mounted() {
-    this.updatePagination();
     this.paginationChanged();
   }
 

--- a/src/components/program/ProgramLocationsTable.vue
+++ b/src/components/program/ProgramLocationsTable.vue
@@ -194,7 +194,7 @@ export default class ProgramLocationsTable extends Vue {
 
   mounted() {
     this.updatePagination();
-    this.getLocations();
+    this.paginationChanged();
   }
 
   setSort(field: string, order: string) {
@@ -222,6 +222,7 @@ export default class ProgramLocationsTable extends Vue {
   }
 
   getLocations() {
+    this.locationsLoading = true;
     ProgramLocationService.getAll(this.activeProgram!.id!, this.paginationController.currentCall, this.locationSort).then(([programLocations, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.locations = programLocations;

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -251,7 +251,6 @@ export default class ProgramUsersTable extends Vue {
   }
 
   mounted() {
-    this.updatePagination();
     this.getRoles();
     this.getSystemUsers();
     this.paginationChanged();

--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -253,8 +253,8 @@ export default class ProgramUsersTable extends Vue {
   mounted() {
     this.updatePagination();
     this.getRoles();
-    this.getUsers();
     this.getSystemUsers();
+    this.paginationChanged();
   }
 
   setSort(field: string, order: string) {
@@ -286,6 +286,7 @@ export default class ProgramUsersTable extends Vue {
   }
 
   getUsers() {
+    this.usersLoading = true;
     ProgramUserService.getAll(this.activeProgram!.id!, this.paginationController.currentCall, this.programUserSort).then(([programUsers, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.users = programUsers;

--- a/src/components/tables/expandableTable/ExpandableTable.vue
+++ b/src/components/tables/expandableTable/ExpandableTable.vue
@@ -74,7 +74,7 @@
         </a>
       </b-table-column>
 
-      <template v-slot:empty v-if="this.loading !== true">
+      <template v-slot:empty v-if="!loading">
         <slot name="emptyMessage" />
       </template>
 

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -270,7 +270,6 @@ export default class TraitsImportTable extends Vue {
 
   @Watch('importPreviewOntologySort', {deep: true})
   getTraitUpload() {
-    this.loaded = false;
     TraitUploadService.getTraits(this.activeProgram!.id!, this.paginationController.currentCall, this.importPreviewOntologySort).then(([upload, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = upload.data || [];

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -250,7 +250,7 @@ export default class TraitsImportTable extends Vue {
 
   mounted() {
     this.updatePagination();
-    this.getTraitUpload();
+    this.paginationChanged();
   }
 
   @Watch('paginationController', { deep: true})
@@ -271,6 +271,7 @@ export default class TraitsImportTable extends Vue {
 
   @Watch('importPreviewOntologySort', {deep: true})
   getTraitUpload() {
+    this.loaded = false;
     TraitUploadService.getTraits(this.activeProgram!.id!, this.paginationController.currentCall, this.importPreviewOntologySort).then(([upload, metadata]) => {
       if (this.paginationController.matchesCurrentRequest(metadata.pagination)){
         this.traits = upload.data || [];

--- a/src/components/trait/TraitsImportTable.vue
+++ b/src/components/trait/TraitsImportTable.vue
@@ -249,7 +249,6 @@ export default class TraitsImportTable extends Vue {
   private fullNameSortLabel: string = OntologySortField.FullName;
 
   mounted() {
-    this.updatePagination();
     this.paginationChanged();
   }
 


### PR DESCRIPTION
# Description
**Story:** [BI-1933](https://breedinginsight.atlassian.net/browse/BI-1933)

A common pattern in bi-web is to have a get{Entities} method for the data in a table view that is called within the `mounted()` method of the component, while also having a `paginationChanged` method with a `@Watch` annotation reference an `PaginationController` that can also call get{Entities}. In some (but not all) cases, the `PaginationController` instance is mutated in the `mounted()` method. This resulted in the get{Entities} method being called twice on initial page load, and (maybe) because of the way Vue handles reactivity, the "empty" table message would sometimes flash on screen. The larger issue though was that the duplicate calls were unnecessary, and since `paginationChanged` already has short-circuiting logic built in to ensure get{Entities} is called only when the request parameters are changed, a good solution was to remove the call to get{Entities} in `mounted()` and directly call `paginationChanged` instead.

Additionally, some components were calling `updatePagination()` from `mounted()`, which is also called *when needed* by `paginationChanged()`, so I removed those calls from `mounted()`.


# Testing
1. Import a large germplasm file (1000+ records) and ensure the "No germplasm are currently defined for this program." message does not flash on screen while the germplasm are loading into the table view. Note that this is hard to reproduce even when present, I recommend focusing on steps 2. and 3. instead.
2. Ensure all tables load data.
3. In the dev tools network tab, ensure duplicate (identical) calls are not being made on initial page load.
These are the affected table components and URL paths where they can be tested:

| File                             | Route                                                     |
|----------------------------------|-----------------------------------------------------------|
| AdminProgramsTable.vue           | /admin/programs                                           |
| AdminUsersTable.vue              | /admin/users                                              |
| ExperimentsObservationsTable.vue | /programs/{programId}/experiments-observations            |
| GermplasmListsTable.vue          | /programs/{programId}/germplasm/germplasm-lists           |
| GermplasmTable.vue               | /programs/{programId}/germplasm/germplasm-all             |
| OntologyTable.vue                | /programs/{programId}/ontology/[active \| archived]-terms |
| ProgramLocationsTable.vue        | /programs/{programId}/program-administration/locations    |
| ProgramUsersTable.vue            | /programs/{programId}/program-administration/users        |
| TraitsImportTable.vue*           | /programs/{programId}/import/ontology                     |

*To test the TraitsImportTable component, import ontology and make sure the preview displays correctly.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-1933]: https://breedinginsight.atlassian.net/browse/BI-1933