### PR TITLE
BI-2639 - Improve duplicate message accuracy

### DIFF
--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -81,8 +81,7 @@
             <p>New Germplasm count: {{ statistics.Germplasm.newObjectCount }}</p>
             <p>New Pedigree Connections: {{ statistics["Pedigree Connections"].newObjectCount }}</p>
             <template v-if="duplicatesPresent(rows)">
-              <p>Duplicate names detected and are highlighted in yellow and show a <alert-triangle-icon size="1.2x" class="icon-align"/> icon.
-                Upon import duplicates will become independent database entries.</p>
+              <p>Duplicate names detected and are highlighted in yellow and show a <alert-triangle-icon size="1.2x" class="icon-align"/> icon.</p>
             </template>
 
           </div>


### PR DESCRIPTION
# Description
**Story:** [BI-2639](https://breedinginsight.atlassian.net/browse/BI-2639?atlOrigin=eyJpIjoiYjY2NjZhYmE4YmE4NGJhNzk5ZmFjYWUxZWVmZjhkMzQiLCJwIjoiaiJ9)

- Removed second part of description text that was misleading

# Dependencies
- bi-aip bug/BI-2639

# Testing
- See that second part of duplicate text has been removed on germplasm import preview

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2639]: https://breedinginsight.atlassian.net/browse/BI-2639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ