### PR TITLE
[BI-2806] Route Experiments using trialDbId, use trialDbId to get metadata

### DIFF
--- a/src/breeding-insight/service/ExperimentService.ts
+++ b/src/breeding-insight/service/ExperimentService.ts
@@ -68,16 +68,13 @@ export class ExperimentService {
         if (!trial) {
             return ResultGenerator.err(new Error('Missing or invalid trial'));
         }
-        if (!trial.externalReferences) {
-            return ResultGenerator.err(new Error('Trial is missing external references'));
+
+        let trialDbId = trial.trialDbId;
+        // Throw if trial is missing trialDbId.
+        if (!trialDbId) {
+            return ResultGenerator.err(new Error("Trial is missing a brapi dbId."));
         }
-        // Try to get the /trials external reference.
-        let externalReferenceId = BrAPIUtils.getBreedingInsightId(trial.externalReferences, '/trials');
-        // Throw if trial is missing ExternalReferenceId.
-        if (!externalReferenceId) {
-            return ResultGenerator.err(new Error("Trial is missing external reference."));
-        }
-        return await ExperimentDAO.getDatasetMetadata(programId, externalReferenceId);
+        return await ExperimentDAO.getDatasetMetadata(programId, trialDbId);
     }
     
     static async getUnassignedCollaboratorsByExperiment(programId: string | undefined, experimentId: string): Promise<Result<Error, Collaborator[]>> {

--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -43,7 +43,7 @@
       v-on:search="initSearch"
     >
       <b-table-column label="Title" field="name" cell-class="fixed-width-wrapped" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
-        <router-link v-bind:to="{name: 'experiment_dataset', params: {datasetId: getDefaultDataset(props.row.data).id, programId: activeProgram.id, experimentId: BrAPIUtils.getBreedingInsightId(props.row.data.externalReferences,'/trials')}}">
+        <router-link v-bind:to="{name: 'experiment_dataset', params: {datasetId: getDefaultDataset(props.row.data).id, programId: activeProgram.id, experimentId: props.row.data.trialDbId}}">
           {{ props.row.data.trialName }}
         </router-link>
 


### PR DESCRIPTION
# Description
**Story:** [BI-2806](https://breedinginsight.atlassian.net/browse/BI-2806)

These changes support the removal of BrAPITrials from the ProgramCache.

The Experiment table will now route experiments using their BrAPITrialDbId, and the metadata grab associated will also use the BrAPITrialDbId.

# Dependencies
[bi-api PR](https://github.com/Breeding-Insight/bi-api/pull/516)

# Testing
Regression on just about anything Experiment related, including:

- Experiment creation
- Experiment deletion
- Experiment updates
- Experiment Collaborator checks
- Experiment viewing
- Dataset viewing
- Dataset creation
- Dataset appending

Verify there are no log messages related to caching trials for a program by looking at logs once above tests have been completed.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 


[BI-2806]: https://breedinginsight.atlassian.net/browse/BI-2806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ