### PR TITLE
BI-2958: Update Germplasm Import Template Source Description.

### DIFF
--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -31,7 +31,7 @@
 
       <template v-slot:importInfoTemplateMessageBox>
         <ImportInfoTemplateMessageBox v-bind:import-type-name="'Germplasm'"
-                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/qavhqq8tzxr058cldqzgw/bi_germplasm_import_template_v12.xls?rlkey=igc1rfim5pjadkpdeu67uno35&st=5h45utag&dl=1'"
+                                      v-bind:template-url="'https://www.dropbox.com/scl/fi/nc3h9vzidx4f6eg5fvw8o/bi_germplasm_import_template_v13.xls?rlkey=dxe2r2ijnixy29uyf40cle6k7&st=0o70d7gz&dl=1'"
                                       class="mb-5">
           <strong>Before You Import...</strong>
           <br/>


### PR DESCRIPTION
# Description
**Story:** [BI-2958](https://breedinginsight.atlassian.net/browse/BI-2958)

Updated the Germplasm import template download used in the Germplasm import flow so the README sheet no longer describes `Source` as being tied to `External UID`.

This change is frontend-scoped and is limited to the downloadable Germplasm template reference used from the Germplasm import page. No backend import logic was changed.

# Dependencies
bi-web: feature/BI-2958
bi-api: develop

# Testing
Manual testing performed:

1. Open the Germplasm import flow in the UI.
2. Click `Download the Germplasm Import Template`.
3. Open the downloaded workbook. You will now see V13 file being downloaded.
4. Go to the `README` sheet.
5. Verify the `Source` description does not contain:
   `If External UID present, assumed to be the source associated with the External UID.`

Also verify no other Germplasm import flow behavior is changed by this update.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth

[BI-2958]: https://breedinginsight.atlassian.net/browse/BI-2958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ