### PR TITLE
 [BI-2355] - Non-informative error message: regression

### DIFF
--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -178,7 +178,7 @@ export default class TraitsImport extends ProgramsBase {
   private showAbortModal = false;
 
   private yesAbortId: string = "traitsimport-yes-abort";
-  private templateUrl: string = "https://cornell.box.com/shared/static/wjfe2ptpqnl9lyqdg1sf6hn2jiz1d7n1.xls";
+  private templateUrl: string = "https://cornell.box.com/shared/static/rxmj35d0wracg15ubemrshizdytmn731.xls";
 
   private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
 


### PR DESCRIPTION
# Description
**Story:** [BI-2355 - Non-informative error message: regression](https://breedinginsight.atlassian.net/browse/BI-2355)

This error was due to tablesaw processing brackets weirdly, resulting in the column name stored in data not matching the column name stored in dynamic column names.

This part of the fix links to a new ontology import template that clarifies that brackets are invalid for ontology term name.

# Dependencies
bi-api: [bug/BI-2355.2](https://github.com/Breeding-Insight/bi-api/pull/423)

# Testing
Download ontology import template and ensure it mentions that brackets along with periods are invalid for ontology term name.


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
