### PR TITLE
BI-2496 When Deleting an Experiment: "Success" message appears even if delete fails.

### DIFF
--- a/src/breeding-insight/dao/ExperimentDAO.ts
+++ b/src/breeding-insight/dao/ExperimentDAO.ts
@@ -110,6 +110,7 @@ export class ExperimentDAO {
 
 
     static async deleteExperiment(programId: string, experimentId: string, softDelete: boolean): Promise<Result<Error, boolean>> {
+          console.info("....deleteExperiment()....");
         const config: any = {};
         config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}`;
         config.method = 'delete';
@@ -127,7 +128,6 @@ export class ExperimentDAO {
                 throw new Error(`Unexpected status code: ${response.status}`);
             }
         } catch (error) {
-            console.info("F");
             return ResultGenerator.err(error);
         }
     }

--- a/src/breeding-insight/dao/ExperimentDAO.ts
+++ b/src/breeding-insight/dao/ExperimentDAO.ts
@@ -110,7 +110,6 @@ export class ExperimentDAO {
 
 
     static async deleteExperiment(programId: string, experimentId: string, softDelete: boolean): Promise<Result<Error, boolean>> {
-          console.info("....deleteExperiment()....");
         const config: any = {};
         config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}`;
         config.method = 'delete';

--- a/src/breeding-insight/service/ExperimentService.ts
+++ b/src/breeding-insight/service/ExperimentService.ts
@@ -23,6 +23,7 @@ import {DatasetMetadata} from "@/breeding-insight/model/DatasetMetadata";
 import {SubEntityDatasetNewRequest} from "@/breeding-insight/model/SubEntityDatasetNewRequest";
 import {BrAPIUtils} from "@/breeding-insight/utils/BrAPIUtils";
 import {Collaborator} from "@/breeding-insight/model/Collaborator";
+import {BiResponse} from "@/breeding-insight/model/BiResponse";
 
 export class ExperimentService {
 
@@ -105,6 +106,11 @@ export class ExperimentService {
         if (!programId) {
             return ResultGenerator.err(new Error('Missing or invalid program id'));
         }
-        return await ExperimentDAO.deleteExperiment(programId, experimentId, hasObsUnits);
+        let response: Result<Error, boolean>;
+        response = await ExperimentDAO.deleteExperiment(programId, experimentId, hasObsUnits);
+        if(response.isErr()) { console.info('ERRRRROR');}
+        else (console.info('Noooo Errrror'));
+        if(response.isErr()) throw response.value;
+        return response;
     }
 }

--- a/src/breeding-insight/service/ExperimentService.ts
+++ b/src/breeding-insight/service/ExperimentService.ts
@@ -23,7 +23,6 @@ import {DatasetMetadata} from "@/breeding-insight/model/DatasetMetadata";
 import {SubEntityDatasetNewRequest} from "@/breeding-insight/model/SubEntityDatasetNewRequest";
 import {BrAPIUtils} from "@/breeding-insight/utils/BrAPIUtils";
 import {Collaborator} from "@/breeding-insight/model/Collaborator";
-import {BiResponse} from "@/breeding-insight/model/BiResponse";
 
 export class ExperimentService {
 
@@ -108,8 +107,6 @@ export class ExperimentService {
         }
         let response: Result<Error, boolean>;
         response = await ExperimentDAO.deleteExperiment(programId, experimentId, hasObsUnits);
-        if(response.isErr()) { console.info('ERRRRROR');}
-        else (console.info('Noooo Errrror'));
         if(response.isErr()) throw response.value;
         return response;
     }

--- a/src/components/experiments/ExperimentDeleteModal.vue
+++ b/src/components/experiments/ExperimentDeleteModal.vue
@@ -41,6 +41,7 @@ import {AlertTriangleIcon} from 'vue-feather-icons';
 import {Trial} from "@/breeding-insight/model/Trial";
 import ConfirmationModal from "@/components/modals/ConfirmationModal.vue";
 import {ExperimentService} from "@/breeding-insight/service/ExperimentService";
+import {ResultGenerator} from "@/breeding-insight/model/Result";
 
 @Component({
   mixins: [validationMixin],
@@ -78,6 +79,7 @@ export default class ExperimentDeleteModal extends Vue {
             this.trialId,
             hasObsUnits,
         );
+
         // now switch screen to the list of remaining experiments
         this.$router.push({
           name: 'experiments-observations',
@@ -85,7 +87,7 @@ export default class ExperimentDeleteModal extends Vue {
             programId: this.activeProgram!.id!
           },
         });
-        this.$emit('show-success-notification', `Success! The experiment has been deleted.`);
+        this.$emit('show-success-notification', `Success!! The experiment has been deleted.`);
 
       } catch (error) {
         // Handle any errors that might occur during the async operation

--- a/src/components/experiments/ExperimentDeleteModal.vue
+++ b/src/components/experiments/ExperimentDeleteModal.vue
@@ -41,7 +41,6 @@ import {AlertTriangleIcon} from 'vue-feather-icons';
 import {Trial} from "@/breeding-insight/model/Trial";
 import ConfirmationModal from "@/components/modals/ConfirmationModal.vue";
 import {ExperimentService} from "@/breeding-insight/service/ExperimentService";
-import {ResultGenerator} from "@/breeding-insight/model/Result";
 
 @Component({
   mixins: [validationMixin],
@@ -79,7 +78,6 @@ export default class ExperimentDeleteModal extends Vue {
             this.trialId,
             hasObsUnits,
         );
-
         // now switch screen to the list of remaining experiments
         this.$router.push({
           name: 'experiments-observations',
@@ -87,7 +85,7 @@ export default class ExperimentDeleteModal extends Vue {
             programId: this.activeProgram!.id!
           },
         });
-        this.$emit('show-success-notification', `Success!! The experiment has been deleted.`);
+        this.$emit('show-success-notification', `Success! The experiment has been deleted.`);
 
       } catch (error) {
         // Handle any errors that might occur during the async operation


### PR DESCRIPTION
# Description
[BI-2496](https://breedinginsight.atlassian.net/browse/BI-2496) When Deleting an Experiment: "Success" message appears even if delete fails.

_Please include a summary of the change that was made._
Read the HTTP-status code returned from bi-api and use that to display the correct banner.


# Testing

1.  Insure the "success" banner still appears when an experiment is successfully deleted.
2. An "error" banner should appear when the delete fails. (to insure the delete fails, I temporarily replace _ExperimentController::deleteExperiment_ with:

```
   @Delete("/${micronaut.bi.api.version}/programs/{programId}/experiments/{experimentId}{?hard}")
    @ProgramSecured(roles = {ProgramSecuredRole.PROGRAM_ADMIN, ProgramSecuredRole.SYSTEM_ADMIN})
    @Produces(MediaType.APPLICATION_JSON)
    public HttpResponse deleteExperiment(
            @PathVariable("programId") UUID programId,
            @PathVariable("experimentId") UUID experimentId,
            @QueryValue(defaultValue = "false") Boolean hard
    ) throws ApiException {
        return HttpResponse.serverError();
    }
```


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [x] I have run SiteImprove on pages impacted by changes 


[BI-2496]: https://breedinginsight.atlassian.net/browse/BI-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ