### PR TITLE
[BI-2915] Update dataset fe to use observationUnitDbId

### DIFF
--- a/src/breeding-insight/service/StudyService.ts
+++ b/src/breeding-insight/service/StudyService.ts
@@ -40,6 +40,7 @@ export class StudyService {
       
       let response: Result<Error, BiResponse>;
       if (trial !== undefined && trial.externalReferences !== undefined) {
+        // TODO: Change to trialDbId when fixing bi-brapi study endpoint [BI-2962]
         let externalReferenceId = BrAPIUtils.getBreedingInsightId(trial.externalReferences, '/trials');
         // Throw if trial is missing ExternalReferenceId.
         if (externalReferenceId === undefined) throw new Error("Trial is missing external reference.");

--- a/src/views/import/Dataset.vue
+++ b/src/views/import/Dataset.vue
@@ -510,13 +510,13 @@ export default class Dataset extends ProgramsBase {
 
       if(!this.isSubEntity){
         datasetTableRow.expUnitId = this.removeUnique(unit.observationUnitName);
-        datasetTableRow.obsUnitId = BrAPIUtils.getBreedingInsightId(unit.externalReferences, "/observationunits");
+        datasetTableRow.obsUnitId = unit.observationUnitDbId;
       } else {
         let parentObsInfo = unit.observationUnitPosition.observationLevelRelationships.find((val) => val.levelOrder === 0);
         if (parentObsInfo) datasetTableRow.obsUnitId = this.removeUnique(parentObsInfo.levelCode);
         datasetTableRow.expUnitId = unit.additionalInfo.expUnitID;
         datasetTableRow.subExpUnitId = this.removeUnique(unit.observationUnitName);
-        datasetTableRow.subObsUnitId = BrAPIUtils.getBreedingInsightId(unit.externalReferences, "/observationunits");
+        datasetTableRow.subObsUnitId = unit.observationUnitDbId;
       }
 
       // Env Year


### PR DESCRIPTION
# Description
**Story:** [BI-2915](https://breedinginsight.atlassian.net/browse/BI-2915)

Frontend displays referencing observationUnit.externalReferences were replaced with observationUnitDbId so now instead of showing exrefs in frontend it shows brapiDbId.



# Dependencies

# Testing


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 


[BI-2915]: https://breedinginsight.atlassian.net/browse/BI-2915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ