### PR TITLE
[BI-2981] - Improve message: duplicate germplasm detected

### DIFF
--- a/src/views/import/ImportGermplasm.vue
+++ b/src/views/import/ImportGermplasm.vue
@@ -81,7 +81,7 @@
             <p>New Germplasm count: {{ statistics.Germplasm.newObjectCount }}</p>
             <p>New Pedigree Connections: {{ statistics["Pedigree Connections"].newObjectCount }}</p>
             <template v-if="duplicatesPresent(rows)">
-              <p>Duplicate names detected and are highlighted in yellow and show a <alert-triangle-icon size="1.2x" class="icon-align"/> icon.</p>
+              <p>Duplicated records detected and highlighted in yellow with a <alert-triangle-icon size="1.2x" class="icon-align"/> icon. If valid GID is specified, the existing record will be referenced in the new list. If no GID is specified, a new record with duplicated name will be created.</p>
             </template>
 
           </div>


### PR DESCRIPTION
# Description
**Story:** [BI-2981 - Improve message: duplicate germplasm detected](https://breedinginsight.atlassian.net/browse/BI-2981)

Updated message on germplasm import to better clarify behavior to user

# Dependencies
bi-api: develop

# Testing
Upload germplasm with duplicate names and no GIDs, updated message should appear in import preview
Upload germplasm with existing GIDs, updated message should appear in import preview
Upload germplasm file with no duplicate names or existing GIDs, message should not appear in import preview

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 
