### PR TITLE
BI-2941 - Genotype Data Import erroring out when the file size is too Large

### DIFF
--- a/src/views/import/ImportGeno.vue
+++ b/src/views/import/ImportGeno.vue
@@ -151,7 +151,9 @@ export default class ImportExperiment extends ProgramsBase {
         this.$emit('show-success-notification', `Genotypic data has uploaded and is being processed.  Check the 'Jobs' page for processing status`);
       }
     } catch (e) {
-      if (e.response && e.response.statusText && e.response.status != 500) {
+      if (e.response && e.response.status == 413) {
+        this.$emit('show-error-notification', 'Uploaded file exceeds the maximum allowed file size.');
+      } else if (e.response && e.response.statusText && e.response.status != 500) {
         this.$emit('show-error-notification', e.response.statusText);
       } else {
         this.$emit('show-error-notification', 'An unknown error has occurred when uploading your import.');


### PR DESCRIPTION
# Description
**Story:** [BI-2941](https://breedinginsight.atlassian.net/browse/BI-2941)

This change updates the Genotype Data import UI to show a clear user-friendly error message when an oversized VCF upload is rejected by the backend.

For BI-2941, the backend size limit issue was addressed by increasing the supported multipart upload size to 800MB. The remaining gap was the user experience when a file larger than the supported limit is uploaded. Previously, the UI displayed the generic `Request Entity Too Large` message. This PR updates the Genotype Data import flow to catch the backend `413` response and show a clearer message explaining that the uploaded file exceeds the maximum allowed file size.

This keeps the backend as the source of truth for upload limits while satisfying the acceptance criteria for the error message shown in the UI.

# Dependencies
bi-web: feature/BI-2941
bi-api: feature/BI-2941

# Testing
1. Open Import Data -> Genotypic Data.
2. Select a sample submission.
3. Upload a VCF file below 800MB and confirm the import continues through the normal flow.
4. Confirm the import job is visible on the Jobs page with the expected status flow.
5. Upload a VCF file larger than the supported backend file size limit.
6. Confirm the request fails with a clear UI error message.
7. Confirm the user does not see the generic `Request Entity Too Large` message.
The new error will look as shown below:
<img width="625" height="337" alt="image" src="https://github.com/user-attachments/assets/6c9c8612-08f2-4e35-8b4c-7f03bf9bad12" />


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth

[BI-2941]: https://breedinginsight.atlassian.net/browse/BI-2941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ