### PR TITLE
BI-2936 - Prevent deleting sample submissions that have genotype imports associated with them

### DIFF
--- a/src/views/sample-mgmt/SubmissionDetails.vue
+++ b/src/views/sample-mgmt/SubmissionDetails.vue
@@ -764,7 +764,7 @@ export default class SubmissionDetails extends ProgramsBase {
           const response = result.value.response;
 
           if (response && response.status === 405) {
-            this.$emit('show-error-notification', `Cannot delete a submission with submitted or completed status`);
+            this.$emit('show-error-notification', response.data);
             return;
           }
           this.$emit('show-error-notification', `Unknown error deleting submission`);


### PR DESCRIPTION
# Description
**Story:** [BI-2936](https://breedinginsight.atlassian.net/browse/BI-2936?atlOrigin=eyJpIjoiMjQ1NDZjOTdhZDQ5NGZjMzgwNWFjMTg3NTJlZjAyODAiLCJwIjoiaiJ9)

- Update error message for sample submission deletion error

# Dependencies
- bi-api feature/BI-2936

# Testing
- See card acceptance criteria

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 


[BI-2936]: https://breedinginsight.atlassian.net/browse/BI-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ