### PR TITLE
[BI-2968] - Improve clarity for program user deactivation

### DIFF
--- a/src/components/program/ProgramUsersTable.vue
+++ b/src/components/program/ProgramUsersTable.vue
@@ -115,6 +115,7 @@
         v-bind:archivable="$ability.can('archive', 'ProgramUser')"
         v-bind:pagination="paginationController"
         v-bind:data-form-state="editUserFormState"
+        v-bind:deactivate-link-text="removeUserLinkText"
         v-on:submit="updateUser($event)"
         v-on:remove="displayWarning($event)"
         v-on:show-error-notification="$emit('show-error-notification', $event)"
@@ -155,7 +156,7 @@
             You can add a user to your program from this panel. When you remove a user from your
             program, their account and membership in other programs is not affected.
           </p>
-          <p>You can add, edit, and delete users from your program from this panel.</p>
+          <p>You can add, edit, and remove users from your program from this panel.</p>
       </template>
     </ExpandableTable>
   </section>
@@ -240,6 +241,8 @@ export default class ProgramUsersTable extends Vue {
 
   private programUserSort!: UserSort;
   private updateSort!: (sort: UserSort) => void;
+
+  private removeUserLinkText: string = "Remove User";
 
   newUserValidations = {
     name: {required},
@@ -431,7 +434,7 @@ export default class ProgramUsersTable extends Vue {
 
     if (user){
       this.deleteUser = user;
-      this.deactivateWarningTitle = "Deactivate " + user.name + " from program " + this.activeProgram!.name + "?";
+      this.deactivateWarningTitle = "Remove " + user.name + " from program " + this.activeProgram!.name + "?";
       this.deactivateActive = true;
     } else {
       Vue.$log.error('Could not find object to delete')


### PR DESCRIPTION
# Description
**Story:** [BI-2968 - Improve clarity for program user deactivation](https://breedinginsight.atlassian.net/browse/BI-2968)

Changed text on program users table to clarify that one can remove users from a program via that table, not deactivate them entirely.

# Dependencies
bi-api: develop

# Testing
- When a program has no users, the text in the program users table should be "You can add, edit, and remove users from your program from this panel."
- When a program has users, the link on each row of the program users table should say "Remove User"
- When clicking on the Remove User link, the modal that pops up should use "Remove" rather than "Deactivate" in its title

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 
