### PR TITLE
[BI-2843] - Select Sample Submission During Genotype Upload

### DIFF
--- a/src/breeding-insight/dao/GenoDAO.ts
+++ b/src/breeding-insight/dao/GenoDAO.ts
@@ -20,14 +20,14 @@ import { BiResponse, Response } from '@/breeding-insight/model/BiResponse';
 
 export class GenoDAO {
 
-  static async uploadData(programId: string, experimentId: string, file: File): Promise<any> {
+  static async uploadData(programId: string, submissionId: string, file: File): Promise<any> {
 
     var formData = new FormData();
     formData.append("file", file);
     formData.append("filename", file.name);
 
     const {data} = await api.call({
-      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/geno/import`,
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/submissions/${submissionId}/geno/import`,
       method: 'post', data: formData}
     ) as Response;
 

--- a/src/breeding-insight/service/GenoService.ts
+++ b/src/breeding-insight/service/GenoService.ts
@@ -22,15 +22,15 @@ import { GermplasmGenotype } from '@/breeding-insight/model/GermplasmGenotype';
 
 export class GenoService {
 
-  static async uploadData(programId: string, experimentId: string, file: File): Promise<ImportResponse> {
+  static async uploadData(programId: string, submissionId: string, file: File): Promise<ImportResponse> {
     if (!programId) {
       throw 'Program ID not provided';
     }
-    if (!experimentId) {
-      throw 'Experiment ID not provided';
+    if (!submissionId) {
+      throw 'Submission ID not provided';
     }
 
-    const response: BiResponse = await GenoDAO.uploadData(programId, experimentId, file);
+    const response: BiResponse = await GenoDAO.uploadData(programId, submissionId, file);
     const data: any = response.result;
     return new ImportResponse(data);
   }

--- a/src/views/import/ImportGeno.vue
+++ b/src/views/import/ImportGeno.vue
@@ -25,7 +25,7 @@
               <div class="has-text-dark">
                 <strong>Before You Import...</strong>
                 <br/>
-                Ensure that Sample IDs match to an Exp Unit ID within the chosen experiment
+                Ensure that the Sample IDs in the .vcf import file match to Sample IDs within the chosen sample submission.
               </div>
             </div>
           </div>
@@ -53,10 +53,10 @@
             <div class="columns is-vcentered">
               <div class="column">
                 <BasicSelectField
-                    v-model="upload.experimentId"
-                    v-bind:validations="validations.experimentId"
-                    v-bind:options="experimentOptions"
-                    v-bind:field-name="'Experiment'"
+                    v-model="upload.submissionId"
+                    v-bind:validations="validations.submissionId"
+                    v-bind:options="submissionOptions"
+                    v-bind:field-name="'Sample Submission Project Name'"
                 />
               </div>
             </div>
@@ -83,22 +83,20 @@
 import { Component } from 'vue-property-decorator';
 import ProgramsBase from '@/components/program/ProgramsBase.vue';
 import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
-import { Trial } from '@/breeding-insight/model/Trial';
 import { mapGetters } from 'vuex';
 import { Program } from '@/breeding-insight/model/Program';
-import { BrAPIService, BrAPIType } from '@/breeding-insight/service/BrAPIService';
-import { SortOrder } from '@/breeding-insight/model/Sort';
 import NewDataForm from '@/components/forms/NewDataForm.vue';
 import BasicInputField from '@/components/forms/BasicInputField.vue';
 import BasicSelectField from '@/components/forms/BasicSelectField.vue';
 import FileSelector from '@/components/file-import/FileSelector.vue';
-import { BrAPIUtils } from '@/breeding-insight/utils/BrAPIUtils';
 import { required } from 'vuelidate/lib/validators';
 import { ImportResponse } from '@/breeding-insight/model/import/ImportResponse';
 import { GenoService } from '@/breeding-insight/service/GenoService';
 import { DEACTIVATE_ALL_NOTIFICATIONS } from '@/store/mutation-types';
 import { ImportMappingConfig } from '@/breeding-insight/model/import/ImportMapping';
 import { ImportService } from '@/breeding-insight/service/ImportService';
+import { SampleSubmission } from '@/breeding-insight/model/SampleSubmission';
+import { SampleSubmissionService } from '@/breeding-insight/service/SampleSubmissionService';
 
 @Component({
   components: {
@@ -112,7 +110,7 @@ import { ImportService } from '@/breeding-insight/service/ImportService';
 })
 export default class ImportExperiment extends ProgramsBase {
   private activeProgram?: Program;
-  private experimentOptions: Array<ExperimentOption> = [];
+  private submissionOptions: Array<SubmissionOption> = [];
   private importState: DataFormEventBusHandler = new DataFormEventBusHandler();
   private currentImport?: ImportResponse = new ImportResponse({});
   private systemImportTemplateId?: string;
@@ -120,33 +118,30 @@ export default class ImportExperiment extends ProgramsBase {
   upload: Upload = new Upload({});
 
   uploadValidations = {
-    experimentId: {required},
+    submissionId: {required},
     file: {required}
   }
 
   mounted() {
-    this.loadExperiments();
+    this.loadSampleSubmissions();
     this.getSystemImportTemplateMapping();
   }
 
-  async loadExperiments () {
-    let expResponse = await BrAPIService.get(BrAPIType.EXPERIMENT, this.activeProgram!.id!, { field: undefined, order: SortOrder.Ascending }, { page: 0, pageSize: 1000 }, {"metadata": false});
-    if (expResponse.result && expResponse.result.data) {
-      this.experimentOptions = expResponse.result.data.map((exp: Trial) => {
-        let breedingInsightId = BrAPIUtils.getBreedingInsightId(exp.externalReferences!, "/trials");
-        return new ExperimentOption({
-          id: breedingInsightId!,
-          name: exp.trialName!
+  async loadSampleSubmissions() {
+    const submissions = await SampleSubmissionService.getProgramSampleSubmissions(this.activeProgram!.id!);
+    this.submissionOptions = submissions.map((submission: SampleSubmission) => {
+        return new SubmissionOption({
+              id: submission.id!,
+              name: submission.name!
         });
       });
-      this.$log.debug(JSON.stringify(this.experimentOptions));
+    this.$log.debug(JSON.stringify(this.submissionOptions));
     }
-  }
 
   async save() {
     try {
       this.$store.commit( DEACTIVATE_ALL_NOTIFICATIONS );
-      this.currentImport = await GenoService.uploadData(this.activeProgram!.id!, this.upload.experimentId!, this.upload.file!);
+      this.currentImport = await GenoService.uploadData(this.activeProgram!.id!, this.upload.submissionId!, this.upload.file!);
       const response: ImportResponse = await this.getDataUpload();
       if (response.progress!.statuscode == 500) {
         this.$emit('show-error-notification', 'An unknown error has occurred when processing your import.');
@@ -208,22 +203,22 @@ export default class ImportExperiment extends ProgramsBase {
 
 }
 
-class ExperimentOption {
+class SubmissionOption {
   id: string;
   name: string;
 
-  constructor({id, name}: ExperimentOption) {
+  constructor({id, name}: SubmissionOption) {
     this.id = id;
     this.name = name;
   }
 }
 
 class Upload {
-  experimentId?: string;
+  submissionId?: string;
   file?: File;
 
-  constructor ({experimentId, file}: Upload) {
-    this.experimentId = experimentId;
+  constructor ({submissionId, file}: Upload) {
+    this.submissionId = submissionId;
     this.file = file;
   }
 }


### PR DESCRIPTION
# Description
JIRA story card link: [BI-2843](https://breedinginsight.atlassian.net/browse/BI-2843?atlOrigin=eyJpIjoiOGU5OGU5OGE3MmQ0NDg0ZTgwNjRlZjZlNWI1NDI3NTYiLCJwIjoiaiJ9)

Updated the Genotypic Data import UI to use a sample submission-based flow instead of the previous experiment-based flow.

This change updates the genotype upload screen to:
- load sample submissions for the active program
- replace experiment selection with sample submission selection
- update the genotype upload helper text to reference sample submissions
- send the selected `submissionId` in the genotype upload request instead of `experimentId`

This keeps the BI-2843 frontend aligned with the submission-scoped upload workflow introduced by the dependent BI-2839 backend work.


# Dependencies
bi-web: feature/BI-2843
bi-api: feature/BI-2839

# Testing
Please verify the following in the UI:
- Open `Import Data > Genotypic Data`
- Confirm the screen shows sample submission-based instructional text
- Confirm the selector is a plain dropdown for sample submissions
- Confirm the selector is populated only with sample submissions for the active program
- Attempt import without selecting a sample submission and confirm upload is blocked
- Confirm the sample submission field is highlighted with validation error styling when import is attempted without a selection
- Confirm the inline validation message `Sample Submission Project Name is required` is shown when import is attempted without a selection
- Select a sample submission and a valid `.vcf` file, then confirm the upload request is built using the selected `submissionId`
- Confirm the UI handles the no-sample-submission scenario with the intended empty-state / restricted upload behavior for the current implementation.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2843]: https://breedinginsight.atlassian.net/browse/BI-2843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ