### PR TITLE
[BI-2628-2] Replace Static ObsUnitID column to Dynamic Sub-entity ObsUnitID column in APpend Workflow

### DIFF
--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -315,7 +315,7 @@ export default class ImportExperiment extends ProgramsBase {
   }
 
   previewDataLoaded(dynamicColumns: String[]) {
-    this.phenotypeColumns = dynamicColumns.filter(name => !name.includes('ObsUnitID'));
+    this.phenotypeColumns = dynamicColumns;
     this.createObservationIndexMap();
   }
 

--- a/src/views/import/ImportTemplate.vue
+++ b/src/views/import/ImportTemplate.vue
@@ -633,7 +633,7 @@ export default class ImportTemplate extends ProgramsBase {
             this.previewData = previewResponse.preview.rows as any[];
             this.newObjectCounts = previewResponse.preview.statistics;
             this.$emit('statistics-loaded', this.newObjectCounts);
-            this.dynamicColumns = previewResponse.preview.dynamicColumnNames;
+            this.dynamicColumns = previewResponse.preview.dynamicColumnNames.filter(name => !name.includes('ObsUnitID'));
             this.$emit('preview-data-loaded', this.dynamicColumns);
             this.importService.send(ImportEvent.IMPORT_SUCCESS);
             // TODO: Temp pagination


### PR DESCRIPTION
# Description
**Story:** [BI-2628](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2628)

The experiment append workflow import preview is showing the wrong count for phenotypic variables.

The frontend import preview template parent component passes the phenotypic dynamic columns used in the import to the experiment import preview child component. Since the dynamicColumns field in the backend preview response now includes additional dynamic columns(the ObsUnitID columns used in the append workflow), the phenotypic columns need to be selected and only these passed to the preview component.

This PR just moves the filter that was used in the experiment preview component to the parent import template component.

# Dependencies
biapi:develop

# Testing

1.   Download an experiment.
2.  Use the Append workflow to import observation data.
3.  Verify that import completed successfully.
4.  Verify that the import preview displays the correct number for the "Observation Variables" field.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2628]: https://breedinginsight.atlassian.net/browse/BI-2628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ