### PR TITLE
BI-2618 - Error with npx sort-package-json

### DIFF
--- a/task/serve.js
+++ b/task/serve.js
@@ -26,7 +26,7 @@ const port = process.env.PORT || JSON.parse(fs.readFileSync('package.json', 'utf
   let spinner = ora({prefixText: ' ', color: 'yellow'});
   try {
     spinner = spinner.start('sort package.json');
-    await execa('npx', ['sort-package-json'], {preferLocal: true});
+    await execa('npx', ['sort-package-json@3.0.0'], {preferLocal: true});
     spinner = spinner.clear()
                      .succeed('package.json sorted');
 


### PR DESCRIPTION
# Description
**Story:** [BI-2618](https://breedinginsight.atlassian.net/browse/BI-2618)

I pinned `sort-package-json` to 3.0.0. Version 3.1.0 broke our usage.
