### PR TITLE
BI-2364 Downloaded ontology file had 'units' added to trait with scale class text.

### DIFF
--- a/src/components/trait/forms/BaseTraitForm.vue
+++ b/src/components/trait/forms/BaseTraitForm.vue
@@ -494,7 +494,6 @@ export default class BaseTraitForm extends Vue {
       }
 
       this.trait.scale.dataType = value;
-      this.trait!.scale!.units = value;
 
     } else if (Scale.dataTypeEquals(value, DataType.Ordinal) && Scale.dataTypeEquals(this.lastCategoryType, DataType.Nominal)) {
       //Nominal to Ordinal
@@ -512,27 +511,16 @@ export default class BaseTraitForm extends Vue {
         this.restoreMinCategories(2);
       }
       this.trait.scale.dataType = value;
-      this.trait!.scale!.units = value;
 
     //Scale history
     } else if (this.scaleHistory[value.toLowerCase()]) {
       this.trait.scale = this.scaleHistory[value.toLowerCase()];
       this.trait.scale.dataType = value;
 
-      if (!Scale.dataTypeEquals(value, DataType.Numerical)) {
-        this.trait!.scale!.units = value;
-      }
     } else {
       // No history
       this.trait.scale = new Scale();
       this.trait.scale.dataType = value;
-
-      // Allow for units in the numerical and duration traits
-      if (Scale.dataTypeEquals(value, DataType.Numerical)) {
-        this.trait!.scale!.units = undefined;
-      } else {
-        this.trait!.scale!.units = value;
-      }
 
       //Establish minimal categories for ordinal and nominal
       if (Scale.dataTypeEquals(value, DataType.Nominal) || Scale.dataTypeEquals(value, DataType.Ordinal)) {


### PR DESCRIPTION
# Description
[BI-2364](https://breedinginsight.atlassian.net/browse/BI-2364) Downloaded ontology file had 'units' added to trait with scale class text.

Deleted lines in the setScaleClass(value: string) method, that set `units` to `value`. (`value` will be one of the following strings "Date", "Nominal", "Numerical", "Ordinal",or  "Text")


# Dependencies
None.

# Testing
WHEN user is on the Ontology List screen,
AND selects the 'Show details' link of an existing ontology,
AND select the 'Edit' link,
AND changes the `Scale` `Class` to anything besides "Numerical",
AND selects 'Save'.
WHEN user selects the 'Manage Ontology' pull-down,
AND selects 'Download File'.
THEN the row associated with the edited ontology should have a <blank> value in the `Units` column.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_


[BI-2364]: https://breedinginsight.atlassian.net/browse/BI-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ