### PR TITLE
[BI-2821] - Improve Mobile View of Authorization

### DIFF
--- a/src/components/layouts/Footer.vue
+++ b/src/components/layouts/Footer.vue
@@ -51,6 +51,7 @@
         <div class="level-right">
 
           <div class="level-item">
+            <div class="level">
             <div v-if="showFullAffiliations" class="level-item">
               <img
                   src="../../assets/img/IFAS-logo.svg"
@@ -83,6 +84,7 @@
                   alt="USDA Logo"
                   width="75"
               >
+            </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Description
**Story:** [BI-2821 - Improve Mobile View of Authorization](https://breedinginsight.atlassian.net/browse/BI-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

Change to behavior where when a DeltaBreed screen that includes full affiliation icons (welcome page, mobile authorization for fieldbook page, etc) becomes narrow, the affiliation icons should stack vertically rather than requiring scrolling left and right to view. 

(Effectively made the html wrapping the affiliation icons match the html wrapping the footer navigation links, which already had the proper vertical stacking behavior).

# Dependencies
bi-api: develop

# Testing
Can try testing that the mobile authorization page has the affiliation icons stack vertically, but also can try simpler option of opening the DeltaBreed welcome page and making the screen narrow and checking that the affiliation images stack vertically like the footer links.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth
- [X] I have run SiteImprove on pages impacted by changes 