### PR TITLE
BI-2334 Wonky Colors - Exp preview

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -1084,5 +1084,9 @@ label.environment-option-label {
   }
 }
 
+article.message.is-success *:not(button) {
+  color: mix(black, $success, 70%);
+}
+
 
 


### PR DESCRIPTION
# Description
**Story:** [BI-2334](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2334)

The exp summary preview statistics text was darkened black.



# Dependencies
none

# Testing
Create or append an experiment and confirm that the blackish text in the green preview table box is pleasing to the eye.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2334]: https://breedinginsight.atlassian.net/browse/BI-2334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ