### PR TITLE
BI-2869 - Show completion notification and reset after genotype data import finishes

### DIFF
--- a/src/breeding-insight/dao/GenoDAO.ts
+++ b/src/breeding-insight/dao/GenoDAO.ts
@@ -26,7 +26,6 @@ export class GenoDAO {
 
     var formData = new FormData();
     formData.append("file", file);
-    formData.append("filename", file.name);
 
     const {data} = await api.call({
       url: `${process.env.VUE_APP_BI_API_V1_PATH}/programs/${programId}/submissions/${submissionId}/geno/import`,

--- a/src/views/import/ImportGeno.vue
+++ b/src/views/import/ImportGeno.vue
@@ -46,7 +46,7 @@
             v-bind:save-button-label="'Import'"
             v-bind:show-cancel-button="false"
             v-on:submit="save"
-            v-on:cancel="cancel"
+            v-on:cancel="clearForm"
             v-on:show-error-notification="$emit('show-error-notification', $event)"
         >
           <template v-slot="validations">
@@ -54,6 +54,7 @@
               <div class="column">
                 <BasicSelectField
                     v-model="upload.submissionId"
+                    v-bind:selected-id="upload.submissionId"
                     v-bind:validations="validations.submissionId"
                     v-bind:options="submissionOptions"
                     v-bind:field-name="'Sample Submission Project Name'"
@@ -146,9 +147,10 @@ export default class ImportExperiment extends ProgramsBase {
       if (response.progress!.statuscode == 500) {
         this.$emit('show-error-notification', 'An unknown error has occurred when processing your import.');
       } else if (response.progress!.statuscode !== 200) {
-        this.$emit('show-error-notification', `Error: ${response.progress!.message}`);
+        this.$emit('show-error-notification', `${response.progress!.message}`);
       } else {
-        this.$emit('show-success-notification', `Genotypic data has uploaded and is being processed.  Check the 'Jobs' page for processing status`);
+        this.$emit('show-success-notification', `Imported genotype data has been added to ${this.activeProgram!.name!}`);
+        this.clearForm();
       }
     } catch (e) {
       if (e.response && e.response.status == 413) {
@@ -159,12 +161,19 @@ export default class ImportExperiment extends ProgramsBase {
         this.$emit('show-error-notification', 'An unknown error has occurred when uploading your import.');
       }
     } finally {
+      if (this.upload.file) {
+        this.clearFile();
+      }
       this.importState.bus.$emit(DataFormEventBusHandler.SAVE_COMPLETE_EVENT);
     }
   }
 
-  cancel() {
+  clearForm() {
     this.upload = new Upload({});
+  }
+
+  clearFile() {
+    this.upload.clearFile();
   }
 
   async getSystemImportTemplateMapping() {
@@ -222,6 +231,10 @@ class Upload {
   constructor ({submissionId, file}: Upload) {
     this.submissionId = submissionId;
     this.file = file;
+  }
+
+  clearFile() {
+    this.file = undefined;
   }
 }
 </script>


### PR DESCRIPTION
# Description
**Story:** [BI-2869](https://breedinginsight.atlassian.net/browse/BI-2869?atlOrigin=eyJpIjoiMzE0MGUyNDhkMmY2NDc4ZGJjMGE2NjQyNGRmYzBlNDEiLCJwIjoiaiJ9)

- Removed "filename" from form data sent to backend that was causing exception and breaking message responses
- Updated messages to be consistent with other imports
- Updated form behavior to be consistent with other imports

# Dependencies
- bi-api develop

# Testing
- See acceptance criteria in card

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [ ] I have run SiteImprove on pages impacted by changes 


[BI-2869]: https://breedinginsight.atlassian.net/browse/BI-2869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ