### PR TITLE
[BI-2744] DeltaBreed:Create exp, create obs level

### DIFF
--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -307,7 +307,7 @@ export default class ExperimentDetails extends ProgramsBase {
     if (!this.experiment.additionalInfo) {
       return '';
     }
-    return this.experiment.additionalInfo.defaultObservationLevel;
+    return StringFormatters.toStartCase(this.experiment.additionalInfo.defaultObservationLevel);
   }
 
   get experimentType(): string {

--- a/src/views/import/ImportExperiment.vue
+++ b/src/views/import/ImportExperiment.vue
@@ -64,7 +64,7 @@
               <template v-if="rows && rows.length > 0">
                 Title: {{ rows[0].trial.brAPIObject.trialName }}
                 <br>Description: {{ rows[0].trial.brAPIObject.trialDescription }}
-                <br>Experimental Unit: {{ rows[0].trial.brAPIObject.additionalInfo.defaultObservationLevel }}
+                <br>Experimental Unit: {{ StringFormatters.toStartCase(rows[0].trial.brAPIObject.additionalInfo.defaultObservationLevel) }}
                 <br>Type: {{ rows[0].trial.brAPIObject.additionalInfo.experimentType }}
                 <br>Experimental Design: Externally generated
               </template>
@@ -307,8 +307,14 @@ import ExpandableTable from "@/components/tables/expandableTable/ExpandableTable
 import {ImportObjectState} from "@/breeding-insight/model/import/ImportObjectState";
 import { GeoCoordinates } from '@/breeding-insight/model/GeoCoordinates';
 import {ExperimentUserInput} from "@/breeding-insight/model/ExperimentUserInput";
+import {StringFormatters} from "../../breeding-insight/utils/StringFormatters";
 
 @Component({
+  computed: {
+    StringFormatters() {
+      return StringFormatters
+    }
+  },
   components: {
     ImportInfoTemplateMessageBox, ConfirmImportMessageBox, ImportTemplate, AlertTriangleIcon, BasicInputField, ExpandableTable
   },


### PR DESCRIPTION
# Description
**Story:** [BI-2744 - DeltaBreed:Create exp, create obs level ](https://breedinginsight.atlassian.net/browse/BI-2744)

Changes to ensure consistent casing (capitalized) of Experimental Unit in UI.

# Dependencies
[bi-api: feature/BI-2744](https://github.com/Breeding-Insight/bi-api/pull/498)

# Testing
see bi-api

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 
