### PR TITLE
BI-2715 - Delete exp warning observation count is wrong

### DIFF
--- a/src/components/experiments/ExperimentDeleteModal.vue
+++ b/src/components/experiments/ExperimentDeleteModal.vue
@@ -25,7 +25,7 @@
     v-on:deactivate="resetExportOptions"
   >
     <template #form>
-      <p>{{obsCount}} observations will be deleted. All records will be lost. Are you sure you want to delete the experimental data?</p>
+      <p>All records will be lost. Are you sure you want to delete the experimental data?</p>
     </template>
   </ConfirmationModal>
 </template>

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -427,7 +427,7 @@ export default class ExperimentDetails extends ProgramsBase {
         }
         let dataset = response.value;
         if(dataset && dataset.additionalInfo){
-          this.obsCount = dataset.additionalInfo.observationsWithData;
+          this.obsCount = dataset.additionalInfo.observations;
         }
       } catch (err) {
         // Display error that dataset cannot be loaded

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -427,7 +427,7 @@ export default class ExperimentDetails extends ProgramsBase {
         }
         let dataset = response.value;
         if(dataset && dataset.additionalInfo){
-          this.obsCount = dataset.additionalInfo.observations;
+          this.obsCount = dataset.additionalInfo.observationsWithData;
         }
       } catch (err) {
         // Display error that dataset cannot be loaded


### PR DESCRIPTION
# Description
**Story:** [BI-2715](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?selectedIssue=BI-2715)

- Removed observations count from delete experiment modal message


# Dependencies
- bi-api develop

# Testing
- Verify that the delete experiment modal not longer shows observation count


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2715]: https://breedinginsight.atlassian.net/browse/BI-2715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ