### PR TITLE
[BI-2574] - Migrate documentation links to the new BOX

### DIFF
--- a/src/components/trait/TraitImportTemplateMessageBox.vue
+++ b/src/components/trait/TraitImportTemplateMessageBox.vue
@@ -32,7 +32,7 @@
             <div class="level-item">
               <div class="has-text-dark has-text-centered is-size-7">
                 <!-- temporary link until the backend card is done -->
-                <a href="https://cornell.box.com/shared/static/8sp0qvccpjotosiv8576tczeg09nnvao.xls"
+                <a href="https://cornell.box.com/shared/static/pgi6ncysrdnxkb3sbk2bijmemcqqrygd.xls"
                   class="button is-outlined is-primary" :id="downloadTraitTemplateId">Download the Trait Import Template</a>
                 <br/>Template version placeholder
               </div>

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -33,7 +33,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Experiments & Observations'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/7ziyhhnia5i7bdvekawhb2ldyobrecmw.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/x53n1x8fhccgij8hroel0zuz3y4l31iu.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -31,7 +31,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/nx22mqw2y2q7uod0xt388zq5t04ejai3.xls'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/qr9raqf70xcotoa7747dybxgjdunt7o0.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>

--- a/src/views/import/ImportSample.vue
+++ b/src/views/import/ImportSample.vue
@@ -30,7 +30,7 @@
     >
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Sample Submission'"
-                                      v-bind:template-url="'https://cornell.box.com/shared/static/trakiri85mhazfd0gfika6ubpnt7gum5.xlsx'"
+                                      v-bind:template-url="'https://cornell.box.com/shared/static/yketd2s1353g62p0psem64w0awob5toz.xls'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>

--- a/src/views/trait/TraitsImport.vue
+++ b/src/views/trait/TraitsImport.vue
@@ -178,7 +178,7 @@ export default class TraitsImport extends ProgramsBase {
   private showAbortModal = false;
 
   private yesAbortId: string = "traitsimport-yes-abort";
-  private templateUrl: string = "https://cornell.box.com/shared/static/rxmj35d0wracg15ubemrshizdytmn731.xls";
+  private templateUrl: string = "https://cornell.box.com/shared/static/pgi6ncysrdnxkb3sbk2bijmemcqqrygd.xls";
 
   private confirmImportState: DataFormEventBusHandler = new DataFormEventBusHandler();
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2574

Updated the download links for all template files to [the new Box folder](https://cornell.box.com/s/7ypfnp5disiz93lvgjnsm137lgbops3q).
> Note that `TraitImportTemplateMessageBox` was updated for completeness, it is not used anywhere.


# Dependencies
_Please include any dependencies to other code branches, testing configurations, scripts to be run, etc._

# Testing
For each import template (germplasm, experiment, ontology and sample submission), ensure that
1. the download works,
2. the most recent template file is downloaded, and
3. the download link matches the share link in [the new Box folder](https://cornell.box.com/s/7ypfnp5disiz93lvgjnsm137lgbops3q).


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 
