### PR TITLE
[BI-1968] - Change default experimental download to "All Environments"

### DIFF
--- a/src/breeding-insight/model/ExperimentExportOptions.ts
+++ b/src/breeding-insight/model/ExperimentExportOptions.ts
@@ -24,7 +24,7 @@ export class ExperimentExportOptions {
     public fileExtension: string = FileTypeOption.xls.id;
     public datasetId: string;
     public environments: string[] = [];
-    public allEnvironments: boolean = false;
+    public allEnvironments: boolean = true;
     public includeTimestamps: string = 'No';
 
     public timestampsTrueFalseString(): string {


### PR DESCRIPTION
# Description
**Story:** [BI-1968 - Change default experimental download to "All Environments"](https://breedinginsight.atlassian.net/browse/BI-1968)

Changed experiment download modal behavior so "All Environments" is checked by default

# Dependencies
bi-api: develop

# Testing
On experiments table, click to download experiment 
Confirm "All Environments" is checked in the modal by default
Confirm environment selection can still be changed

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 