### PR TITLE
BI-2426 -  Disable Sub-Entity Features for v1.1 Release

### DIFF
--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -205,7 +205,7 @@ export default class ExperimentDetails extends ProgramsBase {
       new ActionMenuItem('experiment-import-file', 'import-file', 'Import file', this.$ability.can('create', 'Import')),
       new ActionMenuItem('experiment-download-file', 'download-file', 'Download file'),
       new ActionMenuItem('experiment-add-collaborator', 'add-collaborator', 'Add Collaborator',  this.$ability.can('manage', 'Collaborator')),
-      new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset')
+      // new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset')
   ];
 
   mounted () {


### PR DESCRIPTION
# Description
**Story:** [BI-2426](https://breedinginsight.atlassian.net/browse/BI-2426)

Sub-entity features will not be included in the v1.1 release.

This PR hides the sub-entity option in the dropdown menu.


[BI-2426]: https://breedinginsight.atlassian.net/browse/BI-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ