### PR TITLE
[BI-2140] Accessibility: Home Page

### DIFF
--- a/src/components/layouts/NoSideBarLayout.vue
+++ b/src/components/layouts/NoSideBarLayout.vue
@@ -32,7 +32,7 @@
         </div>
         <div class="level-right">
           <div class="level-item">
-            <h1 class="title has-text-primary level-item">{{title}}</h1>
+            <h1 v-if="title" class="title has-text-primary level-item">{{title}}</h1>
           </div>
           <div class="level-item">
             <UserStatusMenu v-bind:username="username" v-on:logout="$emit('logout')"/>


### PR DESCRIPTION
# Description
[BI-2140](https://breedinginsight.atlassian.net/browse/BI-2140) Accessibility: Home Page

**THE PROBLEM**
If a Program has not yet been selected then the property _title_ in NoSideBarLayout.vue will be blank, which will produce the HTML `<h1></h1>`.  This will cause the _Siteimprove_ errors:
```Empty headings →
A  1.3.1 Info and Relationships
AA 2.4.6 Headings and Labels
```
**THE SOLUTION**
In NoSideBarLayout.vue make the title HTML conditional. Changing:
`<h1 class="title has-text-primary level-item">{{title}}</h1>`
TO
`<h1 v-if="title" class="title has-text-primary level-item">{{title}}</h1>`


# Dependencies
_Please include any dependencies to other code branches, testing configurations, scripts to be run, etc._

# Testing

- IF you have logged into DeltaBreed, 

- and IF you have not yest selected a program 

- and IF the Siteimprove Accessibility Checker is run against the Home page,

- THEN the following should no longer be reported:

```
A  1.3.1 Info and Relationships
AA 2.4.6 Headings and Labels
```



# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [X] I have run SiteImprove on pages impacted by changes 


[BI-2140]: https://breedinginsight.atlassian.net/browse/BI-2140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ