### PR TITLE
[BI-2850] - Add download options to new genotyping page - QA fix

### DIFF
--- a/src/components/VueFeatherIconPack.vue
+++ b/src/components/VueFeatherIconPack.vue
@@ -28,6 +28,7 @@ import { ArrowDownIcon,
   ChevronRightIcon,
   ChevronUpIcon,
   DownloadIcon,
+  UploadIcon,
   LogOutIcon,
   UserIcon} from "vue-feather-icons";
 
@@ -41,7 +42,8 @@ export default {
     ArrowDownIcon,
     LogOutIcon,
     UserIcon,
-    DownloadIcon
+    DownloadIcon,
+    UploadIcon
   },
   props: {
     icon: [String, Array],

--- a/src/views/genotyping/Genotyping.vue
+++ b/src/views/genotyping/Genotyping.vue
@@ -26,7 +26,7 @@
       v-on:click="importGenotypingFile"
     >
       <span class="icon is-small">
-        <PlusCircleIcon
+        <UploadIcon
           size="1.5x"
           aria-hidden="true"
         />
@@ -110,7 +110,7 @@
       >
         {{ displayValue(props.row.data.genotypingImportBy) }}
       </b-table-column>
-      <b-table-column field="data.genotypeImportId" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
+      <b-table-column width="150" field="data.genotypeImportId" sortable v-slot="props" :th-attrs="(column) => ({scope:'col'})">
         <a href="javascript:void(0)" v-on:click="downloadFile(props.row.data)"><DownloadIcon></DownloadIcon> Download</a>
       </b-table-column>
 
@@ -126,7 +126,7 @@
 <script lang="ts">
 import {Component, Watch} from 'vue-property-decorator';
 import {mapGetters} from 'vuex';
-import {PlusCircleIcon, DownloadIcon} from 'vue-feather-icons';
+import {UploadIcon, DownloadIcon} from 'vue-feather-icons';
 import ProgramsBase from '@/components/program/ProgramsBase.vue';
 import ExpandableTable from '@/components/tables/expandableTable/ExpandableTable.vue';
 import {Program} from '@/breeding-insight/model/Program';
@@ -146,8 +146,8 @@ import {
 @Component({
   components: {
     ExpandableTable,
-    PlusCircleIcon,
-    DownloadIcon
+    DownloadIcon,
+    UploadIcon
   },
   computed: {
     ...mapGetters([


### PR DESCRIPTION
# Description
**Story:** [BI-2850 - Add download options to new genotyping page](https://breedinginsight.atlassian.net/browse/BI-2850)

Previous PR for this card: https://github.com/Breeding-Insight/bi-web/pull/474

QA fixes:
- Setting the download column to have a fixed width to prevent wrapping
- Updating upload icon on genotyping page to match figma

# Dependencies
bi-api: develop

# Testing
See acceptance criteria

Also:
- Change window size, ensure download column stays the same width and doesn't wrap
- Ensure the genotype import button now has an upload icon rather than a plus in circle

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 
