### PR TITLE
[BI-2009] - Dynamic Concatenation of Entity + ObsUnitID (Exp UI)

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -230,7 +230,7 @@
         <b-table-column
             v-slot="props"
             field="data.obsUnitId"
-            label="ObsUnitID"
+            v-bind:label="obsUnitIDLabel"
             sortable
             searchable
             :th-attrs="() => ({scope:'col'})"
@@ -306,6 +306,7 @@ export default class Dataset extends ProgramsBase {
   private paginationController: PaginationController = new PaginationController();
   private datasetTableRows: DatasetTableRow[] = [];
   private unitDbIdToTraitValues: any = {};
+  private obsUnitIDLabel :string = "ObsUnitID";
 
   mounted() {
     this.load();
@@ -552,6 +553,11 @@ export default class Dataset extends ProgramsBase {
     }
   }
 
+  setObsUnitIDLabel(){
+    //todo add NA case? what if there is a genuine NA obs lvl
+    this.obsUnitIDLabel = this.observationUnit + " ObsUnitID"
+  }
+
   @Watch('$route')
   async load() {
     try {
@@ -580,6 +586,9 @@ export default class Dataset extends ProgramsBase {
 
       // Use this.datasetModel to initialize this.datasetTableRows
       this.createDatasetTableRows();
+
+      // Set the obsUnitId label to include observation level
+      this.setObsUnitIDLabel();
 
       //Initialize the paginationController
       this.paginationController.totalCount = this.datasetModel.observationUnits.length;

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -554,7 +554,6 @@ export default class Dataset extends ProgramsBase {
   }
 
   setObsUnitIDLabel(){
-    //todo add NA case? what if there is a genuine NA obs lvl
     this.obsUnitIDLabel = this.observationUnit + " ObsUnitID"
   }
 

--- a/task/serve.js
+++ b/task/serve.js
@@ -26,7 +26,7 @@ const port = process.env.PORT || JSON.parse(fs.readFileSync('package.json', 'utf
   let spinner = ora({prefixText: ' ', color: 'yellow'});
   try {
     spinner = spinner.start('sort package.json');
-    await execa('npx', ['sort-package-json'], {preferLocal: true});
+    await execa('npx', ['sort-package-json@3.0.0'], {preferLocal: true});
     spinner = spinner.clear()
                      .succeed('package.json sorted');
 


### PR DESCRIPTION
# Description
**Story:** [BI-2009 - Dynamic Concatenation of Entity + ObsUnitID (Exp UI)](https://breedinginsight.atlassian.net/browse/BI-2009)

Modified Dataset.vue to prefix the ObsUnitID label for the experimental dataset table with the respective observation level

# Dependencies
bi-api: [feature/BI-2009](https://github.com/Breeding-Insight/bi-api/pull/458)

# Testing
UI Display
- Open experiment details for experiments with different observation levels
- In each case, ensure that in the table the ObsUnitID column header is prefixed with the correct observation level (<observation level> ObsUnitID) and that row values appear as expected

Export
- Export dataset for experiments with different observation levels and different environments selected
- In each case, ensure that the ObsUnitID column header in the exported file is prefixed with the correct observation level (<observation level> ObsUnitID) and that row values appear as expected

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [X] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/14775085939) alas since npm fix not in future/1.2, failing
- [X] I have run SiteImprove on pages impacted by changes 
