### PR TITLE
[BI-2342] Experimental filtering is case specific

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -387,7 +387,9 @@ export default class Dataset extends ProgramsBase {
 
   filterByObservations(index: number, propsRow: any, input: string) {
     let obsValue = propsRow.data.traitValues[index];
-    obsValue = obsValue ? obsValue : "";  //convert null or undefined to an empty string
+    //Make case insensitive
+    obsValue = obsValue ? obsValue.toUpperCase() : "";  //convert null or undefined to an empty string;
+    input = input.toUpperCase();
     return obsValue.includes(input);
   }
 


### PR DESCRIPTION
# Description
[BI-2342](https://breedinginsight.atlassian.net/browse/BI-2342) Experimental filtering is case specific

Made the custom search of observations (filterByObservations) case insensitive

# Testing
see [Acceptance Criteria](https://breedinginsight.atlassian.net/browse/BI-2342) in story

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2342]: https://breedinginsight.atlassian.net/browse/BI-2342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ