### PR TITLE
Use trialDbId instead of bi-generated exref for download on top-level exp page

### DIFF
--- a/src/components/experiments/ExperimentsObservationsTable.vue
+++ b/src/components/experiments/ExperimentsObservationsTable.vue
@@ -219,7 +219,7 @@ export default class ExperimentsObservationsTable extends Vue {
   openDownloadModal(experiment: Trial) {
     this.downloadExperiment = experiment;
     this.downloadModalTitle = "Download " + experiment.trialName;
-    this.downloadTrialId = BrAPIUtils.getBreedingInsightId(experiment.externalReferences!, '/trials');
+    this.downloadTrialId = experiment.trialDbId;
     this.downloadModalActive = true;
   }
 


### PR DESCRIPTION

# Description
**Story:** [BI-2934](https://breedinginsight.atlassian.net/browse/BI-2934)

_Please include a summary of the change that was made._
Use trialDbId instead of bi-generated exref for download on top-level exp page


# Dependencies
None
# Testing
For a created experiment with data, and subentity data, do the following

* Click on Experiments tab for program
* Click `Download` button to bring up download experiement modal
* Choose either top-level or any sub-entity dataset to download
* Verify download completes and looks okay

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 


[BI-2934]: https://breedinginsight.atlassian.net/browse/BI-2934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ