### PR TITLE
[BI-2778] Deprecate additionalinfo usage for level and use obs unit level

### DIFF
--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -672,7 +672,7 @@ export default class Dataset extends ProgramsBase {
       this.createDatasetTableRows();
 
       // Set the obsUnitId label to include observation level
-      if (this.isSubEntity) this.subObservationUnit = this.datasetModel.observationUnits[0].additionalInfo.observationLevel;
+      if (this.isSubEntity) this.subObservationUnit = this.datasetModel.observationUnits[0].observationUnitPosition.observationLevel.levelName;
       this.setObsUnitIDLabel();
 
       //Initialize the paginationController


### PR DESCRIPTION
# Description
**Story:**  [BI-2778 - Deprecate additionalinfo usage for level and use obs unit level](https://breedinginsight.atlassian.net/browse/BI-2778)

Fixed sub entity name display

# Dependencies
bi-api: [feature/BI-2778](https://github.com/Breeding-Insight/bi-api/pull/500)

# Testing
see bi-api

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [x] I have run SiteImprove on pages impacted by changes 
