### PR TITLE
BI-2597 Sorting Exp Unit ID incorrectly

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -123,6 +123,7 @@
         <b-table-column
             v-slot="props"
             field="data.expUnitId"
+            :custom-sort="sortExpUnitId"
             label="Exp Unit ID"
             sortable
             searchable
@@ -400,6 +401,18 @@ export default class Dataset extends ProgramsBase {
       if( second > first ){ return 1; }
       else if ( second < first){ return -1;}
       else return 0;
+    }
+  }
+
+  // This sorts the Exp Unit ID's in Alphanumeric order (ie. B300,BO2, B1 would sort to B1, B02, B300)
+  sortExpUnitId(a: any, b: any, isAsc: boolean){
+    let first :any = (a.data.expUnitId);
+    let second :any = (b.data.expUnitId);
+    if (isAsc) {
+      return first.toString().localeCompare(second.toString(), 'en', {numeric: true});
+    }
+    else {
+      return second.toString().localeCompare(first.toString(), 'en', {numeric: true});
     }
   }
 


### PR DESCRIPTION
# Description
[BI-2597](https://breedinginsight.atlassian.net/browse/BI-2597) Sorting Exp Unit ID incorrectly

# Dependencies
bi-api: develop

# Testing

- Import experiment [Test2_bi_experimentObs_UAT-tyrwh-oat.xlsx](https://github.com/user-attachments/files/20004074/Test2_bi_experimentObs_UAT-tyrwh-oat.xlsx)
- Go to the Experiments & Observations page.
- Click on newly imported experiment (_The Test 2 Uniform Oat Performance Nursery_).
- Sort on `Exp Unit ID`.

RESULT

- The first 8 `Exp Unit ID` items should be in the following order:
  - Test1
  - Test02
  - Test02B
  - Test10
  - Test20
  - Test103
  - Test200
  - X10



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2597]: https://breedinginsight.atlassian.net/browse/BI-2597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ