### PR TITLE
BI-2959: Use External UID Source for Germplasm External UID References

### DIFF
--- a/src/breeding-insight/model/import/germplasm/ExternalUID.ts
+++ b/src/breeding-insight/model/import/germplasm/ExternalUID.ts
@@ -18,17 +18,16 @@
 export class ExternalUID {
 
   /**
-   * Get ExternalUID value from germplasm BrAPI external references array based
-   * on the seedSource value
+   * Get ExternalUID value from germplasm BrAPI external references array using
+   * the canonical External UID reference source.
    *
    * @param externalReferences
-   * @param source
    */
-  public static getExternalUIDFromExternalReferences(externalReferences: Array<any>, source : string) : string | undefined {
-    if (externalReferences === undefined || source === undefined) {
+  public static getExternalUIDFromExternalReferences(externalReferences: Array<any>) : string | undefined {
+    if (externalReferences === undefined) {
       return undefined;
     }
-    const externalUID = externalReferences.find( ({ referenceSource }) => referenceSource === source );
+    const externalUID = externalReferences.find( ({ referenceSource }) => referenceSource === "External UID" );
     if (externalUID !== undefined) {
       return externalUID.referenceID;
     } else

--- a/src/breeding-insight/utils/GermplasmUtils.ts
+++ b/src/breeding-insight/utils/GermplasmUtils.ts
@@ -26,8 +26,8 @@ export const MOMENT_DATE_PERSISTED_FORMAT = 'DD/MM/YYYY h:mm:ss';
 export class GermplasmUtils {
     static getExternalUID(germplasm: Germplasm): string | undefined {
         let val;
-        if (germplasm.externalReferences && germplasm.seedSource) {
-            val = germplasm.externalReferences!.filter(ref => ref.referenceSource == germplasm.seedSource!)
+        if (germplasm.externalReferences) {
+            val = germplasm.externalReferences!.filter(ref => ref.referenceSource == "External UID")
                 .map(ref => ref.referenceID);
             return val ? val[0]: "";
         }

--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -136,7 +136,7 @@
             {{ props.row.data.brAPIObject.additionalInfo.maleParentEntryNo }}
           </b-table-column>
           <b-table-column field="externalUID" label="External UID" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
-            {{ ExternalUID.getExternalUIDFromExternalReferences(props.row.data.brAPIObject.externalReferences, props.row.data.brAPIObject.seedSource) }}
+            {{ ExternalUID.getExternalUIDFromExternalReferences(props.row.data.brAPIObject.externalReferences) }}
           </b-table-column>
           <b-table-column field="synonyms" label="Synonyms" v-slot="props" :th-attrs="(column) => ({scope:'col'})">
             {{ GermplasmUtils.formatSynonyms(props.row.data.brAPIObject.synonyms) }}

--- a/tests/unit/models/externalUID.spec.ts
+++ b/tests/unit/models/externalUID.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExternalUID } from "@/breeding-insight/model/import/germplasm/ExternalUID";
+
+describe('ExternalUID helper returns the correct values.', () => {
+
+    it('Returns External UID when canonical External UID reference exists', () => {
+        const externalReferences = [
+            { referenceSource: "USDA", referenceID: "OLD-123" },
+            { referenceSource: "External UID", referenceID: "ABC-123" }
+        ];
+
+        expect(ExternalUID.getExternalUIDFromExternalReferences(externalReferences)).toBe("ABC-123");
+    });
+
+    it('Returns External UID when canonical External UID reference exists and source is blank', () => {
+        const externalReferences = [
+            { referenceSource: "External UID", referenceID: "ABC-456" }
+        ];
+
+        expect(ExternalUID.getExternalUIDFromExternalReferences(externalReferences)).toBe("ABC-456");
+    });
+
+    it('Returns undefined when canonical External UID reference does not exist', () => {
+        const externalReferences = [
+            { referenceSource: "USDA", referenceID: "OLD-123" }
+        ];
+
+        expect(ExternalUID.getExternalUIDFromExternalReferences(externalReferences)).toBeUndefined();
+    });
+
+    it('Returns undefined when external references are undefined', () => {
+        expect(ExternalUID.getExternalUIDFromExternalReferences(undefined as any)).toBeUndefined();
+    });
+
+});

--- a/tests/unit/models/germplasmUtils.spec.ts
+++ b/tests/unit/models/germplasmUtils.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GermplasmUtils } from "@/breeding-insight/utils/GermplasmUtils";
+
+describe('GermplasmUtils External UID helper returns the correct values.', () => {
+
+    it('Returns External UID from canonical External UID reference source', () => {
+        const germplasm: any = {
+            seedSource: "USDA",
+            externalReferences: [
+                { referenceSource: "USDA", referenceID: "OLD-123" },
+                { referenceSource: "External UID", referenceID: "ABC-123" }
+            ]
+        };
+
+        expect(GermplasmUtils.getExternalUID(germplasm)).toBe("ABC-123");
+    });
+
+    it('Returns External UID when seed source is blank and canonical External UID reference exists', () => {
+        const germplasm: any = {
+            externalReferences: [
+                { referenceSource: "External UID", referenceID: "ABC-456" }
+            ]
+        };
+
+        expect(GermplasmUtils.getExternalUID(germplasm)).toBe("ABC-456");
+    });
+
+    it('Returns undefined when canonical External UID reference does not exist', () => {
+        const germplasm: any = {
+            seedSource: "USDA",
+            externalReferences: [
+                { referenceSource: "USDA", referenceID: "OLD-123" }
+            ]
+        };
+
+        expect(GermplasmUtils.getExternalUID(germplasm)).toBeUndefined();
+    });
+
+    it('Returns empty string when external references are missing', () => {
+        const germplasm: any = {};
+
+        expect(GermplasmUtils.getExternalUID(germplasm)).toBe("");
+    });
+
+});


### PR DESCRIPTION
# Description
**Story:** [BI-2959](https://breedinginsight.atlassian.net/browse/BI-2959)

This PR updates the frontend germplasm External UID display logic to match the BI-2959 backend behavior.

External UID is now resolved using the canonical external reference source `"External UID"` instead of the germplasm `Source` / `seedSource` value. This fixes External UID display in:
- germplasm import preview
- germplasm list / all germplasm views

This PR also adds frontend unit tests for the updated External UID lookup behavior.

# Dependencies
bi-web: feature/BI-2959
bi-api: feature/BI-2959 

# Testing
Verified manually:
- germplasm import preview displays External UID when both `Source` and `External UID` are present
- germplasm import preview displays External UID when `Source` is blank and `External UID` is present
- germplasm import preview does not display External UID when no canonical External UID reference exists
- committed germplasm UI resolves External UID from the canonical `"External UID"` reference source

Verified with unit tests:
- `externaluid.spec.ts`
- `germplasmutils.spec.ts`

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have create/modified unit and/or integration tests to cover this change or tests are not applicable
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth

[BI-2959]: https://breedinginsight.atlassian.net/browse/BI-2959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ