### PR TITLE
BI-2805 - Fix autocomplete to work with new BrAPI levelNames

### DIFF
--- a/src/breeding-insight/dao/ExperimentDAO.ts
+++ b/src/breeding-insight/dao/ExperimentDAO.ts
@@ -146,6 +146,21 @@ export class ExperimentDAO {
         }
     }
 
+    static async getRecommendedSubEntityDatasetNames(programId: string, experimentId: string): Promise<Result<Error, string[]>> {
+        const config: any = {};
+        config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/recommended-sub-entity-dataset-names`;
+        config.method = 'get';
+        config.programId = programId;
+        config.experimentId = experimentId;
+        try {
+            const res = await api.call(config) as Response;
+            const { result } = res.data;
+            return ResultGenerator.success(result);
+        } catch (error) {
+            return ResultGenerator.err(error);
+        }
+    }
+
     static async getDatasetById(programId: string, experimentId: string, datasetId: string, stats: boolean): Promise<Result<Error, DatasetModel>> {
         const config: any = {};
         config.url = `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/dataset/${datasetId}`;

--- a/src/breeding-insight/service/ExperimentService.ts
+++ b/src/breeding-insight/service/ExperimentService.ts
@@ -54,6 +54,13 @@ export class ExperimentService {
         return await ExperimentDAO.getDatasetMetadata(programId, experimentId);
     }
 
+    static async getRecommendedSubEntityDatasetNames(programId: string, experimentId: string): Promise<Result<Error, string[]>> {
+        if (!programId) {
+            return ResultGenerator.err(new Error('Missing or invalid program id'));
+        }
+        return await ExperimentDAO.getRecommendedSubEntityDatasetNames(programId, experimentId);
+    }
+
     static async getDatasetMetadataByTrial(programId: string, trial: Trial): Promise<Result<Error, DatasetMetadata[]>> {
         if (!programId) {
             return ResultGenerator.err(new Error('Missing or invalid program id'));

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -167,7 +167,6 @@
 import {Component, Watch} from "vue-property-decorator";
 import {mapGetters} from "vuex";
 import {Collaborator} from "@/breeding-insight/model/Collaborator";
-import {PlusCircleIcon} from 'vue-feather-icons'
 import {Program} from "@/breeding-insight/model/Program";
 import {Result} from "@/breeding-insight/model/Result";
 import {ExperimentService} from "@/breeding-insight/service/ExperimentService";
@@ -184,18 +183,11 @@ import {SubEntityDatasetNewRequest} from "@/breeding-insight/model/SubEntityData
 import {DatasetModel} from "@/breeding-insight/model/DatasetModel";
 import ExperimentAddCollaboratorModal from "@/components/experiments/ExperimentAddCollaboratorModal.vue";
 import ExperimentCollaboratorRemovalModal from "@/components/experiments/ExperimentCollaboratorRemovalModal.vue";
-import {ProgramService} from "@/breeding-insight/service/ProgramService";
-import {ObservationUnitService} from "@/breeding-insight/service/ObservationUnitService";
 import {StringFormatters} from "@/breeding-insight/utils/StringFormatters";
-import {Observation} from "@/breeding-insight/model/Observation";
-import {Metadata} from "@/breeding-insight/model/BiResponse";
-import {ObservationService} from "@/breeding-insight/service/ObservationService";
-import {ProgramObservationLevel} from "@/breeding-insight/model/ProgramObservationLevel";
 
 @Component({
   components: {
     SubEntityDatasetModal,
-    PlusCircleIcon,
     ExperimentObservationsDownloadModal,
     ExperimentDeleteModal,
     ExperimentAddCollaboratorModal,
@@ -337,18 +329,17 @@ export default class ExperimentDetails extends ProgramsBase {
   //   return this.experiment.additionalInfo.environmentsCount;
   // }
 
-  //Get program entity names for sub-entity modal suggestions
+  //Get experiment-scoped suggested names for sub-entity modal autocomplete
   @Watch('$route')
   async getProgramDatasetNames() {
     try {
-      const response: Result<Error, [ProgramObservationLevel[], Metadata]> = await ObservationUnitService.getObservationLevels(this.activeProgram!.id!);
+      const response: Result<Error, string[]> = await ExperimentService.getRecommendedSubEntityDatasetNames(this.activeProgram!.id!, this.experimentUUID);
       if(response.isErr()) {
         this.$emit('show-error-notification', 'Unable to retrieve program dataset names');
       }
 
       if (response.isSuccess()) {
-        const [observationLevelNames, metadata] = response.value;
-        this.programDatasetNames = observationLevelNames.map(value => StringFormatters.toStartCase(value.name!));
+        this.programDatasetNames = response.value.map(value => StringFormatters.toStartCase(value));
         return;
       }
     } catch (error) {
@@ -365,10 +356,10 @@ export default class ExperimentDetails extends ProgramsBase {
     return;
   }
 
-  //Retrieves program entity names minus any that already exist as entity names for the experiment
+  //The API already filters out names that exist in the experiment
   get datasetNameOptions(): String[] {
-    return this.programDatasetNames.filter((x) => !this.experimentDatasetNames.includes(x));
-}
+    return this.programDatasetNames;
+  }
 
   get experimentObservationUnit(): string | null {
     if (this.experiment && this.experiment.additionalInfo) {


### PR DESCRIPTION
# Description
**Story:** [BI-2805](https://breedinginsight.atlassian.net/browse/BI-2805?atlOrigin=eyJpIjoiMDNlNWFkNTc1NDE4NDM3NWI5ZmZmM2QxNDNlODhiZjMiLCJwIjoiaiJ9)

- Switched to use `GET /programs/${programId}/experiments/${experimentId}/recommended-sub-entity-dataset-names` endpoint
- Cleaned up unused imports
- Remove front-end filtering of dataset names already used in experiment as it is now done in the backend
- Left in front-end existing dataset name check on sub entity dataset creation

# Dependencies
- bi-api feature/BI-2805

# Testing
- See acceptance criteria in [BI-2805](https://breedinginsight.atlassian.net/browse/BI-2805?atlOrigin=eyJpIjoiMDNlNWFkNTc1NDE4NDM3NWI5ZmZmM2QxNDNlODhiZjMiLCJwIjoiaiJ9)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2805]: https://breedinginsight.atlassian.net/browse/BI-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ