### PR TITLE
[BI-2328]  Experimental observation file import removes periods from column headers

### DIFF
--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -178,7 +178,7 @@ export default class TraitsImport extends ProgramsBase {
   private showAbortModal = false;
 
   private yesAbortId: string = "traitsimport-yes-abort";
-  private templateUrl: string = "https://cornell.box.com/shared/static/2erlubbeobuv1tochwkbuq5jghdayuei.xls";
+  private templateUrl: string = "https://cornell.box.com/shared/static/wjfe2ptpqnl9lyqdg1sf6hn2jiz1d7n1.xls";
 
   private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
 


### PR DESCRIPTION
# Description
[BI-2328](https://breedinginsight.atlassian.net/browse/BI-2328) Experimental observation file import removes periods from column headers

Change the link for the Ontology Import template to point to the new version (with "No periods are allowed" added to the `name` discription)



# Dependencies
bi-api : **bug/BI-2328_fix**

# Testing
insure that the ontology template button retrieves `bi_ontology_template_v15_2024-10-09`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2328]: https://breedinginsight.atlassian.net/browse/BI-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ