### PR TITLE
BI-2363 Plate details & submission details disappear when status is manually updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bi-web",
-  "version": "v0.10.0+723",
+  "version": "v1.0.0+783",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bi-web",
-      "version": "v0.10.0+723",
+      "version": "v1.0.0+783",
       "hasInstallScript": true,
       "dependencies": {
         "@casl/ability": "~4.0.0",

--- a/src/views/sample-mgmt/SubmissionDetails.vue
+++ b/src/views/sample-mgmt/SubmissionDetails.vue
@@ -622,6 +622,7 @@ export default class SubmissionDetails extends ProgramsBase {
         throw response.value;
       }
       await this.getSubmission(false);
+      await this.getSubmissionDetails();
     } catch (e) {
       this.$emit('show-error-notification', 'Error while trying to update status');
     } finally {

--- a/src/views/sample-mgmt/SubmissionDetails.vue
+++ b/src/views/sample-mgmt/SubmissionDetails.vue
@@ -579,6 +579,7 @@ export default class SubmissionDetails extends ProgramsBase {
       // let orderResponse = response.value;
       // this.submission!.vendorOrderId = orderResponse.orderId;
       await this.getSubmission(false);
+      await this.getSubmissionDetails();
     } catch (e) {
       // this.$emit('show-error-notification', 'Error while trying to submit sample order');
       this.submissionError = e;
@@ -595,6 +596,7 @@ export default class SubmissionDetails extends ProgramsBase {
         throw response.value;
       }
       await this.getSubmission(false);
+      await this.getSubmissionDetails();
     } catch (e) {
       this.$emit('show-error-notification', 'Error while trying to check order status');
     } finally {


### PR DESCRIPTION
# Description
**Story:** [BI-2363](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/34?selectedIssue=BI-2363)

The plate details are fetched after manually updating the status to fix a bug where the data is cleared after updating.

# Dependencies
none

# Testing
Import some samples and go to view the sample details table in the Deltabreed UI. Select the "Mange Submission" button and choose "Manually Update Status". Change the status and save. Verify that the data is still visible for the "Plate Details" and "Submission Details" tabs.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2363]: https://breedinginsight.atlassian.net/browse/BI-2363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ