### PR TITLE
[BI-2555] - Fix Germplasm By List Default Sorting

### DIFF
--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -149,6 +149,16 @@ export default class GermplasmTable extends Vue {
       .reduce((obj, key) => Object.assign({}, obj, { [this.fieldMap[key]]: key }), {});
 
   mounted() {
+    // The initial request was using the default value of the mapped getter, germplasmSort.
+    // This component is used for both AllGermplasm.vue and GermplasmByList.vue with different default sorts
+    // and the built-in buefy properties (default-sort) doesn't seem to do what we want with backend sorting.
+    // Because germplasmSort is persistent client-side state, it needs to be set properly for the initial
+    // request in for both cases.
+    if (this.entryNumberVisible) {
+      this.updateSort(new GermplasmSort("importEntryNumber", "ASC"));
+    } else {
+      this.updateSort(new GermplasmSort("accessionNumber", "DESC"));
+    }
     this.paginationController.pageSize = 200
     this.germplasmCallStack = new CallStack(this.germplasmFetch(
         this.activeProgram!.id!,

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -103,17 +103,6 @@ import {GermplasmFilter} from "@/breeding-insight/model/ListFilter";
     ...mapGetters([
       'activeProgram'
     ]),
-    ...mapGetters('sorting',
-        [
-          'germplasmSort',
-          'germplasmByListSort',
-      ])
-  },
-  methods: {
-    ...mapMutations('sorting', {
-      updateGermplasmSort: UPDATE_GERMPLASM_SORT,
-      updateGermplasmByListSort: UPDATE_GERMPLASM_BY_LIST_SORT,
-    })
   },
   data: () => ({Trait, StringFormatters, TraitStringFormatters, Pedigree, GermplasmUtils, BrAPIUtils, Sort})
 })
@@ -125,6 +114,10 @@ export default class GermplasmTable extends Vue {
   entryNumberVisible?: Boolean;
   @Prop()
   referenceId?: string;
+  @Prop()
+  germplasmSort!: GermplasmSort;
+  @Prop()
+  updateGermplasmSort!: (sort: GermplasmSort) => void;
 
   private activeProgram?: Program;
   private paginationController: PaginationController = new PaginationController();
@@ -134,10 +127,7 @@ export default class GermplasmTable extends Vue {
 
   private germplasmCallStack?: CallStack;
 
-  private germplasmSort!: GermplasmSort;
-  private germplasmByListSort!: GermplasmSort;
-  private updateGermplasmSort!: (sort: GermplasmSort) => void;
-  private updateGermplasmByListSort!: (sort: GermplasmSort) => void;
+
   private fieldMap: any = {
     'importEntryNumber': GermplasmSortField.ImportEntryNumber,
     'accessionNumber': GermplasmSortField.AccessionNumber,
@@ -155,11 +145,9 @@ export default class GermplasmTable extends Vue {
   mounted() {
     // Set default page size to 200.
     this.paginationController.pageSize = 200;
-    // Germplasm and Germplasm by List use different sorts.
-    let sort: GermplasmSort = this.entryNumberVisible ? this.germplasmByListSort : this.germplasmSort;
     this.germplasmCallStack = new CallStack(this.germplasmFetch(
         this.activeProgram!.id!,
-        sort,
+        this.germplasmSort,
         this.paginationController
     ));
 
@@ -208,12 +196,8 @@ export default class GermplasmTable extends Vue {
 
   setSort(field: string, order: string) {
     if (field in this.fieldMap) {
-      // Update the appropriate sort.
-      if (this.entryNumberVisible) {
-        this.updateGermplasmByListSort(new GermplasmSort(this.fieldMap[field], Sort.orderAsBI(order)));
-      } else {
-        this.updateGermplasmSort(new GermplasmSort(this.fieldMap[field], Sort.orderAsBI(order)));
-      }
+      // Update the sort.
+      this.updateGermplasmSort(new GermplasmSort(this.fieldMap[field], Sort.orderAsBI(order)));
       this.getGermplasm();
     }
   }

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -92,7 +92,6 @@ import {
   GermplasmSortField,
   Sort
 } from "@/breeding-insight/model/Sort";
-import {UPDATE_GERMPLASM_SORT, UPDATE_GERMPLASM_BY_LIST_SORT} from "@/store/sorting/mutation-types";
 import { PaginationQuery } from '@/breeding-insight/model/PaginationQuery';
 import {GermplasmFilter} from "@/breeding-insight/model/ListFilter";
 
@@ -126,7 +125,6 @@ export default class GermplasmTable extends Vue {
   private filters: GermplasmFilter = new GermplasmFilter();
 
   private germplasmCallStack?: CallStack;
-
 
   private fieldMap: any = {
     'importEntryNumber': GermplasmSortField.ImportEntryNumber,

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -92,7 +92,7 @@ import {
   GermplasmSortField,
   Sort
 } from "@/breeding-insight/model/Sort";
-import {UPDATE_GERMPLASM_SORT} from "@/store/sorting/mutation-types";
+import {UPDATE_GERMPLASM_SORT, UPDATE_GERMPLASM_BY_LIST_SORT} from "@/store/sorting/mutation-types";
 import { PaginationQuery } from '@/breeding-insight/model/PaginationQuery';
 import {GermplasmFilter} from "@/breeding-insight/model/ListFilter";
 
@@ -105,12 +105,14 @@ import {GermplasmFilter} from "@/breeding-insight/model/ListFilter";
     ]),
     ...mapGetters('sorting',
         [
-          'germplasmSort'
+          'germplasmSort',
+          'germplasmByListSort',
       ])
   },
   methods: {
     ...mapMutations('sorting', {
-      updateSort: UPDATE_GERMPLASM_SORT
+      updateGermplasmSort: UPDATE_GERMPLASM_SORT,
+      updateGermplasmByListSort: UPDATE_GERMPLASM_BY_LIST_SORT,
     })
   },
   data: () => ({Trait, StringFormatters, TraitStringFormatters, Pedigree, GermplasmUtils, BrAPIUtils, Sort})
@@ -133,7 +135,9 @@ export default class GermplasmTable extends Vue {
   private germplasmCallStack?: CallStack;
 
   private germplasmSort!: GermplasmSort;
-  private updateSort!: (sort: GermplasmSort) => void;
+  private germplasmByListSort!: GermplasmSort;
+  private updateGermplasmSort!: (sort: GermplasmSort) => void;
+  private updateGermplasmByListSort!: (sort: GermplasmSort) => void;
   private fieldMap: any = {
     'importEntryNumber': GermplasmSortField.ImportEntryNumber,
     'accessionNumber': GermplasmSortField.AccessionNumber,
@@ -149,20 +153,13 @@ export default class GermplasmTable extends Vue {
       .reduce((obj, key) => Object.assign({}, obj, { [this.fieldMap[key]]: key }), {});
 
   mounted() {
-    // The initial request was using the default value of the mapped getter, germplasmSort.
-    // This component is used for both AllGermplasm.vue and GermplasmByList.vue with different default sorts
-    // and the built-in buefy properties (default-sort) doesn't seem to do what we want with backend sorting.
-    // Because germplasmSort is persistent client-side state, it needs to be set properly for the initial
-    // request in for both cases.
-    if (this.entryNumberVisible) {
-      this.updateSort(new GermplasmSort("importEntryNumber", "ASC"));
-    } else {
-      this.updateSort(new GermplasmSort("accessionNumber", "DESC"));
-    }
-    this.paginationController.pageSize = 200
+    // Set default page size to 200.
+    this.paginationController.pageSize = 200;
+    // Germplasm and Germplasm by List use different sorts.
+    let sort: GermplasmSort = this.entryNumberVisible ? this.germplasmByListSort : this.germplasmSort;
     this.germplasmCallStack = new CallStack(this.germplasmFetch(
         this.activeProgram!.id!,
-        this.germplasmSort,
+        sort,
         this.paginationController
     ));
 
@@ -211,7 +208,12 @@ export default class GermplasmTable extends Vue {
 
   setSort(field: string, order: string) {
     if (field in this.fieldMap) {
-      this.updateSort(new GermplasmSort(this.fieldMap[field], Sort.orderAsBI(order)));
+      // Update the appropriate sort.
+      if (this.entryNumberVisible) {
+        this.updateGermplasmByListSort(new GermplasmSort(this.fieldMap[field], Sort.orderAsBI(order)));
+      } else {
+        this.updateGermplasmSort(new GermplasmSort(this.fieldMap[field], Sort.orderAsBI(order)));
+      }
       this.getGermplasm();
     }
   }

--- a/src/store/sorting/getters.ts
+++ b/src/store/sorting/getters.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import {GetterTree} from 'vuex';
-import {RootState} from "@/store/types";
-import {SortState} from "@/store/sorting/types";
+import { GetterTree } from 'vuex';
+import { RootState } from "@/store/types";
+import { SortState } from "@/store/sorting/types";
 import {
     ExperimentSort,
     GermplasmSort,
@@ -31,7 +31,7 @@ import {
     UserSortField
 } from "@/breeding-insight/model/Sort";
 
-const orderMap: any = {[SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc'};
+const orderMap: any = { [SortOrder.Ascending]: 'asc', [SortOrder.Descending]: 'desc' };
 
 export const getters: GetterTree<SortState, RootState> = {
 
@@ -40,7 +40,7 @@ export const getters: GetterTree<SortState, RootState> = {
         return state.activeOntologySort;
     },
     activeOntologySortOrder(state: SortState): SortOrder {
-      return state.activeOntologySort.order;
+        return state.activeOntologySort.order;
     },
 
     // archived ontology table
@@ -123,6 +123,12 @@ export const getters: GetterTree<SortState, RootState> = {
         return state.germplasmSort;
     },
 
+    // germplasm (by list)
+    germplasmByListSort(state: SortState): GermplasmSort {
+        return state.germplasmByListSort;
+    },
+
+    // germplmas list
     germplasmListSort(state: SortState): GermplasmListSort {
         return state.germplasmListSort;
     },

--- a/src/store/sorting/index.ts
+++ b/src/store/sorting/index.ts
@@ -66,6 +66,9 @@ state = {
     // germplasm table
     germplasmSort: new GermplasmSort(GermplasmSortField.AccessionNumber, SortOrder.Descending),
 
+    // germplasm (by list) table
+    germplasmByListSort: new GermplasmSort(GermplasmSortField.ImportEntryNumber, SortOrder.Ascending),
+
     // germplasm list table
     germplasmListSort: new GermplasmListSort(GermplasmListSortField.Name, SortOrder.Ascending),
 

--- a/src/store/sorting/mutation-types.ts
+++ b/src/store/sorting/mutation-types.ts
@@ -40,6 +40,9 @@ export const UPDATE_PROGRAM_SORT = 'updateProgramSort';
 // germplasm table
 export const UPDATE_GERMPLASM_SORT = 'updateGermplasmSort';
 
+// germplasm (by list) table
+export const UPDATE_GERMPLASM_BY_LIST_SORT = 'updateGermplasmByListSort';
+
 // germplasm list table
 export const UPDATE_GERMPLASM_LIST_SORT = 'updateGermplasmListSort';
 

--- a/src/store/sorting/mutations.ts
+++ b/src/store/sorting/mutations.ts
@@ -24,6 +24,7 @@ import {
     IMPORT_PREVIEW_ONT_TOGGLE_SORT_ORDER,
     IMPORT_PREVIEW_ONT_NEW_SORT_COLUMN,
     UPDATE_GERMPLASM_SORT,
+    UPDATE_GERMPLASM_BY_LIST_SORT,
     UPDATE_GERMPLASM_LIST_SORT,
     UPDATE_EXPERIMENT_SORT, UPDATE_ACTIVE_ONT_SORT, UPDATE_ARCHIVED_ONT_SORT
 } from "@/store/sorting/mutation-types";
@@ -87,6 +88,12 @@ export const mutations: MutationTree<SortState> = {
     [UPDATE_GERMPLASM_SORT](state: SortState, sort: GermplasmSort) {
         state.germplasmSort.field = sort.field;
         state.germplasmSort.order = sort.order;
+    },
+
+    //germplasm (by list) table
+    [UPDATE_GERMPLASM_BY_LIST_SORT](state: SortState, sort: GermplasmSort) {
+        state.germplasmByListSort.field = sort.field;
+        state.germplasmByListSort.order = sort.order;
     },
 
     //germplasm list table

--- a/src/store/sorting/types.ts
+++ b/src/store/sorting/types.ts
@@ -32,10 +32,13 @@ export interface SortState {
     programSort: ProgramSort,
 
     // germplasm table
-    germplasmSort: GermplasmSort
+    germplasmSort: GermplasmSort,
+
+    // germplasm (by list) table
+    germplasmByListSort: GermplasmSort,
 
     // germplasm list table
-    germplasmListSort: GermplasmListSort
+    germplasmListSort: GermplasmListSort,
 
     // experiment and observation table
     experimentSort: ExperimentSort

--- a/src/views/germplasm/AllGermplasm.vue
+++ b/src/views/germplasm/AllGermplasm.vue
@@ -2,6 +2,8 @@
   <section id="germplasmTable">
     <GermplasmTable
       v-bind:germplasmFetch="germplasmFetch"
+      v-bind:germplasm-sort="germplasmSort"
+      v-bind:update-germplasm-sort="updateGermplasmSort"
       >
     </GermplasmTable>
   </section>
@@ -10,7 +12,7 @@
 <script lang="ts">
 import {Component, Vue} from "vue-property-decorator";
 import {validationMixin} from "vuelidate";
-import {mapGetters} from "vuex";
+import {mapGetters, mapMutations} from "vuex";
 import {Trait} from "@/breeding-insight/model/Trait";
 import {StringFormatters} from "@/breeding-insight/utils/StringFormatters";
 import {TraitStringFormatters} from "@/breeding-insight/utils/TraitStringFormatters";
@@ -29,6 +31,7 @@ import {
 } from "@/breeding-insight/model/Sort";
 import GermplasmTable from "@/components/germplasm/GermplasmTable.vue";
 import {PaginationController} from "@/breeding-insight/model/view_models/PaginationController";
+import {UPDATE_GERMPLASM_SORT} from "@/store/sorting/mutation-types";
 
 @Component({
   mixins: [validationMixin],
@@ -37,12 +40,23 @@ import {PaginationController} from "@/breeding-insight/model/view_models/Paginat
     ...mapGetters([
       'activeProgram'
     ]),
+    ...mapGetters('sorting',
+        [
+          'germplasmSort',
+        ])
+  },
+  methods: {
+    ...mapMutations('sorting', {
+      updateGermplasmSort: UPDATE_GERMPLASM_SORT,
+    })
   },
   data: () => ({Trait, StringFormatters, TraitStringFormatters, Pedigree, GermplasmUtils, Sort})
 })
 export default class AllGermplasm extends Vue {
 
   private activeProgram?: Program;
+  private germplasmSort!: GermplasmSort;
+  private updateGermplasmSort!: (sort: GermplasmSort) => void;
 
   // Set the method used to populate the germplasm table
   private germplasmFetch: (programId: string, sort: GermplasmSort, paginationController: PaginationController) => ((filters: any) => Promise<BiResponse>) =

--- a/src/views/germplasm/GermplasmByList.vue
+++ b/src/views/germplasm/GermplasmByList.vue
@@ -116,6 +116,8 @@
         v-bind:germplasmFetch="germplasmFetch"
         entryNumberVisible="true"
         v-bind:reference-id="referenceId"
+        v-bind:germplasm-sort="germplasmByListSort"
+        v-bind:update-germplasm-sort="updateGermplasmByListSort"
     >
     </GermplasmTable>
   </div>
@@ -128,7 +130,7 @@ import GermplasmTable from '@/components/germplasm/GermplasmTable.vue';
 import {GermplasmListSortField, GermplasmSort, SortOrder, GermplasmSortField} from '@/breeding-insight/model/Sort';
 import {BiResponse} from '@/breeding-insight/model/BiResponse';
 import {PaginationQuery} from '@/breeding-insight/model/PaginationQuery';
-import {mapGetters} from 'vuex';
+import {mapGetters, mapMutations} from 'vuex';
 import {Program} from '@/breeding-insight/model/Program';
 import {StringFormatters} from "@/breeding-insight/utils/StringFormatters";
 import GermplasmDownloadButton from '@/components/germplasm/GermplasmDownloadButton.vue';
@@ -142,13 +144,23 @@ import {ListService} from '@/breeding-insight/service/ListService';
 import {ListType} from "@/util/ListType";
 import {GermplasmFilter} from "@/breeding-insight/model/ListFilter";
 import {GermplasmService} from "@/breeding-insight/service/GermplasmService";
+import {UPDATE_GERMPLASM_BY_LIST_SORT} from "@/store/sorting/mutation-types";
 
 @Component({
   components: { FormModal, GermplasmTable, GermplasmDownloadButton, GermplasmListDeletionModal, ActionMenu },
   computed: {
     ...mapGetters([
       'activeProgram'
-    ])
+    ]),
+    ...mapGetters('sorting',
+        [
+          'germplasmByListSort',
+        ])
+  },
+  methods: {
+    ...mapMutations('sorting', {
+      updateGermplasmByListSort: UPDATE_GERMPLASM_BY_LIST_SORT,
+    })
   }
 })
 export default class GermplasmByList extends GermplasmBase {
@@ -164,6 +176,9 @@ export default class GermplasmByList extends GermplasmBase {
     new ActionMenuItem('germplasm-list-delete', 'delete-list', 'Delete', this.$ability.can('delete', 'List')),
     new ActionMenuItem('germplasm-list-download-file', 'download-file', 'Download',  true)
   ];
+
+  private germplasmByListSort: GermplasmSort;
+  private updateGermplasmByListSort: (sort: GermplasmSort) => void;
 
   // Formatting filters
   private toYMD(date: string | null | undefined): string {


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2555

The `GermplasmTable` component is used by both `AllGermplasm` and `GermplasmByList`. Because `AllGermplasm` and `GermplasmByList` have different default sort requirements, and should both remember the user-selected sort when the user navigates away and back again, they needed to be updated to use different pieces of Vuex state. I moved the sorting state management up to the parent components, and added props for `germplasmSort` and `updateGermplasmSort` to `GermplasmTable`. 

# Dependencies
None

# Testing
- Upload germplasm to a program.
- Ensure the default sort of the all germplasm table is GID, descending.
- Ensure the default sort of the germplasm by list table is import entry number, ascending.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes
