### PR TITLE
[BI-2343] - GID filtering not informative

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -99,6 +99,7 @@
             sortable
             searchable
             :th-attrs="() => ({scope:'col'})"
+            :custom-search="(props, filterString) => exactSearchGID(props, filterString)"
         >
           {{ props.row.data.gid }}
         </b-table-column>
@@ -403,6 +404,12 @@ export default class Dataset extends ProgramsBase {
     } else {
       return second.localeCompare(first);
     }
+  }
+
+  //Filter GIDs by exact match
+  exactSearchGID(props: any, input: string) {
+    let value = props.data.gid;
+    return Number(value) === (Number(input));
   }
 
   //sort GIDs numerically

--- a/src/views/sample-mgmt/SubmissionDetails.vue
+++ b/src/views/sample-mgmt/SubmissionDetails.vue
@@ -154,7 +154,8 @@
               {{ props.row.data.additionalInfo.germplasmName || props.row.data.sampleName }}
             </b-table-column>
             <b-table-column field="data.additionalInfo.gid" label="GID" v-slot="props" searchable
-                            :th-attrs="(column) => ({scope:'col'})">
+                            :th-attrs="(column) => ({scope:'col'})"
+                            :custom-search="(props, filterString) => exactSearchGID(props, filterString)">
               <GermplasmLink
                   v-bind:germplasmGID="props.row.data.additionalInfo.gid"
               />
@@ -706,6 +707,12 @@ export default class SubmissionDetails extends ProgramsBase {
     } else {
       return b.data.plateName.localeCompare(a.data.plateName, undefined, {numeric: true, sensitivity: 'base'});
     }
+  }
+
+  //Filter GIDs by exact match
+  exactSearchGID(props: any, input: string) {
+    let value = props.data.additionalInfo.gid;
+    return Number(value) === (Number(input));
   }
 }
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-2343 - GID filtering not informative](https://breedinginsight.atlassian.net/browse/BI-2343)

Changes to enable exact match GID filtering for multiple tables

For Experiment Details and Sample Submission Details tables, frontend search is used, so a custom-search function was added in the respective buefy files to do exact search filtering in the GID case.

For Germplasm and Germplasm list tables, backend search is used, which presently only does partial matching. Due to the high risk associated with modifying backend search to alternatively enable exact or partial match for each filter, ResponseUtils:search was slightly modified to do an exact match specifically when the filter is accessionNumber.

# Dependencies
[bi-api: bug/BI-2343](https://github.com/Breeding-Insight/bi-api/pull/435)

# Testing
On the following table components:
- All Germplasm
- Germplasm List Details
- Experiment Details
- Sample Submission Details

Enter multiple different values into GID to ensure that the results are filtered by exact match
Enter values into GID and other columns to ensure that results are correctly filtered by multiple columns
Check that pagination is still working correctly with GID filtering by filtering by a value that exists through multiple pages

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/11936407481)
- [X] I have run SiteImprove on pages impacted by changes 
