### PR TITLE
[BI-2755] - improve default sub-unit sort

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -56,7 +56,6 @@
           v-bind:pagination="paginationController"
           v-bind:debounce-search="400"
           v-on:show-error-notification="$emit('show-error-notification', $event)"
-          v-bind:default-sort="['data.envLocation', 'desc']"
       >
         <b-table-column
             v-slot="props"


### PR DESCRIPTION
# Description
**Story:** [BI-2755 - improve default sub-unit sort](https://breedinginsight.atlassian.net/browse/BI-2755)

Removed default UI sorting of experimental dataset as it is handled in backend instead.

# Dependencies
[bi-api: BI-2755](https://github.com/Breeding-Insight/bi-api/pull/491)

# Testing
Check there is no table column sort arrow by default when loading a dataset

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [X] I have run SiteImprove on pages impacted by changes 