### PR TITLE
[BI-2449] - Correct Exp Preview Summary Stats

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -29,17 +29,9 @@
         <div class="message-body has-text-dark">
           <div class="columns">
             <div class="column">
-              <div class="columns mb-0">
-                <div class="column has-text-right pr-0 pb-0">
-                  <b>Observation unit:</b>
-                </div>
-                <div class="column pl-1 is-three-quarters pb-0">
-                  {{ observationUnit }}
-                </div>
-              </div>
               <div class="columns mb-0 pb-0 pt-0">
                 <div class="column has-text-right pr-0 pb-0">
-                  <b>Phenotypes:</b>
+                  <b>Observation Variables:</b>
                 </div>
                 <div class="column pl-1 is-three-quarters pb-0">
                   {{ phenotypesCount }}
@@ -51,22 +43,6 @@
                 </div>
                 <div class="column pl-1 is-three-quarters pb-0">
                   {{ totalObservationsCount }}
-                </div>
-              </div>
-              <div class="columns mb-0 pb-0 pt-0">
-                <div class="column has-text-right pr-0 pb-0">
-                  <b>Observations with data:</b>
-                </div>
-                <div class="column pl-1 is-three-quarters pb-0">
-                  {{ observationsWithData }}
-                </div>
-              </div>
-              <div class="columns mb-0 pb-0 pt-0">
-                <div class="column has-text-right pr-0 pb-0">
-                  <b>Observations without data:</b>
-                </div>
-                <div class="column pl-1 is-three-quarters pb-0">
-                  {{ observationsWithoutData }}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# Description
**Story:** [BI-2449 - Correct Exp Preview Summary Stats](https://breedinginsight.atlassian.net/browse/BI-2449)

Renaming and removing some of the experimental summary preview stats.

# Dependencies
bi-api: develop

# Testing
- Go to experiment details
- Ensure that the "Observation Unit", "Observations with Data", and  "Observations without Data" items are no longer present in the summary stats
- Ensure that the items "Observations" and "Observation Variables" are present and have the correct values

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/13137146271)
- [X] I have run SiteImprove on pages impacted by changes 
