### PR TITLE
[BI-2628] Replace Static ObsUnitID column to Dynamic Sub-entity ObsUnitID column in APpend Workflow

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -315,7 +315,7 @@ export default class ImportExperiment extends ProgramsBase {
   }
 
   previewDataLoaded(dynamicColumns: String[]) {
-    this.phenotypeColumns = dynamicColumns;
+    this.phenotypeColumns = dynamicColumns.filter(name => !name.includes('ObsUnitID'));
     this.createObservationIndexMap();
   }
 
@@ -357,7 +357,6 @@ export default class ImportExperiment extends ProgramsBase {
 
   cellClassIfExisting(row: any, column: any) {
     const index = column.meta.index
-
     if(row.data.observations[this.observationIndexMap.get(index)!].state === 'MUTATED') {
       return {'class': 'db-filled'};
     }


### PR DESCRIPTION
# Description
**Story:** [BI-2628](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2628)

The experiment import preview is changed from assuming that all dynamic oolumns are phenotypes to targeting the phenotype columns specifically by omitting other possible dynamic columns associated with observation unit ids.



# Dependencies
bi-api: develop

# Testing
See bi-api PR for feature/BI-2628


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2628]: https://breedinginsight.atlassian.net/browse/BI-2628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ