### PR TITLE
BI-2860 - Experimental Collaborators able to create sub entity datasets

### DIFF
--- a/src/config/AppAbility.ts
+++ b/src/config/AppAbility.ts
@@ -20,7 +20,7 @@ import {Ability, AbilityClass} from '@casl/ability';
 type Actions = 'manage' | 'create' | 'read' | 'update' | 'delete' | 'archive' | 'access' | 'submit';
 type Subjects = 'ProgramUser' | 'Location' | 'User' | 'AdminSection' | 'Trait' | 'Import' | 'ProgramConfiguration' | 'Submission'
     | 'Experiment' | 'Germplasm' | 'Ontology' | 'SampleManagement' | 'ProgramAdministration' | 'JobManagement' | 'Collaborator' | 'BrAPI'
-    | 'List';
+    | 'SubEntityDataset' | 'List';
 
 export type AppAbility = Ability<[Actions, Subjects]>;
 export const AppAbility = Ability as AbilityClass<AppAbility>;

--- a/src/config/ability.ts
+++ b/src/config/ability.ts
@@ -48,6 +48,7 @@ const rolePermissions: Record<string, DefinePermissions> = {
     can('update', 'Trait');
     can('archive', 'Trait');
     can('create', 'Import');
+    can('create', 'SubEntityDataset');
     can('delete', 'Experiment');
     can('access', 'ProgramConfiguration');
     can('create', 'ProgramConfiguration');

--- a/src/views/experiments-and-observations/ExperimentDetails.vue
+++ b/src/views/experiments-and-observations/ExperimentDetails.vue
@@ -225,7 +225,7 @@ export default class ExperimentDetails extends ProgramsBase {
       new ActionMenuItem('experiment-import-file', 'import-file', 'Import file', this.$ability.can('create', 'Import')),
       new ActionMenuItem('experiment-download-file', 'download-file', 'Download file'),
       new ActionMenuItem('experiment-add-collaborator', 'add-collaborator', 'Add Collaborator',  this.$ability.can('manage', 'Collaborator')),
-      new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset'),
+      new ActionMenuItem('experiment-create-sub-entity-dataset', 'create-sub-entity-dataset', 'Create Sub-Entity Dataset', this.$ability.can('create', 'SubEntityDataset')),
       new ActionMenuItem('experiment-delete', 'delete-experiment', 'Delete experiment', this.$ability.can('delete', 'Experiment'))
   ];
 


### PR DESCRIPTION
# Description
JIRA story card link: [BI-2860](https://breedinginsight.atlassian.net/browse/BI-2860?atlOrigin=eyJpIjoiMjU2ZjAzYTVkZjRmNGFlMDkzNDMxY2ZmMTMwMjc3MzkiLCJwIjoiaiJ9)

This PR updates the experiment details UI so that `Experimental Collaborator` users cannot click `Create Sub-Entity Dataset` from the `Manage Experiment` dropdown.

Previously, the option appeared active for collaborator users even though they should not be allowed to create sub-entity datasets. After this change, the option is disabled/grayed out for that role, while `Download file` remains available.

And it depends on the bug/BI-2860-v1.3 for the backend API.

# Dependencies
bi-web: bug/BI-2860-v1.3
bi-api: bug/BI-2860-v1.3

# Testing
- Log in as a Program Administrator
- Create or use a program and experiment
- Add a second user to the program as `Experimental Collaborator`
- Add that user as a collaborator to the experiment
- Log in as the collaborator user
- Open the experiment and click `Manage Experiment`
- Verify `Create Sub-Entity Dataset` is disabled/grayed out
- Verify `Download file` is still enabled and works

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2860]: https://breedinginsight.atlassian.net/browse/BI-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ