### PR TITLE
BI-2860 - Experimental Collaborators able to create sub entity datasets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v1.3.0+925",
+  "version": "v1.3.0+927",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -96,5 +96,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.7.14"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/453a8fc8f27c1b2d34bd2006f643cd4fff7254d1"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/fa0c131ff60c41316c58f20ec66e288b5cce3423"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v1.3.0+927",
+  "version": "v1.3.0+929",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -96,5 +96,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.7.14"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/fa0c131ff60c41316c58f20ec66e288b5cce3423"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/61680133f70e6f01ce2b5732f072f775546c06ba"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bi-web",
-  "version": "v1.3.0+921",
+  "version": "v1.3.0+925",
   "private": true,
   "scripts": {
     "build": "node $npm_package_config_task_path/build.js --dev-audit-level=critical --prod-audit-level=none",
@@ -96,5 +96,5 @@
     "vue-cli-plugin-axios": "0.0.4",
     "vue-template-compiler": "^2.7.14"
   },
-  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/225abab78b144af30373e7dd973eb08a78cfa7b7"
+  "versionInfo": "https://github.com/Breeding-Insight/bi-web/commit/453a8fc8f27c1b2d34bd2006f643cd4fff7254d1"
 }

--- a/src/breeding-insight/dao/GenoDAO.ts
+++ b/src/breeding-insight/dao/GenoDAO.ts
@@ -20,14 +20,14 @@ import { BiResponse, Response } from '@/breeding-insight/model/BiResponse';
 
 export class GenoDAO {
 
-  static async uploadData(programId: string, experimentId: string, file: File): Promise<any> {
+  static async uploadData(programId: string, submissionId: string, file: File): Promise<any> {
 
     var formData = new FormData();
     formData.append("file", file);
     formData.append("filename", file.name);
 
     const {data} = await api.call({
-      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/experiments/${experimentId}/geno/import`,
+      url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/submissions/${submissionId}/geno/import`,
       method: 'post', data: formData}
     ) as Response;
 

--- a/src/breeding-insight/service/GenoService.ts
+++ b/src/breeding-insight/service/GenoService.ts
@@ -22,15 +22,15 @@ import { GermplasmGenotype } from '@/breeding-insight/model/GermplasmGenotype';
 
 export class GenoService {
 
-  static async uploadData(programId: string, experimentId: string, file: File): Promise<ImportResponse> {
+  static async uploadData(programId: string, submissionId: string, file: File): Promise<ImportResponse> {
     if (!programId) {
       throw 'Program ID not provided';
     }
-    if (!experimentId) {
-      throw 'Experiment ID not provided';
+    if (!submissionId) {
+      throw 'Submission ID not provided';
     }
 
-    const response: BiResponse = await GenoDAO.uploadData(programId, experimentId, file);
+    const response: BiResponse = await GenoDAO.uploadData(programId, submissionId, file);
     const data: any = response.result;
     return new ImportResponse(data);
   }

--- a/src/config/AppAbility.ts
+++ b/src/config/AppAbility.ts
@@ -20,7 +20,7 @@ import {Ability, AbilityClass} from '@casl/ability';
 type Actions = 'manage' | 'create' | 'read' | 'update' | 'delete' | 'archive' | 'access' | 'submit';
 type Subjects = 'ProgramUser' | 'Location' | 'User' | 'AdminSection' | 'Trait' | 'Import' | 'ProgramConfiguration' | 'Submission'
     | 'Experiment' | 'Germplasm' | 'Ontology' | 'SampleManagement' | 'ProgramAdministration' | 'JobManagement' | 'Collaborator' | 'BrAPI'
-    | 'List';
+    | 'SubEntityDataset' | 'List';
 
 export type AppAbility = Ability<[Actions, Subjects]>;
 export const AppAbility = Ability as AbilityClass<AppAbility>;

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -48,6 +48,7 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('update', 'Trait');
     can('archive', 'Trait');
     can('create', 'Import');
+    can('create', 'SubEntityDataset');
     can('delete', 'Experiment');
     can('access', 'ProgramConfiguration');
     can('create', 'ProgramConfiguration');

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -225,7 +225,7 @@ export default class ExperimentDetails extends ProgramsBase {
       new ActionMenuItem('experiment-import-file', 'import-file', 'Import file', this.$ability.can('create', 'Import')),
       new ActionMenuItem('experiment-download-file', 'download-file', 'Download file'),
       new ActionMenuItem('experiment-add-collaborator', 'add-collaborator', 'Add Collaborator',  this.$ability.can('manage', 'Collaborator')),
-      new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset'),
+      new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset', this.$ability.can('create', 'SubEntityDataset')),
       new ActionMenuItem('experiment-delete', 'delete-experiment', 'Delete experiment', this.$ability.can('delete', 'Experiment'))
   ];
 

--- a/src/views/import/ImportGeno.vue
+++ b/src/views/import/ImportGeno.vue
@@ -25,7 +25,7 @@
               <div class="has-text-dark">
                 <strong>Before You Import...</strong>
                 <br/>
-                Ensure that Sample IDs match to an Exp Unit ID within the chosen experiment
+                Ensure that the Sample IDs in the .vcf import file match to Sample IDs within the chosen sample submission.
               </div>
             </div>
           </div>
@@ -53,10 +53,10 @@
             <div class="columns is-vcentered">
               <div class="column">
                 <BasicSelectField
-                    v-model="upload.experimentId"
-                    v-bind:validations="validations.experimentId"
-                    v-bind:options="experimentOptions"
-                    v-bind:field-name="'Experiment'"
+                    v-model="upload.submissionId"
+                    v-bind:validations="validations.submissionId"
+                    v-bind:options="submissionOptions"
+                    v-bind:field-name="'Sample Submission Project Name'"
                 />
               </div>
             </div>
@@ -83,22 +83,20 @@
 import { Component } from 'vue-property-decorator';
 import ProgramsBase from '@/components/program/ProgramsBase.vue';
 import { DataFormEventBusHandler } from '@/components/forms/DataFormEventBusHandler';
-import { Trial } from '@/breeding-insight/model/Trial';
 import { mapGetters } from 'vuex';
 import { Program } from '@/breeding-insight/model/Program';
-import { BrAPIService, BrAPIType } from '@/breeding-insight/service/BrAPIService';
-import { SortOrder } from '@/breeding-insight/model/Sort';
 import NewDataForm from '@/components/forms/NewDataForm.vue';
 import BasicInputField from '@/components/forms/BasicInputField.vue';
 import BasicSelectField from '@/components/forms/BasicSelectField.vue';
 import FileSelector from '@/components/file-import/FileSelector.vue';
-import { BrAPIUtils } from '@/breeding-insight/utils/BrAPIUtils';
 import { required } from 'vuelidate/lib/validators';
 import { ImportResponse } from '@/breeding-insight/model/import/ImportResponse';
 import { GenoService } from '@/breeding-insight/service/GenoService';
 import { DEACTIVATE_ALL_NOTIFICATIONS } from '@/store/mutation-types';
 import { ImportMappingConfig } from '@/breeding-insight/model/import/ImportMapping';
 import { ImportService } from '@/breeding-insight/service/ImportService';
+import { SampleSubmission } from '@/breeding-insight/model/SampleSubmission';
+import { SampleSubmissionService } from '@/breeding-insight/service/SampleSubmissionService';
 
 @Component({
   components: {
@@ -112,7 +110,7 @@ import { ImportService } from '@/breeding-insight/service/ImportService';
 })
 export default class ImportExperiment extends ProgramsBase {
   private activeProgram?: Program;
-  private experimentOptions: Array<ExperimentOption> = [];
+  private submissionOptions: Array<SubmissionOption> = [];
   private importState: DataFormEventBusHandler = new DataFormEventBusHandler();
   private currentImport?: ImportResponse = new ImportResponse({});
   private systemImportTemplateId?: string;
@@ -120,33 +118,30 @@ export default class ImportExperiment extends ProgramsBase {
   upload: Upload = new Upload({});
 
   uploadValidations = {
-    experimentId: {required},
+    submissionId: {required},
     file: {required}
   }
 
   mounted() {
-    this.loadExperiments();
+    this.loadSampleSubmissions();
     this.getSystemImportTemplateMapping();
   }
 
-  async loadExperiments () {
-    let expResponse = await BrAPIService.get(BrAPIType.EXPERIMENT, this.activeProgram!.id!, { field: undefined, order: SortOrder.Ascending }, { page: 0, pageSize: 1000 }, {"metadata": false});
-    if (expResponse.result && expResponse.result.data) {
-      this.experimentOptions = expResponse.result.data.map((exp: Trial) => {
-        let breedingInsightId = BrAPIUtils.getBreedingInsightId(exp.externalReferences!, "/trials");
-        return new ExperimentOption({
-          id: breedingInsightId!,
-          name: exp.trialName!
+  async loadSampleSubmissions() {
+    const submissions = await SampleSubmissionService.getProgramSampleSubmissions(this.activeProgram!.id!);
+    this.submissionOptions = submissions.map((submission: SampleSubmission) => {
+        return new SubmissionOption({
+              id: submission.id!,
+              name: submission.name!
         });
       });
-      this.$log.debug(JSON.stringify(this.experimentOptions));
+    this.$log.debug(JSON.stringify(this.submissionOptions));
     }
-  }
 
   async save() {
     try {
       this.$store.commit( DEACTIVATE_ALL_NOTIFICATIONS );
-      this.currentImport = await GenoService.uploadData(this.activeProgram!.id!, this.upload.experimentId!, this.upload.file!);
+      this.currentImport = await GenoService.uploadData(this.activeProgram!.id!, this.upload.submissionId!, this.upload.file!);
       const response: ImportResponse = await this.getDataUpload();
       if (response.progress!.statuscode == 500) {
         this.$emit('show-error-notification', 'An unknown error has occurred when processing your import.');
@@ -208,22 +203,22 @@ export default class ImportExperiment extends ProgramsBase {
 
 }
 
-class ExperimentOption {
+class SubmissionOption {
   id: string;
   name: string;
 
-  constructor({id, name}: ExperimentOption) {
+  constructor({id, name}: SubmissionOption) {
     this.id = id;
     this.name = name;
   }
 }
 
 class Upload {
-  experimentId?: string;
+  submissionId?: string;
   file?: File;
 
-  constructor ({experimentId, file}: Upload) {
-    this.experimentId = experimentId;
+  constructor ({submissionId, file}: Upload) {
+    this.submissionId = submissionId;
     this.file = file;
   }
 }

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -31,7 +31,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/sezsc80x7vxaeor7i8vvn/bi_germplasm_import_template_v11.xls?rlkey=91gf971xi293zqn2x7ago1223&st=46nu0kte&dl=1'"
+                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/qavhqq8tzxr058cldqzgw/bi_germplasm_import_template_v12.xls?rlkey=efxt6a0c441xd65x9zvvtko9n&st=5y2692no&dl=1'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -31,7 +31,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/qavhqq8tzxr058cldqzgw/bi_germplasm_import_template_v12.xls?rlkey=efxt6a0c441xd65x9zvvtko9n&st=5y2692no&dl=1'"
+                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/qavhqq8tzxr058cldqzgw/bi_germplasm_import_template_v12.xls?rlkey=igc1rfim5pjadkpdeu67uno35&st=5h45utag&dl=1'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>


### PR DESCRIPTION
# Description
JIRA story card link: [BI-2860](https://breedinginsight.atlassian.net/browse/BI-2860?atlOrigin=eyJpIjoiMjU2ZjAzYTVkZjRmNGFlMDkzNDMxY2ZmMTMwMjc3MzkiLCJwIjoiaiJ9)

This PR updates the experiment details UI so that `Experimental Collaborator` users cannot click `Create Sub-Entity Dataset` from the `Manage Experiment` dropdown.

Previously, the option appeared active for collaborator users even though they should not be allowed to create sub-entity datasets. After this change, the option is disabled/grayed out for that role, while `Download file` remains available.

And it depends on the bug/BI-2860 for the backend API.

# Dependencies
bi-web: bug/BI-2860
bi-api: bug/BI-2860

# Testing
- Log in as a Program Administrator
- Create or use a program and experiment
- Add a second user to the program as `Experimental Collaborator`
- Add that user as a collaborator to the experiment
- Log in as the collaborator user
- Open the experiment and click `Manage Experiment`
- Verify `Create Sub-Entity Dataset` is disabled/grayed out
- Verify `Download file` is still enabled and works

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2860]: https://breedinginsight.atlassian.net/browse/BI-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ