### PR TITLE
BI-2836 - Unable to retrieve program dataset names error message

### DIFF
--- a/src/breeding-insight/dao/ExperimentDAO.ts
+++ b/src/breeding-insight/dao/ExperimentDAO.ts
@@ -154,8 +154,8 @@ export class ExperimentDAO {
         config.experimentId = experimentId;
         try {
             const res = await api.call(config) as Response;
-            const { result } = res.data;
-            return ResultGenerator.success(result);
+            const biResponse = new BiResponse(res.data);
+            return ResultGenerator.success(biResponse.result.data);
         } catch (error) {
             return ResultGenerator.err(error);
         }

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -232,7 +232,7 @@ export default class ExperimentDetails extends ProgramsBase {
   mounted() {
     this.getExperiment();
     this.getDatasetMetadata();
-    this.getProgramDatasetNames();
+    this.getRecommendedSubEntityDatasetNames();
   }
 
   private importFile() {
@@ -331,22 +331,22 @@ export default class ExperimentDetails extends ProgramsBase {
 
   //Get experiment-scoped suggested names for sub-entity modal autocomplete
   @Watch('$route')
-  async getProgramDatasetNames() {
+  async getRecommendedSubEntityDatasetNames(): Promise<void> {
     try {
       const response: Result<Error, string[]> = await ExperimentService.getRecommendedSubEntityDatasetNames(this.activeProgram!.id!, this.experimentUUID);
-      if(response.isErr()) {
-        this.$emit('show-error-notification', 'Unable to retrieve program dataset names');
-      }
-
-      if (response.isSuccess()) {
-        this.programDatasetNames = response.value.map(value => StringFormatters.toStartCase(value));
+      if (response.isErr()) {
+        this.showProgramDatasetNamesError();
         return;
       }
+
+      this.programDatasetNames = response.value.map(value => StringFormatters.toStartCase(value));
     } catch (error) {
-      this.$emit('show-error-notification', 'Unable to retrieve program dataset names');
+      this.showProgramDatasetNamesError();
     }
+  }
+
+  private showProgramDatasetNamesError(): void {
     this.$emit('show-error-notification', 'Unable to retrieve program dataset names');
-    return;
   }
 
   //Retrieves entity names in experiment

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -232,7 +232,6 @@ export default class ExperimentDetails extends ProgramsBase {
   mounted() {
     this.getExperiment();
     this.getDatasetMetadata();
-    this.getRecommendedSubEntityDatasetNames();
   }
 
   private importFile() {
@@ -277,8 +276,17 @@ export default class ExperimentDetails extends ProgramsBase {
     return true;
   }
 
-  private openSubEntityModal() {
+  private async openSubEntityModal(): Promise<void> {
+    await this.refreshSubEntityModalData();
     this.subEntityModalActive = true;
+  }
+
+  // get datasets and recommended names so we have latest data for validation and sub entity autocomplete
+  private async refreshSubEntityModalData(): Promise<void> {
+    await Promise.allSettled([
+      this.getDatasetMetadata(),
+      this.getRecommendedSubEntityDatasetNames()
+    ]);
   }
 
   get experimentUUID(): string {
@@ -329,8 +337,8 @@ export default class ExperimentDetails extends ProgramsBase {
   //   return this.experiment.additionalInfo.environmentsCount;
   // }
 
-  //Get experiment-scoped suggested names for sub-entity modal autocomplete
-  @Watch('$route')
+  // Get experiment-scoped suggested names for sub-entity modal autocomplete.
+  // This is only needed when the modal is opened.
   async getRecommendedSubEntityDatasetNames(): Promise<void> {
     try {
       const response: Result<Error, string[]> = await ExperimentService.getRecommendedSubEntityDatasetNames(this.activeProgram!.id!, this.experimentUUID);


### PR DESCRIPTION
# Description
**Story:** [BI-2836](https://breedinginsight.atlassian.net/browse/BI-2836?atlOrigin=eyJpIjoiNWNjOTExM2FlZGVkNGFkZjlhNjJiNjlmNDJiMGVhYjAiLCJwIjoiaiJ9)

- Updated for bi-api data response format
- Cleaned up naming and some error handling
- Fixed issues with stale data in Sub Entity creation Modal

# Dependencies
- bi-api bug/BI-2836

# Testing
- See acceptance criteria in JIRA card

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [x] I have run SiteImprove on pages impacted by changes 


[BI-2836]: https://breedinginsight.atlassian.net/browse/BI-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ