### PR TITLE
BI-2844 - Update frontend germplasm import template download link

### DIFF
--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -31,7 +31,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/sezsc80x7vxaeor7i8vvn/bi_germplasm_import_template_v11.xls?rlkey=91gf971xi293zqn2x7ago1223&st=46nu0kte&dl=1'"
+                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/qavhqq8tzxr058cldqzgw/bi_germplasm_import_template_v12.xls?rlkey=efxt6a0c441xd65x9zvvtko9n&st=5y2692no&dl=1'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -31,7 +31,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/qavhqq8tzxr058cldqzgw/bi_germplasm_import_template_v12.xls?rlkey=efxt6a0c441xd65x9zvvtko9n&st=5y2692no&dl=1'"
+                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/qavhqq8tzxr058cldqzgw/bi_germplasm_import_template_v12.xls?rlkey=igc1rfim5pjadkpdeu67uno35&st=5h45utag&dl=1'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>


### PR DESCRIPTION
# Description
Link to the story in Jira: [BI-2844](https://breedinginsight.atlassian.net/browse/BI-2844?atlOrigin=eyJpIjoiMTg1OWM4ODZkYTNiNDQ3ZjgyY2FhN2U0NzdlNWJmMzUiLCJwIjoiaiJ9)

This PR updates the frontend germplasm import template download link for BI-2844.

The change replaces the hard-coded germplasm import template URL on the germplasm import page so that it points to the latest approved Dropbox template file (v12) instead of the older v11 file.

This PR preserves the direct-download behavior for the template link by using the Dropbox direct-download format.

No backend logic is changed in this PR. This is a frontend-only update so users downloading the germplasm import template from the import workflow receive the current approved file format and guidance.

# Dependencies
bi-web: feature/BI-2844
bi-api: develop

# Testing
Manual testing performed for this frontend-only change.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2844]: https://breedinginsight.atlassian.net/browse/BI-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ