### PR TITLE
[BI-2449-fix] - Correct Exp Preview Summary Stats, QA fix

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -42,7 +42,7 @@
                   <b>Total observations:</b>
                 </div>
                 <div class="column pl-1 is-three-quarters pb-0">
-                  {{ totalObservationsCount }}
+                  {{ observationsWithData }}
                 </div>
               </div>
             </div>

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -68,9 +68,6 @@
           </div>
           <div id="experiment-summary" class ="right-confirm-column">
             <p class="is-size-5 mb-2"><strong>Import Summary</strong></p>
-            Dataset: {{ rows[0].observationUnit.brAPIObject.additionalInfo.observationLevel }}
-            <br>Germplasm: {{ statistics.GIDs.newObjectCount }}
-            <br>Environment(s): {{ statistics.Environments.newObjectCount }}
             <br>Observation Variables: {{ dynamicColumns.length }}
 
             <span v-if="isExisting(rows)" >


### PR DESCRIPTION
# Description
**Story:** [BI-2449 - Correct Exp Preview Summary Stats](https://breedinginsight.atlassian.net/browse/BI-2449)

Renaming and removing some of the experimental summary preview stats.

The main change for this QA fix is clarifying that "Observations" actually means the count of observations recorded, not the observation variables x observation units (which is merely the ceiling for "observations")


# Dependencies
bi-api: develop

# Testing
- Go to experiment details
- Ensure that the "Observation Unit", "Observations with Data", and  "Observations without Data" items are no longer present in the summary stats
- Ensure that the items "Observations" and "Observation Variables" are present and have the correct values
- NOTE: Observations should equal the number of observations with values, NOT observation variables x observation units (which is merely the ceiling for "observations")

NEW TESTING
- Import Experiment
- Ensure that in experiment preview under "Import Summary" only "Observation Variables" and "Observations" entries are present.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [X] I have run SiteImprove on pages impacted by changes 
