### PR TITLE
[BI-2878] Germplasm External UID missing from UI

### DIFF
--- a/src/breeding-insight/model/Sort.ts
+++ b/src/breeding-insight/model/Sort.ts
@@ -168,6 +168,7 @@ export enum GermplasmSortField {
   Pedigree = "pedigree",
   FemaleParent = "femaleParentGID",
   MaleParent = "maleParentGID",
+  ExternalUID = "externalUID",
   CreatedDate = "createdDate",
   UserName = "createdByUserName"
 }

--- a/src/breeding-insight/utils/GermplasmUtils.ts
+++ b/src/breeding-insight/utils/GermplasmUtils.ts
@@ -18,6 +18,7 @@
 import moment from "moment";
 import {Germplasm} from "@/breeding-insight/brapi/model/germplasm";
 import {MOMENT_BRAPI_DATE_FORMAT} from "@/breeding-insight/utils/BrAPIDateTime";
+import {ExternalReferences} from "@/breeding-insight/brapi/model/externalReferences";
 
 // The moment.js interpretable format for Date values sent and received via the BI API.
 export const MOMENT_DATE_PERSISTED_FORMAT = 'DD/MM/YYYY h:mm:ss';

--- a/src/components/germplasm/GermplasmTable.vue
+++ b/src/components/germplasm/GermplasmTable.vue
@@ -47,6 +47,9 @@
             v-bind:germplasmGID="Pedigree.parsePedigreeStringWithUnknowns(props.row.data.pedigree,props.row.data.additionalInfo.femaleParentUnknown,props.row.data.additionalInfo.maleParentUnknown, props.row.data.accessionNumber).maleParent"
         > </GermplasmLink>
       </b-table-column>
+      <b-table-column field="externalUID" label="External UID" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
+        {{ GermplasmUtils.getExternalUID(props.row.data) }}
+      </b-table-column>
       <b-table-column field="createdDate" label="Created Date" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})" searchable>
         {{ GermplasmUtils.getCreatedDate(props.row.data) }}
       </b-table-column>
@@ -134,6 +137,7 @@ export default class GermplasmTable extends Vue {
     'seedSource': GermplasmSortField.SeedSource,
     'femaleParentGID': GermplasmSortField.FemaleParent,
     'maleParentGID': GermplasmSortField.MaleParent,
+    'externalUID' : GermplasmSortField.ExternalUID,
     'createdDate': GermplasmSortField.CreatedDate,
     'createdByUserName': GermplasmSortField.UserName,
   };


### PR DESCRIPTION
[BI-2878](https://breedinginsight.atlassian.net/browse/BI-2878) Germplasm External UID missing from UI
Dependencies

bi-api: feature/[BI-2878](https://breedinginsight.atlassian.net/browse/BI-2878)

# Testing

1. Import Germplasm with both a Seed Source and a External UID
2. Go to `Germplasm` page (list of all Germplasm).
**Expected Result:**
- The External UID should be displayed for the newly imported Germplasm.
3. Press the `Lists` tab.
4. Press the `Details` link for the newly imported Germplasm List.
**Expected Result:**
- The External UID should be displayed for the newly imported Germplasm.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [x] I have run SiteImprove on pages impacted by changes 


[BI-2878]: https://breedinginsight.atlassian.net/browse/BI-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2878]: https://breedinginsight.atlassian.net/browse/BI-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ