### PR TITLE
BI- 2615 Incorrect sorting Exp Rep #, Exp Block #, Row and Col 

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -146,6 +146,7 @@
         <b-table-column
             v-slot="props"
             field="data.expReplicate"
+            :custom-sort="sortExpReplicate"
             label="Exp Replicate #"
             sortable
             searchable
@@ -157,6 +158,7 @@
             v-slot="props"
             field="data.expBlock"
             label="Exp Block #"
+            :custom-sort="sortExpBlock"
             sortable
             searchable
             :th-attrs="() => ({scope:'col'})"
@@ -167,6 +169,7 @@
             v-slot="props"
             field="data.row"
             label="Row"
+            :custom-sort="sortRow"
             sortable
             searchable
             :th-attrs="() => ({scope:'col'})"
@@ -177,6 +180,8 @@
             v-slot="props"
             field="data.column"
             label="Column"
+            :custom-sort="sortColumn"
+
             sortable
             searchable
             :th-attrs="() => ({scope:'col'})"
@@ -418,33 +423,51 @@ export default class Dataset extends ProgramsBase {
   }
 
   //sort GIDs numerically
+
   sortGID(a: any, b: any, isAsc: boolean){
     let first :number = parseInt(a.data.gid);
     let second :number = parseInt(b.data.gid);
-    if (isAsc) {
-      if( first > second){ return 1; }
-      else if (first < second){ return -1;}
-      else return 0;
-    } else {
-      if( second > first ){ return 1; }
-      else if ( second < first){ return -1;}
-      else return 0;
-    }
+    return this.sortAlphaAsNumeric(first, second, isAsc);
+  }
+  sortColumn(a: any, b: any, isAsc: boolean) {
+    let first: any = (a.data.column);
+    let second: any = (b.data.column);
+    return this.sortAlphaAsNumeric(first, second, isAsc);
+  }
+
+  sortRow(a: any, b: any, isAsc: boolean) {
+    let first: any = (a.data.row);
+    let second: any = (b.data.row);
+    return this.sortAlphaAsNumeric(first, second, isAsc);
+  }
+
+  sortExpBlock(a: any, b: any, isAsc: boolean) {
+    let first: any = (a.data.expBlock);
+    let second: any = (b.data.expBlock);
+    return this.sortAlphaAsNumeric(first, second, isAsc);
+  }
+  sortExpReplicate(a: any, b: any, isAsc: boolean){
+    let first :any = (a.data.expReplicate);
+    let second :any = (b.data.expReplicate);
+    return this.sortAlphaAsNumeric( first, second, isAsc);
   }
 
   // This sorts the Exp Unit ID's in Alphanumeric order (ie. B300,BO2, B1 would sort to B1, B02, B300)
   sortExpUnitId(a: any, b: any, isAsc: boolean){
     let first :any = (a.data.expUnitId);
     let second :any = (b.data.expUnitId);
+    return this.sortAlphaAsNumeric( first, second, isAsc);
+  }
+
+  private sortAlphaAsNumeric( first: any, second: any, isAsc: boolean)  {
     if (isAsc) {
       return first.toString().localeCompare(second.toString(), 'en', {numeric: true});
-    }
-    else {
+    } else {
       return second.toString().localeCompare(first.toString(), 'en', {numeric: true});
     }
   }
 
-  // This sorts the Sub Unit ID's in Alphanumeric order (ie. B300,BO2, B1 would sort to B1, B02, B300)
+// This sorts the Sub Unit ID's in Alphanumeric order (ie. B300,BO2, B1 would sort to B1, B02, B300)
   sortSubUnitId(a: any, b: any, isAsc: boolean) {
     let first: any = (a.data.subExpUnitId);
     let second: any = (b.data.subExpUnitId);

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -409,11 +409,8 @@ export default class Dataset extends ProgramsBase {
     first = first ? first : "";  //convert null or undefined to an empty string
     let second = b.data.traitValues[index];
     second = second ? second : "";  //convert null or undefined to an empty string
-    if (isAsc) {
-      return first.localeCompare(second);
-    } else {
-      return second.localeCompare(first);
-    }
+    return this.sortAlphaAsNumeric(first, second, isAsc);
+
   }
 
   //Filter GIDs by exact match
@@ -430,52 +427,48 @@ export default class Dataset extends ProgramsBase {
     return this.sortAlphaAsNumeric(first, second, isAsc);
   }
   sortColumn(a: any, b: any, isAsc: boolean) {
-    let first: any = (a.data.column);
-    let second: any = (b.data.column);
+
+    let first: any = a.data.column;
+    let second: any = b.data.column;
     return this.sortAlphaAsNumeric(first, second, isAsc);
   }
 
   sortRow(a: any, b: any, isAsc: boolean) {
-    let first: any = (a.data.row);
-    let second: any = (b.data.row);
+    let first: any = a.data.row;
+    let second: any = b.data.row;
     return this.sortAlphaAsNumeric(first, second, isAsc);
   }
 
   sortExpBlock(a: any, b: any, isAsc: boolean) {
-    let first: any = (a.data.expBlock);
-    let second: any = (b.data.expBlock);
+    let first: any = a.data.expBlock;
+    let second: any = b.data.expBlock;
     return this.sortAlphaAsNumeric(first, second, isAsc);
   }
   sortExpReplicate(a: any, b: any, isAsc: boolean){
-    let first :any = (a.data.expReplicate);
-    let second :any = (b.data.expReplicate);
+    let first :any = a.data.expReplicate;
+    let second :any = b.data.expReplicate;
     return this.sortAlphaAsNumeric( first, second, isAsc);
   }
 
   // This sorts the Exp Unit ID's in Alphanumeric order (ie. B300,BO2, B1 would sort to B1, B02, B300)
   sortExpUnitId(a: any, b: any, isAsc: boolean){
-    let first :any = (a.data.expUnitId);
-    let second :any = (b.data.expUnitId);
+    let first :any = a.data.expUnitId;
+    let second :any = b.data.expUnitId;
     return this.sortAlphaAsNumeric( first, second, isAsc);
-  }
-
-  private sortAlphaAsNumeric( first: any, second: any, isAsc: boolean)  {
-    if (isAsc) {
-      return first.toString().localeCompare(second.toString(), 'en', {numeric: true});
-    } else {
-      return second.toString().localeCompare(first.toString(), 'en', {numeric: true});
-    }
   }
 
 // This sorts the Sub Unit ID's in Alphanumeric order (ie. B300,BO2, B1 would sort to B1, B02, B300)
   sortSubUnitId(a: any, b: any, isAsc: boolean) {
-    let first: any = (a.data.subExpUnitId);
-    let second: any = (b.data.subExpUnitId);
+    let first: any = a.data.subExpUnitId;
+    let second: any = b.data.subExpUnitId;
+    return this.sortAlphaAsNumeric( first, second, isAsc);
+  }
+  
+  private sortAlphaAsNumeric( first: number, second: number, isAsc: boolean)  {
     if (isAsc) {
       return first.toString().localeCompare(second.toString(), 'en', {numeric: true});
     } else {
       return second.toString().localeCompare(first.toString(), 'en', {numeric: true});
-
     }
   }
 


### PR DESCRIPTION
# Description
[BI- 2615](https://breedinginsight.atlassian.net/browse/BI-2615) Incorrect sorting **Exp Rep #**, **Exp Block #**, **Row** and **Col**

# Dependencies
BI_API :Develop

# Testing
1. add an Experiment with (at minimum) the values of 1,...10,....2 for **Exp Rep #**, **Exp Block #**, **Row** and **Col**
2. Go to Experiment List
3. Select the newly added Experiment (from step 1.)
4. Sort on each of the columns **Exp Rep #**, **Exp Block #**, **Row** and **Col**
**Expected Result**
* Each sorted columns should be sorted in numerical order (Ex. 1,....2,...10)



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<link to TAF run>_
- [ ] I have run SiteImprove on pages impacted by changes 
