### PR TITLE
BI-2437 Program name search (under Sys Admin) not working properly

### DIFF
--- a/src/components/layouts/UserSideBarLayout.vue
+++ b/src/components/layouts/UserSideBarLayout.vue
@@ -294,7 +294,8 @@
     }
 
     filterPrograms($event: any) {
-      let filter = $event.target.value.toLowerCase();
+      this.programFilterValue = $event.target.value;
+      let filter = this.programFilterValue.toLowerCase();
       if(filter.trim().length > 0) {
         this.filteredPrograms = this.programs.filter(value => value.name!.toLowerCase().includes(filter));
       } else {


### PR DESCRIPTION
# Description
[BI-2437](https://breedinginsight.atlassian.net/browse/BI-2437) Program name search (under Sys Admin) not working properly

The value of the Program Name field was not being updated

# Testing
_see story_

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 
