### PR TITLE
[BI-2850] - Add download options to new genotyping page

### DIFF
--- a/src/breeding-insight/model/GenotypeImport.ts
+++ b/src/breeding-insight/model/GenotypeImport.ts
@@ -16,6 +16,7 @@
  */
 
 export class GenotypeImport {
+  genotypeImportId?: string;
   sampleSubmissionId?: string;
   projectNameForSampleSubmission?: string;
   sampleSubmissionCreatedBy?: string;
@@ -24,6 +25,7 @@ export class GenotypeImport {
   genotypingImportBy?: string;
 
   constructor({
+                genotypeImportId,
                 sampleSubmissionId,
                 projectNameForSampleSubmission,
                 sampleSubmissionCreatedBy,
@@ -31,6 +33,7 @@ export class GenotypeImport {
                 genotypingImportDate,
                 genotypingImportBy
               }: GenotypeImport = {}) {
+    this.genotypeImportId = genotypeImportId;
     this.sampleSubmissionId = sampleSubmissionId;
     this.projectNameForSampleSubmission = projectNameForSampleSubmission;
     this.sampleSubmissionCreatedBy = sampleSubmissionCreatedBy;

--- a/src/components/VueFeatherIconPack.vue
+++ b/src/components/VueFeatherIconPack.vue
@@ -27,6 +27,7 @@ import { ArrowDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   ChevronUpIcon,
+  DownloadIcon,
   LogOutIcon,
   UserIcon} from "vue-feather-icons";
 
@@ -39,7 +40,8 @@ export default {
     ArrowUpIcon,
     ArrowDownIcon,
     LogOutIcon,
-    UserIcon
+    UserIcon,
+    DownloadIcon
   },
   props: {
     icon: [String, Array],

--- a/src/views/genotyping/Genotyping.vue
+++ b/src/views/genotyping/Genotyping.vue
@@ -110,6 +110,9 @@
       >
         {{ displayValue(props.row.data.genotypingImportBy) }}
       </b-table-column>
+      <b-table-column field="data.genotypeImportId" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+        <a href="javascript:void(0)" v-on:click="downloadFile(props.row.data)"><DownloadIcon></DownloadIcon> Download</a>
+      </b-table-column>
 
       <template v-slot:emptyMessage>
         <p class="has-text-weight-bold">
@@ -123,7 +126,7 @@
 <script lang="ts">
 import {Component, Watch} from 'vue-property-decorator';
 import {mapGetters} from 'vuex';
-import {PlusCircleIcon} from 'vue-feather-icons';
+import {PlusCircleIcon, DownloadIcon} from 'vue-feather-icons';
 import ProgramsBase from '@/components/program/ProgramsBase.vue';
 import ExpandableTable from '@/components/tables/expandableTable/ExpandableTable.vue';
 import {Program} from '@/breeding-insight/model/Program';
@@ -143,7 +146,8 @@ import {
 @Component({
   components: {
     ExpandableTable,
-    PlusCircleIcon
+    PlusCircleIcon,
+    DownloadIcon
   },
   computed: {
     ...mapGetters([
@@ -260,6 +264,14 @@ export default class Genotyping extends ProgramsBase {
 
   displayValue(value?: string): string {
     return value || '';
+  }
+
+  private downloadFile(genotype: GenotypeImport) {
+    if (this.activeProgram) {
+      window.open(process.env.VUE_APP_BI_API_ROOT + '/v1/programs/' + this.activeProgram.id + '/geno/imports/' + genotype.genotypeImportId + '/download' , '_blank');
+      return true;
+    }
+    return false;
   }
 }
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-2850 - Add download options to new genotyping page](https://breedinginsight.atlassian.net/browse/BI-2850)

Front end support for downloading genotype vcf files

Added download column to genotyping table in Genotyping.vue and associated method call to endpoint
Modified GenotypeImport model to include genotypeImportId
Added download icon to VueFeatherIconPack.vue

# Dependencies
bi-api: feature/BI-2901

# Testing
See acceptance criteria

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 
