### PR TITLE
BI-2123 Jobs table sizing is wonky & hiding the "details" option

### DIFF
--- a/src/views/program/JobManagement.vue
+++ b/src/views/program/JobManagement.vue
@@ -55,9 +55,6 @@
       <b-table-column field="data.updatedAt" label="Last Updated" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         {{ formatDate(props.row.data.updatedAt) }}
       </b-table-column>
-      <b-table-column field="data.statusMessage" label="Status Message" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" :width="50">
-        <span class="truncated">{{ props.row.data.statusMessage }}</span>
-      </b-table-column>
 
       <template v-slot:detail="{row}">
         <div class="column" v-if="row.jobDetail.jobType === 'IMPORT'">


### PR DESCRIPTION
# Description
**Story:** [BI-2123](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2123)

The bugfix card described an issue where the right-most column on the Jobs table, containing the "Details" link, was inaccessible as it was running outside the available viewport for a laptop running the Brave browser. This behavior was not reproducible at the time that this story was worked on; however, it was noticed that the text in the "Status Message" column was getting cut off because the row height is not sufficient to display the full message. It was decided to remove the Status Message column to provide ample space for the Details column as a safeguard and to remove a redundant cut-off message that is available to read in full by clicking on the Details link.

# Dependencies
bi-api release/1.0

# Testing
Open a program containing a listing of prior jobs and confirm that the status message is gone, that the Details column is visible, and that clicking Details reveals the full status message.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2123]: https://breedinginsight.atlassian.net/browse/BI-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ